### PR TITLE
feat: add slice1 show room list - Squashed commit of the following:

### DIFF
--- a/apps/backend/app/api/rooms/route.ts
+++ b/apps/backend/app/api/rooms/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../../../lib/prisma";
-import { RoomStatus } from "../../../generated/prisma/enums";
+import { MatchStatus } from "../../../generated/prisma/enums";
 
 export const dynamic = "force-dynamic";
 
@@ -29,8 +29,8 @@ export async function POST() {
 }
 
 export async function GET() {
-  const rooms = await prisma.room.findMany({
-    where: { status: RoomStatus.WAITING },
+  const rooms = await prisma.match.findMany({
+    where: { status: MatchStatus.WAITING },
     orderBy: { createdAt: "desc" },
     include: {
       participants: true,

--- a/apps/backend/app/api/rooms/route.ts
+++ b/apps/backend/app/api/rooms/route.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../../../lib/prisma";
+import { RoomStatus } from "../../../generated/prisma/enums";
 
 export const dynamic = "force-dynamic";
 
@@ -25,4 +26,28 @@ export async function POST() {
       { status: 500 },
     );
   }
+}
+
+export async function GET() {
+  const rooms = await prisma.room.findMany({
+    where: { status: RoomStatus.WAITING },
+    orderBy: { createdAt: "desc" },
+    include: {
+      participants: true,
+    },
+  });
+
+  const body = rooms.map((r) => ({
+    id: r.id,
+    status: r.status,
+    ruleType: r.ruleType,
+    boardSize: r.boardSize,
+    createdAt: r.createdAt,
+    players: r.participants.map((p) => ({
+      displayName: p.displayNameSnapshot,
+      seat: p.seat,
+    })),
+  }));
+
+  return Response.json(body);
 }

--- a/apps/frontend/app/api/rooms/route.ts
+++ b/apps/frontend/app/api/rooms/route.ts
@@ -52,3 +52,36 @@ export async function POST(request: Request) {
     );
   }
 }
+
+export async function GET() {
+  const backendUrl =
+    process.env["BACKEND_INTERNAL_URL"] ?? "http://backend:3001";
+  try {
+    const response = await fetch(`${backendUrl}/api/rooms`, {
+      method: "GET",
+      cache: "no-store",
+    });
+    const contentType = response.headers.get("content-type");
+    const rawBody = await response.text();
+    if (contentType?.includes("application/json")) {
+      try {
+        const data = rawBody ? JSON.parse(rawBody) : null;
+        return Response.json(data, { status: response.status });
+      } catch {}
+    }
+    return new Response(rawBody, {
+      status: response.status,
+      headers: contentType ? { "content-type": contentType } : undefined,
+    });
+  } catch (error) {
+    const message = getErrorMessage(error);
+    return Response.json(
+      {
+        error: "failed_to_list_rooms",
+        message,
+        detail: message,
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/frontend/app/proto/page.tsx
+++ b/apps/frontend/app/proto/page.tsx
@@ -3,9 +3,60 @@
 import { useState } from "react";
 import { RoomCreateButton } from "../../components/proto/RoomCreateButton";
 
+type Room = {
+  id: string;
+};
+
+type ErrorResponse = {
+  message?: string;
+  detail?: string;
+  error?: string;
+};
+
 export default function ProtoPage() {
   const [roomId, setRoomId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [rooms, setRooms] = useState<Room[]>([]);
+  const [listError, setListError] = useState<string | null>(null);
+
+  async function loadRooms() {
+    try {
+      const response = await fetch("/api/rooms", {
+        cache: "no-store",
+      });
+
+      if (!response.ok) {
+        const errorPayload = (await response
+          .json()
+          .catch(() => null)) as ErrorResponse | null;
+        const message =
+          errorPayload?.message ??
+          errorPayload?.detail ??
+          errorPayload?.error ??
+          `Request failed with status ${response.status}`;
+
+        setListError(message);
+        setRooms([]);
+        return;
+      }
+
+      const data = (await response.json()) as Room[];
+      setRooms(data);
+      setListError(null);
+    } catch {
+      setListError("Network error while loading rooms");
+      setRooms([]);
+    }
+  }
+
+  // Memo: if we want to use useEffect for loadRooms
+  // Put this at the top of this code
+  // import { useState } from "react";
+  //
+  // and activate these hundler
+  // useEffect(() => {
+  //   void loadRooms();
+  // }, []);
 
   function handleSuccess(nextRoomId: string) {
     setRoomId(nextRoomId);
@@ -24,6 +75,22 @@ export default function ProtoPage() {
           <RoomCreateButton onSuccess={handleSuccess} onError={handleError} />
           {roomId ? <p>roomId: {roomId}</p> : null}
           {error ? <p role="alert">error: {error}</p> : null}
+        </article>
+
+        <article className="card">
+          <button type="button" className="btn" onClick={loadRooms}>
+            Load Rooms
+          </button>
+          <p>rooms:</p>
+          {listError ? <p role="alert">error: {listError}</p> : null}
+          <ul>
+            {rooms.map((room) => (
+              <li key={room.id}>
+                {room.id}
+                {room.id === roomId ? " <- just created" : ""}
+              </li>
+            ))}
+          </ul>
         </article>
       </section>
     </main>

--- a/dev-plan-phase0.3en.md
+++ b/dev-plan-phase0.3en.md
@@ -1,0 +1,745 @@
+# Development Notes: Phase 0.3 Communication Foundation Check
+
+## Background and Goal
+
+The current repository already has Docker-based `frontend / backend / PostgreSQL` setup in place, and basic connectivity between Next.js, Socket.IO, and Prisma has been confirmed. The game board, rule validation, matchmaking, authentication, match history, and rankings are still unimplemented.
+
+At the same time, `apps/backend/prisma/schema.prisma` already includes more than the minimum game schema:
+
+- Authentication foundation via `User / OAuthAccount / UserSession`
+- Social foundation via `Friendship`
+- Chat foundation via `Conversation / ConversationParticipant / ChatMessage`
+- Match and stats foundation via `Room / RoomParticipant / Move / UserGameStats`
+
+The MVP goal remains the same: first make online Gomoku playable. However, in Phase 0.3, the implementation plan is rewritten to match the current Prisma schema and treat these pieces as **production-oriented building blocks that can be extended later without rework**.
+
+- Server-authoritative game state management
+- Clear separation of responsibilities between REST and WebSocket
+- Move confirmation backed by DB persistence
+- Use `Room / RoomParticipant / Move` in a way that remains compatible with `User / Conversation`
+- API contracts that tolerate reconnection and future expansion
+
+The UI can stay simple, but APIs and data structures should be designed from the beginning so they can grow later. The board display can be a **simple 1x5 board**, but coordinates should use `{ x, y }` from the start.
+
+---
+
+## Design Principles
+
+### 1. Server authority
+
+Adopt the rule that "the server is the only source of truth for valid game state."
+
+- Legal move validation is handled by the backend
+- Only moves successfully saved to the DB become official state
+- The client updates the board only after receiving `game:update`
+- The client does not locally finalize moves on its own
+
+### 2. Clear separation between REST and WebSocket
+
+Use both `REST + WebSocket`, but do not give them overlapping responsibilities.
+
+- REST: command submission and error responses
+- WebSocket: delivery of confirmed state
+
+With this design, both the player who placed the stone and the opponent update their board from the same `game:update`.
+
+### 3. Separate display names, participant IDs, and authenticated user IDs
+
+In the current schema, display names, match participant IDs, and authenticated user IDs are treated as different things.
+
+- For display: `displayName` in the API, `RoomParticipant.displayNameSnapshot` in the DB
+- Internal identifier: `playerId`; in the API this is an alias of `RoomParticipant.id`
+- Authentication linkage: `userId`; if the user is logged in, connect this through `RoomParticipant.userId` and `Room.createdByUserId`
+- Role: `role` (`PLAYER` / `SPECTATOR`)
+- Seat: `seat` (`BLACK` / `WHITE` / `null`)
+
+Phase 0 only targets a 2-player game, so in practice we handle only participants where `role = PLAYER` and `seat != null`. However, since the schema already anticipates spectators and authentication, the document should also consistently use `RoomParticipant`.
+
+#### `playerId` storage policy in Phase 0
+
+`playerId` refers to the `RoomParticipant.id` returned by the backend when room creation or join succeeds. The frontend stores it in `sessionStorage`.
+
+- Stored values: `roomId`, `playerId`, `role`, `seat`, `displayName`
+- Reason: we want reloads in the same tab to work, but we do not want to take on persistent login responsibilities yet
+- Scope: temporary session within the same tab
+
+Storage example:
+
+```ts
+sessionStorage["proto:roomSession:<roomId>"] = JSON.stringify({
+  roomId,
+  playerId,
+  role,
+  seat,
+  displayName,
+});
+```
+
+Phase 0 uses the following rules:
+
+- If session data exists in `sessionStorage`, reconnect using that `playerId`
+- If it does not exist, after reload the user must rejoin or create a new room
+- Integration with `userId` or authentication sessions is deferred to Phase 1 and later
+
+### 4. Keep the UI simple, keep the contracts generic
+
+Phase 0 uses a simple 1x5 UI, but the following should already use generic shapes from the start so we can later support 15x15, Renju, spectators, and reconnection:
+
+- Coordinates: `position: { x, y }`
+- Board size: `boardSize`
+- Rule type: `ruleType`
+- Version: `stateVersion`
+- Visibility: `visibility`
+- Participation type: `role`
+- End-of-game info: `winningSeat`, `endReason`
+
+---
+
+## Four Communication Patterns and Their Role
+
+| Frontend-side communication pattern | Phase 0 implementation                                                        |
+| ----------------------------------- | ----------------------------------------------------------------------------- |
+| 1. Browser-only                     | Name input, turn display, click enabled/disabled control                      |
+| 2. Click -> server -> response      | Send move via REST and receive accept/reject response                         |
+| 3. Fetch -> render                  | Fetch room list and current state via `GET /rooms` and `GET /rooms/:id/state` |
+| 4. Server push                      | Send `game:update` to everyone in the room and sync the board                 |
+
+---
+
+## Overall Flow
+
+```text
+Player 1:
+  Enter name -> create room via POST /rooms
+             -> create one Room record
+             -> create one RoomParticipant(role=PLAYER, seat=BLACK)
+
+Player 2:
+  Enter name -> fetch room list via GET /rooms
+             -> join via POST /rooms/:id/join
+             -> create one RoomParticipant(role=PLAYER, seat=WHITE)
+
+Once two players are present:
+  Room.status = PLAYING
+  Room.nextTurnSeat = BLACK
+  Record Room.startedAt
+
+Both players:
+  Subscribe to the room via WebSocket
+
+When making a move:
+  1. The player clicks a cell
+  2. If the action is obviously invalid, the frontend does not send it
+     - example: the cell is already occupied
+     - example: it is not your turn
+  3. Send POST /rooms/:id/moves
+  4. The backend checks:
+     - whether playerId is a valid RoomParticipant in the room
+     - whether role is PLAYER
+     - whether seat matches the current turn
+     - whether the position is valid
+     - whether the target cell is unoccupied
+  5. If invalid, return a REST error response
+  6. If valid, save Move(participantId, x, y, requestId, baseVersion, stateVersion)
+     and update Room.stateVersion and nextTurnSeat
+     - `moveNumber` is assigned by the server, not the frontend
+     - numbering is based on the current number of moves in the room, then saved as `+1`
+  7. After the save succeeds, broadcast game:update to everyone in the room
+  8. Both the player who moved and the opponent update their board from the same game:update
+```
+
+Notes:
+
+- If the room creator is logged in, `Room.createdByUserId` can be filled
+- If a participant is logged in, `RoomParticipant.userId` can be filled
+- Even if chat is not implemented in Phase 0, future room chat can be attached through `Conversation.roomId`
+
+---
+
+## Sequence Diagram
+
+```text
+Player1       Frontend1      Backend           DB           Frontend2
+  |               |             |               |                |
+  | Enter name    |             |               |                |
+  |--click------->|             |               |                |
+  |               | POST /rooms |               |                |
+  |               |------------>| INSERT room   |                |
+  |               |             | INSERT participant(BLACK)      |
+  |               |             |-------------> |                |
+  |               | <-----------| roomId/player |                |
+  |               |             |               |                |
+  |      (Player2 joins via GET /rooms -> POST /join)            |
+  |               |             | INSERT participant(WHITE)      |
+  |               |             | UPDATE Room.status=PLAYING     |
+  |               |             |               |                |
+  |      (Both clients subscribe to the room via WebSocket)      |
+  |               | WS subscribe|               |                |
+  |               |------------>|               |                |
+  |               |             |<--------------| WS subscribe   |
+  |               |             |               |                |
+  | Click a cell  |             |               |                |
+  |--click------->|             |               |                |
+  |               | POST /moves |               |                |
+  |               |------------>| Validate move |                |
+  |               |             | INSERT move   |                |
+  |               |             | UPDATE room   |                |
+  |               |             |-------------> |                |
+  |               | <-----------| {ok:true}     |                |
+  |               |             | WS game:update|--------------->|
+  |               |<------------| WS game:update|                |
+  | Update board  |             |               | Update board   |
+```
+
+Notes:
+
+- A successful REST response means "accepted"
+- The only source of truth for official board updates is WebSocket `game:update`
+- Error display is returned only to the requesting player through REST failure responses
+
+---
+
+## API List
+
+### REST
+
+| Method | Path                   | Description                                                      |
+| ------ | ---------------------- | ---------------------------------------------------------------- |
+| `POST` | `/api/rooms`           | Create a room                                                    |
+| `GET`  | `/api/rooms`           | Return a list of joinable rooms                                  |
+| `POST` | `/api/rooms/:id/join`  | Join the specified room                                          |
+| `POST` | `/api/rooms/:id/moves` | Send a move command                                              |
+| `GET`  | `/api/rooms/:id/state` | Return the current state; used for reconnection and initial sync |
+
+### Room Creation API
+
+```ts
+// POST /api/rooms
+
+// Request
+{
+  displayName: string,
+  visibility?: "PUBLIC" | "PRIVATE",
+  ruleType?: "GOMOKU" | "RENJU",
+  boardSize?: 15
+}
+
+// Response
+{
+  roomId: string,
+  playerId: string, // RoomParticipant.id
+  role: "PLAYER",
+  seat: "BLACK"
+}
+```
+
+When creating a room, the backend does the following:
+
+- Create one `Room`
+- Create one `RoomParticipant` for the creator with `role = PLAYER` and `seat = BLACK`
+- If the creator is logged in, fill `Room.createdByUserId` and `RoomParticipant.userId`
+- Leave `winningSeat`, `endReason`, `startedAt`, and `finishedAt` as `null`
+
+### Room Join API
+
+```ts
+// POST /api/rooms/:id/join
+
+// Request
+{
+  displayName: string
+}
+
+// Response
+{
+  roomId: string,
+  playerId: string, // RoomParticipant.id
+  role: "PLAYER",
+  seat: "WHITE"
+}
+```
+
+When the second player joins, the backend performs the following in the same transaction or immediately afterward:
+
+- Update `Room.status` to `PLAYING`
+- Set `nextTurnSeat` to `BLACK`
+- Record `startedAt` if needed
+- Keep `winningSeat` and `endReason` as `null`
+
+The start of the match is represented not by a dedicated `room:started` event, but by `status: "PLAYING"` included in the next `game:update`.
+
+### Move API
+
+```ts
+// POST /api/rooms/:id/moves
+
+// Request
+{
+  playerId: string,
+  position: { x: number, y: number },
+  requestId?: string,
+  baseVersion?: number
+}
+
+// Response (success)
+{
+  ok: true,
+  accepted: true,
+  requestId: string | null
+}
+
+// Response (failure)
+{
+  ok: false,
+  reason:
+    | "occupied"
+    | "not_your_turn"
+    | "invalid_position"
+    | "room_not_found"
+    | "game_not_started"
+    | "game_finished"
+    | "room_cancelled"
+    | "not_a_player"
+    | "stale_state",
+  requestId: string | null
+}
+```
+
+`baseVersion` shows which state version the client was looking at when it made the move. Since `Move.baseVersion` already exists in the current schema as nullable, Phase 0.3 treats it as "optional for now, but send it when available."
+
+`requestId` is treated as an **idempotency key and response correlation key** generated by the frontend for each move.
+
+- The frontend generates `requestId` before sending the request
+- The server stores it in `Move.requestId` and returns the same value in the response
+- If the same `requestId` is retried, the system should avoid creating duplicate moves while still allowing the frontend to identify which action the response belongs to
+- Uniqueness is enforced by `Move` `@@unique([roomId, requestId])`
+
+Also, `occupied` is protected not only by app-level validation, but also by `Move` `@@unique([roomId, x, y])`.
+
+### State Fetch API
+
+```ts
+// GET /api/rooms/:id/state
+
+{
+  roomId: string,
+  status: "WAITING" | "PLAYING" | "FINISHED" | "CANCELLED",
+  visibility: "PUBLIC" | "PRIVATE",
+  ruleType: "GOMOKU" | "RENJU",
+  boardSize: number,
+  stateVersion: number,
+  nextTurnSeat: "BLACK" | "WHITE" | null,
+  winningSeat: "BLACK" | "WHITE" | null,
+  endReason: string | null,
+  createdByUserId: string | null,
+  participants: Array<{
+    playerId: string,
+    userId: string | null,
+    displayName: string, // returned from RoomParticipant.displayNameSnapshot
+    role: "PLAYER" | "SPECTATOR",
+    seat: "BLACK" | "WHITE" | null,
+    joinedAt: string,
+    leftAt: string | null
+  }>,
+  moves: Array<{
+    moveNumber: number,
+    playerId: string, // API representation of Move.participantId
+    position: { x: number, y: number },
+    requestId: string | null,
+    baseVersion: number | null,
+    stateVersion: number
+  }>
+}
+```
+
+By returning `participants`, the Phase 0 frontend can simply use the two records where `role === "PLAYER"`, while future spectator UI can reuse the same shape without redesign.
+
+---
+
+## WebSocket Events
+
+| Direction        | Event name        | Description                                                       |
+| ---------------- | ----------------- | ----------------------------------------------------------------- |
+| Client -> Server | `room:subscribe`  | Start subscribing to a room                                       |
+| Server -> Client | `room:subscribed` | Subscription completed                                            |
+| Server -> Client | `game:update`     | Broadcast the latest confirmed game state to everyone in the room |
+| Server -> Client | `room:closed`     | Notify clients of `FINISHED` / `CANCELLED` or connection cleanup  |
+
+### Example `game:update`
+
+```ts
+{
+  roomId: string,
+  status: "WAITING" | "PLAYING" | "FINISHED" | "CANCELLED",
+  visibility: "PUBLIC" | "PRIVATE",
+  ruleType: "GOMOKU" | "RENJU",
+  boardSize: number,
+  stateVersion: number,
+  nextTurnSeat: "BLACK" | "WHITE" | null,
+  winningSeat: "BLACK" | "WHITE" | null,
+  endReason: string | null,
+  participants: Array<{
+    playerId: string,
+    displayName: string,
+    role: "PLAYER" | "SPECTATOR",
+    seat: "BLACK" | "WHITE" | null
+  }>,
+  lastMove: {
+    moveNumber: number,
+    playerId: string,
+    position: { x: number, y: number },
+    stateVersion: number
+  } | null,
+  board: Cell[][]
+}
+```
+
+`game:update` is sent to **everyone in the room, including the player who made the move**.
+
+---
+
+## Error Display Policy
+
+### Cases the frontend may silently block
+
+The following cases can be determined entirely on the frontend before sending, so it is acceptable to treat them as invalid actions and not send REST requests.
+
+- Clicking an already occupied cell
+- A clearly not-your-turn state
+- A move attempt by a participant already known to have `role !== PLAYER`
+
+This can still work even with no visible feedback, but at minimum one of the following is desirable:
+
+- Disable clicking
+- Do not show hover feedback
+- Show a fixed message such as `Waiting for your opponent's move`
+
+However, these are only **UX-oriented pre-checks**, not a replacement for server authority. If the client state is stale or simultaneous actions occur, the backend may still reject the move for the same reasons.
+
+### Cases that should be returned via REST
+
+The following cases require server confirmation, so they should be handled in the REST response.
+
+- `occupied`
+- `not_your_turn`
+- `not_a_player`
+- `game_finished`
+- `room_cancelled`
+- `room_not_found`
+- `stale_state`
+
+`occupied` and `not_your_turn` are usually prevented on the frontend, but they may still be returned by REST for the following reasons:
+
+- The client was looking at an outdated `game:update`
+- Another player moved at almost the same time
+- Duplicate send or retry happened
+
+Therefore the implementation policy should be:
+
+- Frontend: stop the action before sending whenever it can determine that locally
+- Backend: always perform final validation and return the same reason when necessary
+
+Error display can remain simple.
+
+- `occupied` -> `You cannot place a stone there`
+- `not_your_turn` -> `Waiting for your opponent's move`
+- `not_a_player` -> `This participant is not allowed to make moves`
+- `game_finished` -> `This match has already finished`
+- `room_cancelled` -> `This room has been closed`
+- `stale_state` -> `The board has been updated`
+
+### Network failure
+
+If the REST request itself fails, handle it separately.
+
+- `network_error`
+- `timeout`
+
+Example messages:
+
+- `Communication failed`
+- `Please try again`
+
+---
+
+## DB Schema Design
+
+The following is the part of `apps/backend/prisma/schema.prisma` directly related to the match domain.
+
+```prisma
+enum RoomStatus {
+  WAITING
+  PLAYING
+  FINISHED
+  CANCELLED
+}
+
+enum RoomVisibility {
+  PUBLIC
+  PRIVATE
+}
+
+enum RuleType {
+  GOMOKU
+  RENJU
+}
+
+enum Role {
+  PLAYER
+  SPECTATOR
+}
+
+enum Seat {
+  BLACK
+  WHITE
+}
+
+model Room {
+  id              String         @id @default(dbgenerated("cuid2()"))
+  status          RoomStatus     @default(WAITING)
+  visibility      RoomVisibility @default(PUBLIC)
+  ruleType        RuleType       @default(GOMOKU)
+  boardSize       Int            @default(15)
+  stateVersion    Int            @default(0)
+  nextTurnSeat    Seat?
+  winningSeat     Seat?
+  endReason       String?
+  createdByUserId String?
+  startedAt       DateTime?
+  finishedAt      DateTime?
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @updatedAt
+
+  createdBy    User?             @relation("roomCreator", fields: [createdByUserId], references: [id])
+  participants RoomParticipant[]
+  moves        Move[]
+  conversation Conversation?
+
+  @@index([status])
+  @@index([createdByUserId])
+}
+
+model RoomParticipant {
+  id                  String    @id @default(dbgenerated("cuid2()")) // playerId in the Phase 0 API
+  roomId              String
+  userId              String?
+  displayNameSnapshot String
+  role                Role      @default(PLAYER)
+  seat                Seat?
+  joinedAt            DateTime  @default(now())
+  leftAt              DateTime?
+
+  room  Room   @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  user  User?  @relation(fields: [userId], references: [id])
+  moves Move[]
+
+  @@unique([roomId, seat])
+  @@unique([roomId, userId])
+  @@index([roomId])
+  @@index([userId])
+}
+
+model Move {
+  id            String   @id @default(dbgenerated("cuid2()"))
+  roomId        String
+  participantId String
+  moveNumber    Int
+  x             Int
+  y             Int
+  requestId     String?
+  baseVersion   Int?
+  stateVersion  Int
+  createdAt     DateTime @default(now())
+
+  room        Room            @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  participant RoomParticipant @relation(fields: [participantId], references: [id], onDelete: Cascade)
+
+  @@unique([roomId, moveNumber])
+  @@unique([roomId, x, y])
+  @@unique([roomId, requestId])
+  @@index([roomId])
+  @@index([participantId])
+}
+```
+
+Even if the Phase 0 UI is only 1x5, the DB already includes the following fields, so it can be extended directly to 15x15 boards and spectator mode:
+
+- `x / y`
+- `stateVersion`
+- `baseVersion`
+- `role`
+- `seat`
+- `winningSeat`
+- `endReason`
+
+---
+
+## File Structure Notes
+
+### Prisma-related files currently present
+
+```text
+apps/backend/
+  prisma/
+    schema.prisma             <- current schema source of truth
+  generated/
+    prisma/                   <- client generated from schema.prisma
+  lib/
+    prisma.ts                 <- Prisma client entry point
+```
+
+### Candidate placement for Phase 0 implementation
+
+```text
+apps/frontend/
+  app/
+    proto/
+      page.tsx                <- Phase 0 verification page
+  components/
+    proto/
+      NameInput.tsx           <- player name input
+      RoomList.tsx            <- room list display
+      MiniBoard.tsx           <- simple 1x5 board UI
+      TurnBanner.tsx          <- turn and error display
+  hooks/
+    useRoom.ts                <- room creation, join, and state fetch
+    useSocketGame.ts          <- room subscription and game:update handling
+
+apps/backend/
+  app/
+    api/
+      rooms/
+        route.ts              <- GET, POST /api/rooms
+        [id]/
+          join/route.ts       <- POST /api/rooms/:id/join
+          moves/route.ts      <- POST /api/rooms/:id/moves
+          state/route.ts      <- GET /api/rooms/:id/state
+  lib/
+    prisma.ts                 <- Prisma client
+    rooms/
+      room-store.ts           <- room / participant / move management via Prisma
+    game/
+      move-validator.ts       <- legal move validation
+      state-builder.ts        <- build state from Move records
+    socket/
+      game-handler.ts         <- room:subscribe and game:update broadcast
+  prisma/
+    schema.prisma
+```
+
+`Conversation` and `ChatMessage` do not need implementation in Phase 0, but room chat can later be added through `Conversation.roomId`.
+
+---
+
+## Implementation Order
+
+In this phase, do not implement by large horizontal layers. Instead, move forward using tiny vertical slices where **1 command = 1 visible outcome**.
+
+Each slice should contain only these four things whenever possible:
+
+- One frontend action
+- One REST or WebSocket responsibility
+- One DB change or the minimum necessary DB usage
+- One visible confirmation in the UI
+
+```text
+Slice 0: minimum create_room flow
+  - Schema: use existing Room / RoomParticipant
+  - Save: store RoomParticipant(role=PLAYER, seat=BLACK) for the creator
+  - Front: only a Create room button
+  - API: POST /api/rooms
+  - Confirm: roomId and playerId appear on the screen
+
+Slice 1: add list_rooms
+  - API: GET /api/rooms
+  - Query: return rooms with status=WAITING and visibility=PUBLIC
+  - Front: display a list of created rooms
+  - Confirm: the room created just before is visible in the list
+
+Slice 2: add join_room
+  - Schema: use existing RoomParticipant
+  - Save: store the participant with role=PLAYER, seat=WHITE
+  - Transition: when 2 players are present, update Room.status=PLAYING, nextTurnSeat=BLACK, startedAt
+  - Front: add a Join button
+  - Confirm: both players' displayName and seat are visible
+
+Slice 3: add subscribe_room
+  - WS: room:subscribe / room:subscribed
+  - Front: display subscription status
+  - Confirm: subscribed appears on the screen
+
+Slice 4: minimum submit_move
+  - Schema: use existing Move
+  - Save: store moveNumber, participantId, x, y, requestId, baseVersion, stateVersion
+  - API: POST /api/rooms/:id/moves
+  - Rule: prioritize confirming that saving works first
+  - Confirm: after saving, game:update reaches both screens
+
+Slice 5: add not_your_turn
+  - Rule: add turn validation
+  - Confirm: if the wrong player tries to move, REST returns an error
+
+Slice 6: add occupied
+  - Rule: add occupied-cell validation
+  - DB Guard: also protect it through @@unique([roomId, x, y])
+  - Confirm: placing on an occupied cell is rejected
+
+Slice 7: add stateBuilder
+  - Logic: build the board from Move records
+  - WS: include board / participants / status in game:update
+  - Confirm: the full board is rendered, not just the last move
+  - Confirm: the WAITING -> PLAYING transition is also visible through game:update
+
+Slice 8: add GET /state
+  - API: GET /api/rooms/:id/state
+  - Front: implement initial sync on reload
+  - Front: restore the local seat using playerId from sessionStorage
+  - Confirm: after reload, the same board state is restored
+
+Slice 9: actively use stateVersion / baseVersion
+  - Schema: use existing Room.stateVersion and Move.baseVersion
+  - Rule: support stale_state
+  - Confirm: moves from stale client state can be rejected
+
+Slice 10: prepare the entry point for terminal states
+  - State: provide an update path for FINISHED / CANCELLED and winningSeat / endReason / finishedAt
+  - Note: win/loss judgment itself may be deferred to Phase 1
+  - Note: in Phase 0.3, keep CANCELLED as a state in the model first, and defer actual transitions caused by disconnects or timeouts to Phase 1
+```
+
+Do not build `moveValidator` fully from the beginning. First make sure "it can be saved" and "it can be broadcast" work, then add rules one by one afterward.
+
+---
+
+## Phase 0 Completion Criteria
+
+- Player 1 can create a room
+- Player 2 can see the room list and join
+- `RoomParticipant.id` is stored as `playerId` and can be used for resync
+- Both players can subscribe to the same room
+- Moves are confirmed only through backend validation and DB persistence
+- Invalid moves are returned to the requesting player as REST errors
+- Official board updates are broadcast to everyone through `game:update`
+- Both the player who moved and the opponent update the board from the same event
+- The client can resync through `GET /state`
+- The local match flow works even when `userId` is `null`
+- It can run locally through Docker Compose
+
+---
+
+## Migration Path from Phase 0 to Phase 1
+
+| Phase 0 component               | Phase 1 use                                                                      |
+| ------------------------------- | -------------------------------------------------------------------------------- |
+| `MiniBoard.tsx`                 | Replace with `Board.tsx` (15x15)                                                 |
+| `move-validator.ts`             | Extend to Gomoku win/loss judgment                                               |
+| `state-builder.ts`              | Reuse for spectators, reconnection, and move replay                              |
+| `Room / RoomParticipant / Move` | Extend to Renju, public/private rooms, and spectators                            |
+| `role / userId`                 | Connect to auth, spectators, and friend flows                                    |
+| `stateVersion / baseVersion`    | Foundation for simultaneous move handling, retries, and reconnection             |
+| `winningSeat / endReason`       | Foundation for match result display and history persistence                      |
+| `Conversation.roomId`           | Connect to room chat                                                             |
+| `UserGameStats`                 | Connect to stats, rating, and ranking                                            |
+| `GET /state`                    | Foundation for reconnection, page reload, and joining ongoing games as spectator |
+
+The goal of Phase 0 is not to build a toy game. It is to build the communication core first, in a way that can scale toward a Gomoku.com-style service while staying aligned with the current schema.

--- a/dev-plan-phase0.3ja.md
+++ b/dev-plan-phase0.3ja.md
@@ -1,0 +1,745 @@
+# 開発方針メモ：Phase 0.3 通信基盤確認
+
+## 背景と目的
+
+現状のリポジトリは `frontend / backend / PostgreSQL` の Docker 構成と、Next.js + Socket.IO + Prisma の疎通確認まで完了している。ゲーム盤面・ルール判定・マッチング・認証・履歴・ランキングはまだ未実装。
+
+一方で、`apps/backend/prisma/schema.prisma` には、対局の最小構成を超えて以下まで先に入っている。
+
+- `User / OAuthAccount / UserSession` による認証基盤
+- `Friendship` によるソーシャル基盤
+- `Conversation / ConversationParticipant / ChatMessage` によるチャット基盤
+- `Room / RoomParticipant / Move / UserGameStats` による対局・統計基盤
+
+MVP は引き続き「まずオンライン五目並べを成立させる」ことに切る。ただし Phase 0.3 では、現在の Prisma スキーマに合わせて、**後でそのまま育てられる本番寄りの部品** として実装方針を整理し直す。
+
+- サーバー権威のゲーム状態管理
+- REST と WebSocket の責務分離
+- DB 永続化を伴う着手確定
+- `Room / RoomParticipant / Move` を `User / Conversation` に接続可能なまま使う
+- 再接続や拡張に耐える API 契約
+
+UI は簡略化してよいが、API やデータ構造は最初から将来拡張しやすい形に寄せる。盤面表示は **1x5 の簡易ボード** でよいが、座標表現は最初から `{ x, y }` を使う。
+
+---
+
+## 設計原則
+
+### 1. サーバー権威
+
+「正しいゲーム状態はサーバーだけが持つ」という方針を採用する。
+
+- 合法手判定はバックエンドが行う
+- DB 保存が成功した着手だけを正式状態とする
+- クライアントは `game:update` を受けて初めて盤面を更新する
+- クライアントはローカルで仮確定しない
+
+### 2. REST と WebSocket の責務分離
+
+`REST + WebSocket` の併用は採用する。ただし、同じ責務を二重に持たせない。
+
+- REST: コマンド送信とエラー応答
+- WebSocket: 確定済み状態の配信
+
+この設計では、石を置いた本人も相手プレイヤーも **同じ `game:update`** を受けて盤面を更新する。
+
+### 3. 表示名・参加者ID・認証IDを分離
+
+現行スキーマでは、表示名・対局参加者ID・認証済みユーザーIDは別物として扱う。
+
+- 表示用: API 上の `displayName`、DB 上は `RoomParticipant.displayNameSnapshot`
+- 内部識別: `playerId`。API 上の `playerId` は `RoomParticipant.id` の別名として扱う
+- 認証連携: `userId`。ログイン済みなら `RoomParticipant.userId` と `Room.createdByUserId` に接続する
+- 役割: `role` (`PLAYER` / `SPECTATOR`)
+- 席情報: `seat` (`BLACK` / `WHITE` / `null`)
+
+Phase 0 ではプレイヤー 2 人対戦だけを対象にするため、通常は `role = PLAYER`、`seat != null` の参加者だけを扱う。ただしスキーマは観戦や認証統合まで見越しているため、文書上も `RoomParticipant` 前提で揃える。
+
+#### Phase 0 における `playerId` の保持方針
+
+`playerId` は、ルーム作成または参加の成功時にバックエンドが返す `RoomParticipant.id` を指す。フロントエンドはこれを **`sessionStorage`** に保持する。
+
+- 対象: `roomId`, `playerId`, `role`, `seat`, `displayName`
+- 理由: タブ内リロードには耐えたいが、永続ログインの責務までは持たせないため
+- スコープ: 同一タブの一時セッション
+
+保存イメージ:
+
+```ts
+sessionStorage["proto:roomSession:<roomId>"] = JSON.stringify({
+  roomId,
+  playerId,
+  role,
+  seat,
+  displayName,
+});
+```
+
+Phase 0 では以下の扱いとする。
+
+- `sessionStorage` に情報があれば、その `playerId` で再接続する
+- 情報がなければ、リロード後は再参加または新規作成とする
+- `userId` や認証セッションとの統合は Phase 1 以降で扱う
+
+### 4. UI は簡略、契約は汎用
+
+Phase 0 では 1x5 の簡易 UI を使うが、将来の 15x15・連珠・観戦・再接続に備え、以下は最初から汎用形にする。
+
+- 座標: `position: { x, y }`
+- 盤面サイズ: `boardSize`
+- ルール種別: `ruleType`
+- バージョン: `stateVersion`
+- 公開範囲: `visibility`
+- 参加種別: `role`
+- 終了情報: `winningSeat`, `endReason`
+
+---
+
+## 4 種類の通信パターンと位置づけ
+
+| フロント視点の通信パターン         | Phase 0 での対応実装                                    |
+| ---------------------------------- | ------------------------------------------------------- |
+| ① ブラウザ完結                     | 名前入力・手番表示・クリック可能/不可の制御             |
+| ② クリック → サーバー → レスポンス | 着手を REST で送信し、受理/拒否を返す                   |
+| ③ フェッチ → レンダリング          | `GET /rooms` と `GET /rooms/:id/state` で一覧・状態取得 |
+| ④ サーバープッシュ                 | `game:update` を room 全員へ配信し、盤面を同期          |
+
+---
+
+## 全体フロー
+
+```text
+プレイヤー1:
+  名前入力 → POST /rooms でルーム作成
+          → Room を 1 件作成
+          → RoomParticipant(role=PLAYER, seat=BLACK) を 1 件作成
+
+プレイヤー2:
+  名前入力 → GET /rooms で一覧取得
+           → POST /rooms/:id/join で参加
+           → RoomParticipant(role=PLAYER, seat=WHITE) を 1 件作成
+
+参加が 2 人揃ったら:
+  Room.status = PLAYING
+  Room.nextTurnSeat = BLACK
+  Room.startedAt を記録
+
+両者:
+  WebSocket で room を購読
+
+着手時:
+  1. プレイヤーがマスをクリック
+  2. フロントで明らかに無効な操作なら送信しない
+     - 例: 既に埋まっている
+     - 例: 自分の手番ではない
+  3. POST /rooms/:id/moves を送る
+  4. バックエンドが以下を判定する
+     - playerId が room 内の有効な RoomParticipant か
+     - role が PLAYER か
+     - seat が現在手番か
+     - 位置が有効か
+     - 対象マスが未占有か
+  5. NG なら REST でエラー応答を返す
+  6. OK なら Move(participantId, x, y, requestId, baseVersion, stateVersion) を保存し、
+     Room.stateVersion と nextTurnSeat を更新する
+     - `moveNumber` はフロントではなくサーバーが決める
+     - 採番はその room の現在までの着手数を基準に `+1` して保存する
+  7. 保存成功後、game:update を room 全員へ配信する
+  8. 着手した本人も相手も、同じ game:update を受けて盤面を更新する
+```
+
+補足:
+
+- ログイン済みユーザーが作成した room では `Room.createdByUserId` を埋められる
+- ログイン済み参加者がいれば `RoomParticipant.userId` を埋められる
+- Phase 0 ではチャットを実装しなくても、将来は `Conversation.roomId` で room と会話を 1 対 1 に結べる
+
+---
+
+## シーケンス図
+
+```text
+Player1       Frontend1      Backend           DB           Frontend2
+  |               |             |               |                |
+  | 名前入力      |             |               |                |
+  |--click------->|             |               |                |
+  |               | POST /rooms |               |                |
+  |               |------------>| INSERT room   |                |
+  |               |             | INSERT participant(BLACK)      |
+  |               |             |-------------> |                |
+  |               | <-----------| roomId/player |                |
+  |               |             |               |                |
+  |      (Player2 が GET /rooms → POST /join で参加)             |
+  |               |             | INSERT participant(WHITE)      |
+  |               |             | UPDATE Room.status=PLAYING     |
+  |               |             |               |                |
+  |      (両者が WebSocket で room を購読)                       |
+  |               | WS subscribe|               |                |
+  |               |------------>|               |                |
+  |               |             |<--------------| WS subscribe   |
+  |               |             |               |                |
+  | マスをクリック|             |               |                |
+  |--click------->|             |               |                |
+  |               | POST /moves |               |                |
+  |               |------------>| 合法手判定    |                |
+  |               |             | INSERT move   |                |
+  |               |             | UPDATE room   |                |
+  |               |             |-------------> |                |
+  |               | <-----------| {ok:true}     |                |
+  |               |             | WS game:update|--------------->|
+  |               |<------------| WS game:update|                |
+  | 盤面更新      |             |               |   盤面更新     |
+```
+
+注記:
+
+- REST 成功レスポンスは「受理された」ことを返す
+- 盤面の正式更新は WebSocket の `game:update` を唯一の真実とする
+- REST 失敗時のみ、本人にエラー表示を返す
+
+---
+
+## API 一覧
+
+### REST
+
+| メソッド | パス                   | 説明                                   |
+| -------- | ---------------------- | -------------------------------------- |
+| `POST`   | `/api/rooms`           | ルームを作成する                       |
+| `GET`    | `/api/rooms`           | 参加可能なルーム一覧を返す             |
+| `POST`   | `/api/rooms/:id/join`  | 指定ルームに参加する                   |
+| `POST`   | `/api/rooms/:id/moves` | 着手コマンドを送信する                 |
+| `GET`    | `/api/rooms/:id/state` | 現在状態を返す。再接続や初期同期に使う |
+
+### ルーム作成 API
+
+```ts
+// POST /api/rooms
+
+// Request
+{
+  displayName: string,
+  visibility?: "PUBLIC" | "PRIVATE",
+  ruleType?: "GOMOKU" | "RENJU",
+  boardSize?: 15
+}
+
+// Response
+{
+  roomId: string,
+  playerId: string, // RoomParticipant.id
+  role: "PLAYER",
+  seat: "BLACK"
+}
+```
+
+作成時にバックエンドは以下を行う。
+
+- `Room` を 1 件作成する
+- 作成者用の `RoomParticipant` を `role = PLAYER`, `seat = BLACK` で 1 件作成する
+- ログイン済みなら `Room.createdByUserId` と `RoomParticipant.userId` を埋める
+- `winningSeat`, `endReason`, `startedAt`, `finishedAt` は `null` のまま始める
+
+### ルーム参加 API
+
+```ts
+// POST /api/rooms/:id/join
+
+// Request
+{
+  displayName: string
+}
+
+// Response
+{
+  roomId: string,
+  playerId: string, // RoomParticipant.id
+  role: "PLAYER",
+  seat: "WHITE"
+}
+```
+
+ルーム参加時にプレイヤー 2 人が揃った場合、バックエンドは同じトランザクション内または直後の処理で以下を行う。
+
+- `Room.status` を `PLAYING` に更新する
+- `nextTurnSeat` を `BLACK` に設定する
+- 必要なら `startedAt` を記録する
+- `winningSeat` と `endReason` はまだ `null`
+
+対局開始の事実は、専用の `room:started` ではなく、次の `game:update` に含まれる `status: "PLAYING"` で表現する。
+
+### 着手 API
+
+```ts
+// POST /api/rooms/:id/moves
+
+// Request
+{
+  playerId: string,
+  position: { x: number, y: number },
+  requestId?: string,
+  baseVersion?: number
+}
+
+// Response（成功）
+{
+  ok: true,
+  accepted: true,
+  requestId: string | null
+}
+
+// Response（失敗）
+{
+  ok: false,
+  reason:
+    | "occupied"
+    | "not_your_turn"
+    | "invalid_position"
+    | "room_not_found"
+    | "game_not_started"
+    | "game_finished"
+    | "room_cancelled"
+    | "not_a_player"
+    | "stale_state",
+  requestId: string | null
+}
+```
+
+`baseVersion` は「クライアントがどの状態を見て着手したか」を示す。現行スキーマでは `Move.baseVersion` が nullable で用意済みなので、Phase 0.3 では「今は任意、ただし送れるなら送る」に寄せる。
+
+`requestId` は、フロントエンドが着手のたびに生成する **冪等キー兼レスポンス照合キー** として扱う。
+
+- フロントは送信前に `requestId` を生成する
+- サーバーは `Move.requestId` に保存し、レスポンスにも同じ値をそのまま返す
+- 再送時に同じ `requestId` が来た場合は、二重着手を防ぎつつ「どの操作に対する応答か」をフロントが対応付けられるようにする
+- 一意性は `Move` の `@@unique([roomId, requestId])` を使って担保する
+
+また、`occupied` はアプリ層で事前判定するだけでなく、`Move` の `@@unique([roomId, x, y])` でも守られる想定にする。
+
+### 状態取得 API
+
+```ts
+// GET /api/rooms/:id/state
+
+{
+  roomId: string,
+  status: "WAITING" | "PLAYING" | "FINISHED" | "CANCELLED",
+  visibility: "PUBLIC" | "PRIVATE",
+  ruleType: "GOMOKU" | "RENJU",
+  boardSize: number,
+  stateVersion: number,
+  nextTurnSeat: "BLACK" | "WHITE" | null,
+  winningSeat: "BLACK" | "WHITE" | null,
+  endReason: string | null,
+  createdByUserId: string | null,
+  participants: Array<{
+    playerId: string,
+    userId: string | null,
+    displayName: string, // RoomParticipant.displayNameSnapshot を返す
+    role: "PLAYER" | "SPECTATOR",
+    seat: "BLACK" | "WHITE" | null,
+    joinedAt: string,
+    leftAt: string | null
+  }>,
+  moves: Array<{
+    moveNumber: number,
+    playerId: string, // Move.participantId の API 表現
+    position: { x: number, y: number },
+    requestId: string | null,
+    baseVersion: number | null,
+    stateVersion: number
+  }>
+}
+```
+
+`participants` を返す形にしておけば、Phase 0 のフロントは `role === "PLAYER"` の 2 件だけを使い、将来はそのまま観戦者表示にも伸ばせる。
+
+---
+
+## WebSocket イベント
+
+| 方向            | イベント名        | 内容                                       |
+| --------------- | ----------------- | ------------------------------------------ |
+| Client → Server | `room:subscribe`  | room の購読開始                            |
+| Server → Client | `room:subscribed` | 購読完了通知                               |
+| Server → Client | `game:update`     | 確定済みの最新ゲーム状態を room 全員へ配信 |
+| Server → Client | `room:closed`     | `FINISHED` / `CANCELLED` や切断整理を通知  |
+
+### `game:update` の例
+
+```ts
+{
+  roomId: string,
+  status: "WAITING" | "PLAYING" | "FINISHED" | "CANCELLED",
+  visibility: "PUBLIC" | "PRIVATE",
+  ruleType: "GOMOKU" | "RENJU",
+  boardSize: number,
+  stateVersion: number,
+  nextTurnSeat: "BLACK" | "WHITE" | null,
+  winningSeat: "BLACK" | "WHITE" | null,
+  endReason: string | null,
+  participants: Array<{
+    playerId: string,
+    displayName: string,
+    role: "PLAYER" | "SPECTATOR",
+    seat: "BLACK" | "WHITE" | null
+  }>,
+  lastMove: {
+    moveNumber: number,
+    playerId: string,
+    position: { x: number, y: number },
+    stateVersion: number
+  } | null,
+  board: Cell[][]
+}
+```
+
+`game:update` は **着手した本人を含む room 全員** に送る。
+
+---
+
+## エラー表示方針
+
+### フロントで握りつぶしてよいもの
+
+以下は、送信前にフロントだけで分かるため、REST を送らずに無効操作として扱ってよい。
+
+- 既に埋まっているマス
+- 明らかに自分の手番でない状態
+- `role !== PLAYER` と分かっている参加者の着手操作
+
+この場合は「完全無反応」でも動くが、最低限以下のどれかは欲しい。
+
+- クリック不可にする
+- hover を出さない
+- `相手の手を待っています` のような固定表示を出す
+
+ただし、これらは **UX 上の事前チェック** であり、サーバー権威の代替ではない。クライアント状態が古い場合や同時操作が起きた場合には、バックエンドが同じ理由で拒否することがある。
+
+### REST で返すべきもの
+
+以下はサーバーに確認しないと確定できないため、REST レスポンスで扱う。
+
+- `occupied`
+- `not_your_turn`
+- `not_a_player`
+- `game_finished`
+- `room_cancelled`
+- `room_not_found`
+- `stale_state`
+
+`occupied` と `not_your_turn` は、フロントが通常は事前に防ぐ対象だが、以下の理由で REST でも返しうる。
+
+- クライアントが古い `game:update` を見ていた
+- ほぼ同時に別プレイヤーが着手した
+- 多重送信や再送が起きた
+
+したがって実装方針は以下とする。
+
+- フロント: 分かる範囲では送信前に止める
+- バックエンド: 常に最終判定を行い、必要なら同じ理由を返す
+
+表示は簡素でよい。
+
+- `occupied` → `そこには置けません`
+- `not_your_turn` → `相手の手を待っています`
+- `not_a_player` → `この参加者は着手できません`
+- `game_finished` → `この対局は終了しています`
+- `room_cancelled` → `このルームは終了しました`
+- `stale_state` → `盤面が更新されました`
+
+### 通信失敗
+
+REST 自体が失敗した場合は、別扱いにする。
+
+- `network_error`
+- `timeout`
+
+表示例:
+
+- `通信に失敗しました`
+- `再試行してください`
+
+---
+
+## DB スキーマ設計
+
+`apps/backend/prisma/schema.prisma` のうち、対局領域に直接関係する部分を抜粋すると以下になる。
+
+```prisma
+enum RoomStatus {
+  WAITING
+  PLAYING
+  FINISHED
+  CANCELLED
+}
+
+enum RoomVisibility {
+  PUBLIC
+  PRIVATE
+}
+
+enum RuleType {
+  GOMOKU
+  RENJU
+}
+
+enum Role {
+  PLAYER
+  SPECTATOR
+}
+
+enum Seat {
+  BLACK
+  WHITE
+}
+
+model Room {
+  id              String         @id @default(dbgenerated("cuid2()"))
+  status          RoomStatus     @default(WAITING)
+  visibility      RoomVisibility @default(PUBLIC)
+  ruleType        RuleType       @default(GOMOKU)
+  boardSize       Int            @default(15)
+  stateVersion    Int            @default(0)
+  nextTurnSeat    Seat?
+  winningSeat     Seat?
+  endReason       String?
+  createdByUserId String?
+  startedAt       DateTime?
+  finishedAt      DateTime?
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @updatedAt
+
+  createdBy    User?             @relation("roomCreator", fields: [createdByUserId], references: [id])
+  participants RoomParticipant[]
+  moves        Move[]
+  conversation Conversation?
+
+  @@index([status])
+  @@index([createdByUserId])
+}
+
+model RoomParticipant {
+  id                  String    @id @default(dbgenerated("cuid2()")) // playerId in Phase 0 API
+  roomId              String
+  userId              String?
+  displayNameSnapshot String
+  role                Role      @default(PLAYER)
+  seat                Seat?
+  joinedAt            DateTime  @default(now())
+  leftAt              DateTime?
+
+  room  Room   @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  user  User?  @relation(fields: [userId], references: [id])
+  moves Move[]
+
+  @@unique([roomId, seat])
+  @@unique([roomId, userId])
+  @@index([roomId])
+  @@index([userId])
+}
+
+model Move {
+  id            String   @id @default(dbgenerated("cuid2()"))
+  roomId        String
+  participantId String
+  moveNumber    Int
+  x             Int
+  y             Int
+  requestId     String?
+  baseVersion   Int?
+  stateVersion  Int
+  createdAt     DateTime @default(now())
+
+  room        Room            @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  participant RoomParticipant @relation(fields: [participantId], references: [id], onDelete: Cascade)
+
+  @@unique([roomId, moveNumber])
+  @@unique([roomId, x, y])
+  @@unique([roomId, requestId])
+  @@index([roomId])
+  @@index([participantId])
+}
+```
+
+Phase 0 の UI は 1x5 でも、DB はすでに以下を持っているため 15x15 や観戦にそのまま伸ばせる。
+
+- `x / y`
+- `stateVersion`
+- `baseVersion`
+- `role`
+- `seat`
+- `winningSeat`
+- `endReason`
+
+---
+
+## ファイル構成メモ
+
+### 現在確認できる Prisma 関連ファイル
+
+```text
+apps/backend/
+  prisma/
+    schema.prisma             ← 現行スキーマ本体
+  generated/
+    prisma/                   ← schema.prisma から生成された client
+  lib/
+    prisma.ts                 ← Prisma client 利用起点
+```
+
+### Phase 0 実装を進める場合の候補配置
+
+```text
+apps/frontend/
+  app/
+    proto/
+      page.tsx                ← Phase 0 の検証ページ
+  components/
+    proto/
+      NameInput.tsx           ← プレイヤー名入力
+      RoomList.tsx            ← ルーム一覧表示
+      MiniBoard.tsx           ← 1x5 UI の簡易盤面
+      TurnBanner.tsx          ← 手番とエラー表示
+  hooks/
+    useRoom.ts                ← ルーム作成・参加・状態取得
+    useSocketGame.ts          ← room 購読と game:update 受信
+
+apps/backend/
+  app/
+    api/
+      rooms/
+        route.ts              ← GET, POST /api/rooms
+        [id]/
+          join/route.ts       ← POST /api/rooms/:id/join
+          moves/route.ts      ← POST /api/rooms/:id/moves
+          state/route.ts      ← GET /api/rooms/:id/state
+  lib/
+    prisma.ts                 ← Prisma client
+    rooms/
+      room-store.ts           ← Prisma を使った room / participant / move 管理
+    game/
+      move-validator.ts       ← 合法手判定
+      state-builder.ts        ← Move から state を組み立てる
+    socket/
+      game-handler.ts         ← room:subscribe と game:update 配信
+  prisma/
+    schema.prisma
+```
+
+`Conversation` や `ChatMessage` を扱う実装は Phase 0 では不要だが、room ごとのチャットを追加するなら `Conversation.roomId` を起点に増設できる。
+
+---
+
+## 実装順序
+
+この Phase では、レイヤーごとの大きな実装ではなく、**1 コマンド = 1 つの見える成果** を確認する極小の縦スライスで進める。
+
+各スライスは、できるだけ以下の 4 点だけを持つ。
+
+- フロントの操作が 1 つある
+- REST または WebSocket の責務が 1 つある
+- DB の変更が 1 つか最小限である
+- 画面で「動いた」が確認できる
+
+```text
+Slice 0: create_room の最小疎通
+  - Schema: 既存の Room / RoomParticipant を使う
+  - Save: creator 用に RoomParticipant(role=PLAYER, seat=BLACK) を保存
+  - Front: Create room ボタンだけ
+  - API: POST /api/rooms
+  - Confirm: roomId と playerId が画面に表示される
+
+Slice 1: list_rooms を追加
+  - API: GET /api/rooms
+  - Query: status=WAITING かつ visibility=PUBLIC の room 一覧を返す
+  - Front: 作成済み room 一覧を表示
+  - Confirm: 直前に作った room が一覧に見える
+
+Slice 2: join_room を追加
+  - Schema: 既存の RoomParticipant を使う
+  - Save: 参加者を role=PLAYER, seat=WHITE で保存
+  - Transition: 2 人揃ったら Room.status=PLAYING, nextTurnSeat=BLACK, startedAt を更新
+  - Front: Join ボタンを追加
+  - Confirm: 2 人の displayName / seat が画面に見える
+
+Slice 3: subscribe_room を追加
+  - WS: room:subscribe / room:subscribed
+  - Front: 購読状態を表示
+  - Confirm: subscribed が画面に出る
+
+Slice 4: submit_move の最小版
+  - Schema: 既存の Move を使う
+  - Save: moveNumber, participantId, x, y, requestId, baseVersion, stateVersion を保存
+  - API: POST /api/rooms/:id/moves
+  - Rule: 最初は保存できることの確認を優先する
+  - Confirm: 保存後に game:update が両画面へ届く
+
+Slice 5: not_your_turn を追加
+  - Rule: 手番チェックを入れる
+  - Confirm: 間違った人が打つと REST エラーになる
+
+Slice 6: occupied を追加
+  - Rule: 占有チェックを入れる
+  - DB Guard: @@unique([roomId, x, y]) でも守る
+  - Confirm: 既に埋まった場所に置けない
+
+Slice 7: stateBuilder を追加
+  - Logic: Move から board を組み立てる
+  - WS: game:update に board / participants / status を載せる
+  - Confirm: 最後の一手だけでなく盤面全体が描画される
+  - Confirm: status が WAITING → PLAYING に変わったことも game:update で見える
+
+Slice 8: GET /state を追加
+  - API: GET /api/rooms/:id/state
+  - Front: 再読込時の初期同期を実装
+  - Front: sessionStorage の playerId を使って自席情報も復元する
+  - Confirm: リロード後に同じ盤面へ戻る
+
+Slice 9: stateVersion / baseVersion を有効活用する
+  - Schema: 既存の Room.stateVersion と Move.baseVersion を利用する
+  - Rule: stale_state を扱えるようにする
+  - Confirm: 古い状態からの着手を拒否できる
+
+Slice 10: terminal state の入口を用意する
+  - State: FINISHED / CANCELLED と winningSeat / endReason / finishedAt の更新経路を用意
+  - Note: 勝敗判定そのものは Phase 1 に回してもよい
+  - Note: Phase 0.3 では `CANCELLED` を状態として先に持ち、片方の離脱やタイムアウトで実際に遷移させる処理は Phase 1 に回してよい
+```
+
+`moveValidator` は最初から全部作らない。まずは「保存できる」「配信できる」を通し、その後にルールを 1 つずつ追加する。
+
+---
+
+## Phase 0 完了条件
+
+- プレイヤー1がルームを作成できる
+- プレイヤー2がルーム一覧を見て参加できる
+- `RoomParticipant.id` を `playerId` として保持し、再同期に使える
+- 両者が同じ room を購読できる
+- 着手はバックエンドの合法手判定と DB 保存を経由して確定する
+- 不正手は REST エラーとして本人に返る
+- 正式な盤面更新は `game:update` で全員に配信される
+- 着手した本人も相手も、同じイベントで盤面を更新する
+- `GET /state` で再同期できる
+- `userId` が `null` でもローカル対局フローが成立する
+- Docker Compose でローカル起動できる
+
+---
+
+## Phase 0 → Phase 1 への移行方針
+
+| Phase 0 の部品                  | Phase 1 での用途                         |
+| ------------------------------- | ---------------------------------------- |
+| `MiniBoard.tsx`                 | `Board.tsx`（15x15）へ置き換え           |
+| `move-validator.ts`             | 五目並べの勝敗判定へ拡張                 |
+| `state-builder.ts`              | 観戦・再接続・棋譜再生に流用             |
+| `Room / RoomParticipant / Move` | 連珠・公開/非公開・観戦へ拡張            |
+| `role / userId`                 | 認証・観戦・フレンド導線へ接続           |
+| `stateVersion / baseVersion`    | 同時着手・再送・再接続対応の基礎         |
+| `winningSeat / endReason`       | 対局結果表示・履歴保存の基礎             |
+| `Conversation.roomId`           | ルームチャットへ接続                     |
+| `UserGameStats`                 | 戦績・レーティング・ランキングへ接続     |
+| `GET /state`                    | 再接続・ページ再読込・観戦途中参加の基礎 |
+
+Phase 0 の目的は「簡易ゲームを作ること」ではなく、**将来の Gomoku.com 風サービスでも通用する通信の芯を、現行スキーマに沿って先に作ること** とする。


### PR DESCRIPTION
  - feat(backend):(Slice1 WIP) add GET /api/rooms endpoint
  - fix(frontend, backend):(Slice1 WIP) fix small mistakes
  - feat(frontend):(Slice1:WIP) add GET in front end
  - feat(frontend):(Slice1:LINT error) add loadRoom but error
  - fix(frontend):(Slice1:WIP) ESLint error caused by missing dependency in useEffect
  - refactor(frontend):(Slice1:WIP) Add room list button
  - doc(frontend):(Sllice0:WIP) fix CI error on GitHub Action
  - doc: update dev-plan-phase with prisma.schema
  - refactor(frontend):(Slice1) CreateRoom button does not refresh the list

commit b25bdd9292e14baf59b9616cedccaed000748886
Author: root <sushi.honda@gmail.com>
Date:   Fri Apr 10 09:07:31 2026 +0800

    refactor(frontend):(Slice1) CreateRoom button does not refresh the list

      - In previous, loadRoom() was called from the handler of CreateRoomButton to show the latest record. However, it made the LoadButton to to waste.
      - To clarify the behavior of the both buttons, remove the calling from the handler

commit 439ac55c3277851abae5cedd4f6965cec8b290b8
Author: vboxuser <vboxuser@vbox.42singapore.sg>
Date:   Thu Apr 9 15:06:45 2026 +0800

    doc: update dev-plan-phase with prisma.schema

      previous version 0.2 was based on prototype schema.

commit ea327f6145dbfe1e4eb081bf752bd986f2666f97
Author: vboxuser <vboxuser@vbox.42singapore.sg>
Date:   Thu Apr 9 14:06:08 2026 +0800

    doc(frontend):(Sllice0:WIP) fix CI error on GitHub Action

      Type error: 'useEffect' is declared but its value is never read.

commit 318f59249d3bc64ecd0ad3572efa17eebc96250c
Author: vboxuser <vboxuser@vbox.42singapore.sg>
Date:   Thu Apr 9 13:51:36 2026 +0800

    refactor(frontend):(Slice1:WIP) Add room list button

      - In the previous two commits, the approach assumed using useEffect to determine how to call the loadRoom function. useEffect is a React hook that runs after the initial render of the returned JSX. However, this structure introduced constraints, such as linting errors and the inability to call loadRoom from other handlers.

    While researching useEffect, I came across opinions suggesting that fetch should not be called inside it, and that server components should be used instead.

    That may be valid, but for this Slice 1, the goal is simply to implement a minimal, agile prototype: call an API route with a GET method, retrieve a list of records from the database, and display them.

    Therefore, the structure is simplified to a very straightforward one—clicking a button fetches and displays the list.

commit 9d3424a15c39ed39c83a9efc1b37e8490e17dcd4
Author: root <sushi.honda@gmail.com>
Date:   Wed Apr 8 15:41:03 2026 +0800

    fix(frontend):(Slice1:WIP) ESLint error caused by missing dependency in useEffect

    The ESLint (react-hooks/exhaustive-deps) warning was triggered because loadRooms was defined outside of useEffect but used inside it without being included in the dependency array. Since functions defined in the component are recreated on every render, this created an implicit dependency that was not declared, potentially leading to stale closures or unintended behavior.

    To resolve this, loadRooms was moved inside the useEffect so it becomes a local function scoped to the effect. This removes the need to declare it as a dependency and aligns with React’s hook rules.

    No functional behavior was changed; this refactor ensures correct dependency handling and satisfies the linter.

commit 6bd7a63d95ee44bb45536f12343217dfde3a625f
Author: root <sushi.honda@gmail.com>
Date:   Wed Apr 8 14:24:51 2026 +0800

    feat(frontend):(Slice1:LINT error) add loadRoom but error

      - rooms object iterates by map mathod to display room.id for the list
      - When accessing page, useEffect runs loadRooms() - loadRooms fetch API and updates Room[] array by React

commit 3963acc3bb27f444390855fd2faad0307ad73294
Author: root <sushi.honda@gmail.com>
Date:   Wed Apr 8 08:01:28 2026 +0800

    feat(frontend):(Slice1:WIP) add GET in front end

      - same structure to POST

commit 65f806f3f8adc7c17139de21049964f4e2550747
Author: root <sushi.honda@gmail.com>
Date:   Tue Apr 7 18:48:47 2026 +0800

    fix(frontend, backend):(Slice1 WIP) fix small mistakes

      - roomId -> id in backend because column name should be same to DB in routing. it should be customized in frontend page.
      - delete all GET() in frontend becasue it was for backend

commit d9e913baf39f4300ef616ff48b0b608e6887b33b
Author: vboxuser <vboxuser@vbox.42singapore.sg>
Date:   Mon Apr 6 21:48:13 2026 +0800

    feat(backend):(Slice1 WIP) add GET /api/rooms endpoint

      - Add GET /api/rooms to return a list of rooms with status WAITING. Includes participants (displayNameSnapshot, seat) via Prisma relation. Frontend integration pending.