### PR TITLE
Addressing PR comments

### DIFF
--- a/apps/frontend/app/api/rooms/route.ts
+++ b/apps/frontend/app/api/rooms/route.ts
@@ -9,22 +9,18 @@ export async function POST(request: Request) {
     process.env["BACKEND_INTERNAL_URL"] ?? "http://backend:3001";
 
   try {
-    const init: RequestInit & { duplex?: "half" } = {
+    const response = await fetch(`${backendUrl}/api/rooms`, {
       method: "POST",
       headers: request.headers,
       body: request.body,
       cache: "no-store",
-      duplex: "half",
-    };
-
-    const response = await fetch(`${backendUrl}/api/rooms`, init);
-
-    return new Response(response.body, {
-      status: response.status,
-      headers: response.headers,
     });
+
+    const data = await response.json();
+    return Response.json(data, { status: response.status });
   } catch (error) {
     const message = getErrorMessage(error);
+
     return Response.json(
       {
         error: "failed_to_create_room",

--- a/apps/frontend/app/api/rooms/route.ts
+++ b/apps/frontend/app/api/rooms/route.ts
@@ -16,8 +16,27 @@ export async function POST(request: Request) {
       cache: "no-store",
     });
 
-    const data = await response.json();
-    return Response.json(data, { status: response.status });
+    const contentType = response.headers.get("content-type");
+
+    if (response.status === 204 || response.status === 205) {
+      return new Response(null, { status: response.status });
+    }
+
+    const rawBody = await response.text();
+
+    if (contentType?.includes("application/json")) {
+      try {
+        const data = rawBody ? JSON.parse(rawBody) : null;
+        return Response.json(data, { status: response.status });
+      } catch {
+        // fall back to returning the raw body below
+      }
+    }
+
+    return new Response(rawBody, {
+      status: response.status,
+      headers: contentType ? { "content-type": contentType } : undefined,
+    });
   } catch (error) {
     const message = getErrorMessage(error);
 


### PR DESCRIPTION
Adds robust handling to the `/api/rooms` proxy so upstream responses are forwarded without masking errors: 204/205 responses short-circuit, JSON bodies are parsed when present, and non-JSON or malformed bodies fall back to raw text while preserving content type instead of triggering a 502 wrapper.