### PR TITLE
17 prisma domain schema and migration baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ For host-side Prisma commands, `DATABASE_URL` should point to `localhost:5432`. 
 When `schema.prisma` changes, create a migration locally with `prisma migrate dev`,
 verify it, and commit the generated `apps/backend/prisma/migrations/` files.
 
+Seed the database with development demo data (skips if users already exist):
+
+```bash
+(cd apps/backend && bun run prisma:seed)
+```
+
 This repo now applies committed migrations on container startup with
 `prisma migrate deploy` instead of syncing the schema with `db push`.
 

--- a/apps/backend/app/api/rooms/route.ts
+++ b/apps/backend/app/api/rooms/route.ts
@@ -8,13 +8,13 @@ function getErrorMessage(error: unknown): string {
 
 export async function POST() {
   try {
-    const room = await prisma.room.create({
+    const match = await prisma.match.create({
       data: {},
     });
     return Response.json({
-      id: room.id,
-      status: room.status,
-      createdAt: room.createdAt,
+      id: match.id,
+      status: match.status,
+      createdAt: match.createdAt,
     });
   } catch (error) {
     return Response.json(

--- a/apps/backend/lib/prisma.ts
+++ b/apps/backend/lib/prisma.ts
@@ -36,10 +36,12 @@ function getPrisma(): PrismaClient {
     "UserSession",
     "Conversation",
     "ConversationParticipant",
-    "ChatMessage",
-    "Room",
-    "RoomParticipant",
-    "Move",
+    "DirectMessage",
+    "Match",
+    "MatchParticipant",
+    "MatchMove",
+    "AvatarMedia",
+    "AnalyticsEvent",
   ]);
 
   const prisma = new PrismaClient({ adapter }).$extends(
@@ -47,8 +49,11 @@ function getPrisma(): PrismaClient {
       query: {
         $allModels: {
           create({ model, args, query }) {
-            if (cuidModels.has(model) && args?.data && args.data.id == null) {
-              args.data.id = createId();
+            if (cuidModels.has(model) && args?.data) {
+              const payload = args.data as { id?: string | null };
+              if (payload.id == null) {
+                payload.id = createId();
+              }
             }
             return query(args);
           },
@@ -58,8 +63,9 @@ function getPrisma(): PrismaClient {
                 ? args.data
                 : [args.data];
               for (const entry of payloads) {
-                if (entry && entry.id == null) {
-                  entry.id = createId();
+                const mutableEntry = entry as { id?: string | null } | null;
+                if (mutableEntry && mutableEntry.id == null) {
+                  mutableEntry.id = createId();
                 }
               }
             }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -25,9 +25,6 @@
     "react-dom": "19.0.0",
     "socket.io": "4.8.1"
   },
-  "prisma": {
-    "seed": "bun --bun prisma/seed.ts"
-  },
   "devDependencies": {
     "@types/node": "24.6.0",
     "@types/pg": "8.20.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -10,7 +10,8 @@
     "start": "bun server.ts",
     "prisma:generate": "node -e \"require('fs').rmSync('generated/prisma', { recursive: true, force: true });\" && bunx --bun prisma generate",
     "prisma:migrate:dev": "bunx --bun prisma migrate dev",
-    "prisma:migrate:deploy": "bunx --bun prisma migrate deploy"
+    "prisma:migrate:deploy": "bunx --bun prisma migrate deploy",
+    "prisma:seed": "bunx --bun prisma db seed"
   },
   "dependencies": {
     "@paralleldrive/cuid2": "3.3.0",
@@ -23,6 +24,9 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "socket.io": "4.8.1"
+  },
+  "prisma": {
+    "seed": "bun --bun prisma/seed.ts"
   },
   "devDependencies": {
     "@types/node": "24.6.0",

--- a/apps/backend/prisma.config.ts
+++ b/apps/backend/prisma.config.ts
@@ -16,6 +16,9 @@ const databaseUrl =
 
 export default defineConfig({
   schema: "./prisma/schema.prisma",
+  migrations: {
+    seed: "bun --bun prisma/seed.ts",
+  },
   datasource: {
     url: databaseUrl ?? env("DATABASE_URL"),
   },

--- a/apps/backend/prisma/migrations/20260407130000_domain_foundation/migration.sql
+++ b/apps/backend/prisma/migrations/20260407130000_domain_foundation/migration.sql
@@ -1,0 +1,347 @@
+-- CreateEnum
+CREATE TYPE "ProfileVisibility" AS ENUM ('PUBLIC', 'FRIENDS', 'PRIVATE');
+
+-- CreateEnum
+CREATE TYPE "MatchStatus" AS ENUM ('WAITING', 'IN_PROGRESS', 'FINISHED', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "MatchVisibility" AS ENUM ('PUBLIC', 'PRIVATE');
+
+-- CreateEnum
+CREATE TYPE "MatchResult" AS ENUM ('WIN', 'LOSS', 'DRAW', 'CANCELLED');
+
+-- AlterEnum
+ALTER TYPE "FriendshipStatus" ADD VALUE 'BLOCKED';
+
+-- AlterEnum
+BEGIN;
+CREATE TYPE "ConversationKind_new" AS ENUM ('DIRECT', 'GROUP', 'MATCH');
+ALTER TABLE "Conversation" ALTER COLUMN "kind" DROP DEFAULT;
+ALTER TABLE "Conversation" ALTER COLUMN "kind" TYPE "ConversationKind_new" USING ("kind"::text::"ConversationKind_new");
+ALTER TYPE "ConversationKind" RENAME TO "ConversationKind_old";
+ALTER TYPE "ConversationKind_new" RENAME TO "ConversationKind";
+DROP TYPE "ConversationKind_old";
+ALTER TABLE "Conversation" ALTER COLUMN "kind" SET DEFAULT 'DIRECT';
+COMMIT;
+
+-- DropForeignKey
+ALTER TABLE "Conversation" DROP CONSTRAINT "Conversation_roomId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ChatMessage" DROP CONSTRAINT "ChatMessage_conversationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ChatMessage" DROP CONSTRAINT "ChatMessage_senderUserId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Room" DROP CONSTRAINT "Room_createdByUserId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "RoomParticipant" DROP CONSTRAINT "RoomParticipant_roomId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "RoomParticipant" DROP CONSTRAINT "RoomParticipant_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Move" DROP CONSTRAINT "Move_roomId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Move" DROP CONSTRAINT "Move_participantId_fkey";
+
+-- DropIndex
+DROP INDEX "Conversation_roomId_key";
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "statusMessage" TEXT;
+
+-- AlterTable
+ALTER TABLE "OAuthAccount" ADD COLUMN     "scopes" TEXT;
+
+-- AlterTable
+ALTER TABLE "UserSession" ADD COLUMN     "ipAddress" TEXT,
+ADD COLUMN     "revokedAt" TIMESTAMP(3),
+ADD COLUMN     "userAgent" TEXT;
+
+-- AlterTable
+ALTER TABLE "Friendship" ADD COLUMN     "acceptedAt" TIMESTAMP(3),
+ADD COLUMN     "declinedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Conversation" DROP COLUMN "roomId",
+ADD COLUMN     "matchId" TEXT,
+ADD COLUMN     "topic" TEXT;
+
+-- AlterTable
+ALTER TABLE "UserGameStats" ADD COLUMN     "averageMoveTimeMs" INTEGER,
+ADD COLUMN     "totalPlayTimeSeconds" INTEGER NOT NULL DEFAULT 0;
+
+-- DropTable
+DROP TABLE "ChatMessage";
+
+-- DropTable
+DROP TABLE "Room";
+
+-- DropTable
+DROP TABLE "RoomParticipant";
+
+-- DropTable
+DROP TABLE "Move";
+
+-- DropEnum
+DROP TYPE "RoomStatus";
+
+-- DropEnum
+DROP TYPE "RoomVisibility";
+
+-- CreateTable
+CREATE TABLE "UserProfile" (
+    "userId" TEXT NOT NULL,
+    "avatarId" TEXT,
+    "tagline" TEXT,
+    "countryCode" TEXT,
+    "language" TEXT,
+    "timezone" TEXT,
+    "visibility" "ProfileVisibility" NOT NULL DEFAULT 'PUBLIC',
+    "preferences" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserProfile_pkey" PRIMARY KEY ("userId")
+);
+
+-- CreateTable
+CREATE TABLE "AvatarMedia" (
+    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "uploadedById" TEXT,
+    "url" TEXT NOT NULL,
+    "provider" TEXT,
+    "storageKey" TEXT,
+    "width" INTEGER,
+    "height" INTEGER,
+    "blurHash" TEXT,
+    "fileSize" INTEGER,
+    "contentType" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AvatarMedia_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DirectMessage" (
+    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "conversationId" TEXT NOT NULL,
+    "senderUserId" TEXT,
+    "kind" "MessageKind" NOT NULL DEFAULT 'USER',
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "editedAt" TIMESTAMP(3),
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "DirectMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Match" (
+    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "status" "MatchStatus" NOT NULL DEFAULT 'WAITING',
+    "visibility" "MatchVisibility" NOT NULL DEFAULT 'PUBLIC',
+    "ruleType" "RuleType" NOT NULL DEFAULT 'GOMOKU',
+    "boardSize" INTEGER NOT NULL DEFAULT 15,
+    "stateVersion" INTEGER NOT NULL DEFAULT 0,
+    "nextTurnSeat" "Seat",
+    "winningSeat" "Seat",
+    "endReason" TEXT,
+    "createdByUserId" TEXT,
+    "startedAt" TIMESTAMP(3),
+    "finishedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Match_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MatchParticipant" (
+    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "matchId" TEXT NOT NULL,
+    "userId" TEXT,
+    "displayNameSnapshot" TEXT NOT NULL,
+    "role" "Role" NOT NULL DEFAULT 'PLAYER',
+    "seat" "Seat",
+    "result" "MatchResult",
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "leftAt" TIMESTAMP(3),
+
+    CONSTRAINT "MatchParticipant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MatchMove" (
+    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "matchId" TEXT NOT NULL,
+    "participantId" TEXT NOT NULL,
+    "moveNumber" INTEGER NOT NULL,
+    "x" INTEGER NOT NULL,
+    "y" INTEGER NOT NULL,
+    "requestId" TEXT,
+    "baseVersion" INTEGER,
+    "stateVersion" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MatchMove_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AchievementDefinition" (
+    "id" SERIAL NOT NULL,
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "points" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AchievementDefinition_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserAchievement" (
+    "id" SERIAL NOT NULL,
+    "userId" TEXT NOT NULL,
+    "achievementId" INTEGER NOT NULL,
+    "unlockedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "progress" INTEGER NOT NULL DEFAULT 0,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "UserAchievement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AnalyticsEvent" (
+    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "userId" TEXT,
+    "sessionId" TEXT,
+    "matchId" TEXT,
+    "eventType" TEXT NOT NULL,
+    "properties" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AnalyticsEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "UserProfile_avatarId_idx" ON "UserProfile"("avatarId");
+
+-- CreateIndex
+CREATE INDEX "AvatarMedia_uploadedById_idx" ON "AvatarMedia"("uploadedById");
+
+-- CreateIndex
+CREATE INDEX "DirectMessage_conversationId_idx" ON "DirectMessage"("conversationId");
+
+-- CreateIndex
+CREATE INDEX "DirectMessage_senderUserId_idx" ON "DirectMessage"("senderUserId");
+
+-- CreateIndex
+CREATE INDEX "Match_status_idx" ON "Match"("status");
+
+-- CreateIndex
+CREATE INDEX "Match_createdByUserId_idx" ON "Match"("createdByUserId");
+
+-- CreateIndex
+CREATE INDEX "MatchParticipant_matchId_idx" ON "MatchParticipant"("matchId");
+
+-- CreateIndex
+CREATE INDEX "MatchParticipant_userId_idx" ON "MatchParticipant"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MatchParticipant_matchId_seat_key" ON "MatchParticipant"("matchId", "seat");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MatchParticipant_matchId_userId_key" ON "MatchParticipant"("matchId", "userId");
+
+-- CreateIndex
+CREATE INDEX "MatchMove_matchId_idx" ON "MatchMove"("matchId");
+
+-- CreateIndex
+CREATE INDEX "MatchMove_participantId_idx" ON "MatchMove"("participantId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MatchMove_matchId_moveNumber_key" ON "MatchMove"("matchId", "moveNumber");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MatchMove_matchId_x_y_key" ON "MatchMove"("matchId", "x", "y");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MatchMove_matchId_requestId_key" ON "MatchMove"("matchId", "requestId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AchievementDefinition_code_key" ON "AchievementDefinition"("code");
+
+-- CreateIndex
+CREATE INDEX "UserAchievement_userId_idx" ON "UserAchievement"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserAchievement_achievementId_idx" ON "UserAchievement"("achievementId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserAchievement_userId_achievementId_key" ON "UserAchievement"("userId", "achievementId");
+
+-- CreateIndex
+CREATE INDEX "AnalyticsEvent_eventType_idx" ON "AnalyticsEvent"("eventType");
+
+-- CreateIndex
+CREATE INDEX "AnalyticsEvent_createdAt_idx" ON "AnalyticsEvent"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Conversation_matchId_key" ON "Conversation"("matchId");
+
+-- CreateIndex
+CREATE INDEX "Conversation_matchId_idx" ON "Conversation"("matchId");
+
+-- AddForeignKey
+ALTER TABLE "UserProfile" ADD CONSTRAINT "UserProfile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserProfile" ADD CONSTRAINT "UserProfile_avatarId_fkey" FOREIGN KEY ("avatarId") REFERENCES "AvatarMedia"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AvatarMedia" ADD CONSTRAINT "AvatarMedia_uploadedById_fkey" FOREIGN KEY ("uploadedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "Match"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DirectMessage" ADD CONSTRAINT "DirectMessage_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DirectMessage" ADD CONSTRAINT "DirectMessage_senderUserId_fkey" FOREIGN KEY ("senderUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Match" ADD CONSTRAINT "Match_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MatchParticipant" ADD CONSTRAINT "MatchParticipant_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "Match"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MatchParticipant" ADD CONSTRAINT "MatchParticipant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MatchMove" ADD CONSTRAINT "MatchMove_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "Match"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MatchMove" ADD CONSTRAINT "MatchMove_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "MatchParticipant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserAchievement" ADD CONSTRAINT "UserAchievement_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserAchievement" ADD CONSTRAINT "UserAchievement_achievementId_fkey" FOREIGN KEY ("achievementId") REFERENCES "AchievementDefinition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AnalyticsEvent" ADD CONSTRAINT "AnalyticsEvent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AnalyticsEvent" ADD CONSTRAINT "AnalyticsEvent_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "UserSession"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AnalyticsEvent" ADD CONSTRAINT "AnalyticsEvent_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "Match"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/backend/prisma/migrations/20260407130000_domain_foundation/migration.sql
+++ b/apps/backend/prisma/migrations/20260407130000_domain_foundation/migration.sql
@@ -111,7 +111,7 @@ CREATE TABLE "UserProfile" (
 
 -- CreateTable
 CREATE TABLE "AvatarMedia" (
-    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "id" TEXT NOT NULL,
     "uploadedById" TEXT,
     "url" TEXT NOT NULL,
     "provider" TEXT,
@@ -128,7 +128,7 @@ CREATE TABLE "AvatarMedia" (
 
 -- CreateTable
 CREATE TABLE "DirectMessage" (
-    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "id" TEXT NOT NULL,
     "conversationId" TEXT NOT NULL,
     "senderUserId" TEXT,
     "kind" "MessageKind" NOT NULL DEFAULT 'USER',
@@ -142,7 +142,7 @@ CREATE TABLE "DirectMessage" (
 
 -- CreateTable
 CREATE TABLE "Match" (
-    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "id" TEXT NOT NULL,
     "status" "MatchStatus" NOT NULL DEFAULT 'WAITING',
     "visibility" "MatchVisibility" NOT NULL DEFAULT 'PUBLIC',
     "ruleType" "RuleType" NOT NULL DEFAULT 'GOMOKU',
@@ -162,7 +162,7 @@ CREATE TABLE "Match" (
 
 -- CreateTable
 CREATE TABLE "MatchParticipant" (
-    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "id" TEXT NOT NULL,
     "matchId" TEXT NOT NULL,
     "userId" TEXT,
     "displayNameSnapshot" TEXT NOT NULL,
@@ -177,7 +177,7 @@ CREATE TABLE "MatchParticipant" (
 
 -- CreateTable
 CREATE TABLE "MatchMove" (
-    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "id" TEXT NOT NULL,
     "matchId" TEXT NOT NULL,
     "participantId" TEXT NOT NULL,
     "moveNumber" INTEGER NOT NULL,
@@ -218,7 +218,7 @@ CREATE TABLE "UserAchievement" (
 
 -- CreateTable
 CREATE TABLE "AnalyticsEvent" (
-    "id" TEXT NOT NULL DEFAULT cuid2(),
+    "id" TEXT NOT NULL,
     "userId" TEXT,
     "sessionId" TEXT,
     "matchId" TEXT,

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -81,7 +81,7 @@ enum MatchResult {
 // Models
 
 model User {
-  id              String    @id @default(dbgenerated("cuid2()"))
+  id              String    @id @default(cuid(2))
   kind            UserKind  @default(HUMAN)
   username        String    @unique
   displayName     String
@@ -132,7 +132,7 @@ model UserProfile {
 }
 
 model AvatarMedia {
-  id           String   @id @default(dbgenerated("cuid2()"))
+  id           String   @id @default(cuid(2))
   uploadedById String?
   url          String
   provider     String?
@@ -151,7 +151,7 @@ model AvatarMedia {
 }
 
 model OAuthAccount {
-  id                String        @id @default(dbgenerated("cuid2()"))
+  id                String        @id @default(cuid(2))
   userId            String
   provider          OAuthProvider
   providerAccountId String
@@ -168,7 +168,7 @@ model OAuthAccount {
 }
 
 model UserSession {
-  id           String    @id @default(dbgenerated("cuid2()"))
+  id           String    @id @default(cuid(2))
   userId       String
   sessionToken String    @unique
   expiresAt    DateTime
@@ -203,7 +203,7 @@ model Friendship {
 }
 
 model Conversation {
-  id            String           @id @default(dbgenerated("cuid2()"))
+  id            String           @id @default(cuid(2))
   kind          ConversationKind @default(DIRECT)
   directKey     String?          @unique
   matchId       String?          @unique
@@ -220,7 +220,7 @@ model Conversation {
 }
 
 model ConversationParticipant {
-  id             String    @id @default(dbgenerated("cuid2()"))
+  id             String    @id @default(cuid(2))
   conversationId String
   userId         String
   joinedAt       DateTime  @default(now())
@@ -235,7 +235,7 @@ model ConversationParticipant {
 }
 
 model DirectMessage {
-  id             String      @id @default(dbgenerated("cuid2()"))
+  id             String      @id @default(cuid(2))
   conversationId String
   senderUserId   String?
   kind           MessageKind @default(USER)
@@ -252,7 +252,7 @@ model DirectMessage {
 }
 
 model Match {
-  id              String          @id @default(dbgenerated("cuid2()"))
+  id              String          @id @default(cuid(2))
   status          MatchStatus     @default(WAITING)
   visibility      MatchVisibility @default(PUBLIC)
   ruleType        RuleType        @default(GOMOKU)
@@ -278,7 +278,7 @@ model Match {
 }
 
 model MatchParticipant {
-  id                  String       @id @default(dbgenerated("cuid2()")) // playerId in Phase 0.2 API
+  id                  String       @id @default(cuid(2)) // playerId in Phase 0.2 API
   matchId             String
   userId              String?
   displayNameSnapshot String
@@ -299,7 +299,7 @@ model MatchParticipant {
 }
 
 model MatchMove {
-  id            String   @id @default(dbgenerated("cuid2()"))
+  id            String   @id @default(cuid(2))
   matchId       String
   participantId String
   moveNumber    Int
@@ -374,7 +374,7 @@ model UserAchievement {
 }
 
 model AnalyticsEvent {
-  id         String   @id @default(dbgenerated("cuid2()"))
+  id         String   @id @default(cuid(2))
   userId     String?
   sessionId  String?
   matchId    String?

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -24,28 +24,18 @@ enum FriendshipStatus {
   PENDING
   ACCEPTED
   DECLINED
+  BLOCKED
 }
 
 enum ConversationKind {
   DIRECT
-  ROOM
+  GROUP
+  MATCH
 }
 
 enum MessageKind {
   USER
   SYSTEM
-}
-
-enum RoomStatus {
-  WAITING
-  PLAYING
-  FINISHED
-  CANCELLED
-}
-
-enum RoomVisibility {
-  PUBLIC
-  PRIVATE
 }
 
 enum RuleType {
@@ -63,6 +53,31 @@ enum Seat {
   WHITE
 }
 
+enum ProfileVisibility {
+  PUBLIC
+  FRIENDS
+  PRIVATE
+}
+
+enum MatchStatus {
+  WAITING
+  IN_PROGRESS
+  FINISHED
+  CANCELLED
+}
+
+enum MatchVisibility {
+  PUBLIC
+  PRIVATE
+}
+
+enum MatchResult {
+  WIN
+  LOSS
+  DRAW
+  CANCELLED
+}
+
 // Models
 
 model User {
@@ -75,22 +90,64 @@ model User {
   passwordHash    String?
   avatarUrl       String?
   bio             String?
+  statusMessage   String?
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
   lastSeenAt      DateTime?
 
-  oauthAccounts    OAuthAccount[]
-  sessions         UserSession[]
-  conversations    ConversationParticipant[]
-  messages         ChatMessage[]
-  roomParticipants RoomParticipant[]
-  createdRooms     Room[]                    @relation("roomCreator")
-  gameStats        UserGameStats[]
+  profile           UserProfile?
+  oauthAccounts     OAuthAccount[]
+  sessions          UserSession[]
+  conversations     ConversationParticipant[]
+  messages          DirectMessage[]           @relation("MessageSender")
+  matchParticipants MatchParticipant[]
+  createdMatches    Match[]                   @relation("matchCreator")
+  gameStats         UserGameStats[]
+  achievements      UserAchievement[]
+  analyticsEvents   AnalyticsEvent[]
+  avatars           AvatarMedia[]             @relation("avatarUploader")
 
   // friendship relations (multiple relations to the same model must be named)
   friendshipsLow     Friendship[] @relation("friendLow")
   friendshipsHigh    Friendship[] @relation("friendHigh")
   friendshipRequests Friendship[] @relation("friendRequestedBy")
+}
+
+model UserProfile {
+  userId      String            @id
+  avatarId    String?
+  tagline     String?
+  countryCode String?
+  language    String?
+  timezone    String?
+  visibility  ProfileVisibility @default(PUBLIC)
+  preferences Json?
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @updatedAt
+
+  user   User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  avatar AvatarMedia? @relation(fields: [avatarId], references: [id], onDelete: SetNull)
+
+  @@index([avatarId])
+}
+
+model AvatarMedia {
+  id           String   @id @default(dbgenerated("cuid2()"))
+  uploadedById String?
+  url          String
+  provider     String?
+  storageKey   String?
+  width        Int?
+  height       Int?
+  blurHash     String?
+  fileSize     Int?
+  contentType  String?
+  createdAt    DateTime @default(now())
+
+  uploadedBy User?         @relation("avatarUploader", fields: [uploadedById], references: [id], onDelete: SetNull)
+  profiles   UserProfile[]
+
+  @@index([uploadedById])
 }
 
 model OAuthAccount {
@@ -102,6 +159,7 @@ model OAuthAccount {
   refreshToken      String?
   expiresAt         DateTime?
   createdAt         DateTime      @default(now())
+  scopes            String?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -110,13 +168,17 @@ model OAuthAccount {
 }
 
 model UserSession {
-  id           String   @id @default(dbgenerated("cuid2()"))
+  id           String    @id @default(dbgenerated("cuid2()"))
   userId       String
-  sessionToken String   @unique
+  sessionToken String    @unique
   expiresAt    DateTime
-  createdAt    DateTime @default(now())
+  createdAt    DateTime  @default(now())
+  revokedAt    DateTime?
+  ipAddress    String?
+  userAgent    String?
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user            User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  analyticsEvents AnalyticsEvent[]
 
   @@index([userId])
 }
@@ -129,6 +191,8 @@ model Friendship {
   status        FriendshipStatus @default(PENDING)
   createdAt     DateTime         @default(now())
   respondedAt   DateTime?
+  acceptedAt    DateTime?
+  declinedAt    DateTime?
 
   userLow     User @relation("friendLow", fields: [userLowId], references: [id], onDelete: Cascade)
   userHigh    User @relation("friendHigh", fields: [userHighId], references: [id], onDelete: Cascade)
@@ -142,15 +206,17 @@ model Conversation {
   id            String           @id @default(dbgenerated("cuid2()"))
   kind          ConversationKind @default(DIRECT)
   directKey     String?          @unique
-  roomId        String?          @unique
+  matchId       String?          @unique
+  topic         String?
   createdAt     DateTime         @default(now())
   lastMessageAt DateTime?
 
-  room         Room?                     @relation(fields: [roomId], references: [id])
+  match        Match?                    @relation("MatchConversation", fields: [matchId], references: [id], onDelete: SetNull)
   participants ConversationParticipant[]
-  messages     ChatMessage[]
+  messages     DirectMessage[]
 
   @@index([directKey])
+  @@index([matchId])
 }
 
 model ConversationParticipant {
@@ -168,7 +234,7 @@ model ConversationParticipant {
   @@index([userId])
 }
 
-model ChatMessage {
+model DirectMessage {
   id             String      @id @default(dbgenerated("cuid2()"))
   conversationId String
   senderUserId   String?
@@ -179,60 +245,62 @@ model ChatMessage {
   deletedAt      DateTime?
 
   conversation Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
-  sender       User?        @relation(fields: [senderUserId], references: [id])
+  sender       User?        @relation("MessageSender", fields: [senderUserId], references: [id], onDelete: SetNull)
 
   @@index([conversationId])
   @@index([senderUserId])
 }
 
-model Room {
-  id              String         @id @default(dbgenerated("cuid2()"))
-  status          RoomStatus     @default(WAITING)
-  visibility      RoomVisibility @default(PUBLIC)
-  ruleType        RuleType       @default(GOMOKU)
-  boardSize       Int            @default(15)
-  stateVersion    Int            @default(0)
+model Match {
+  id              String          @id @default(dbgenerated("cuid2()"))
+  status          MatchStatus     @default(WAITING)
+  visibility      MatchVisibility @default(PUBLIC)
+  ruleType        RuleType        @default(GOMOKU)
+  boardSize       Int             @default(15)
+  stateVersion    Int             @default(0)
   nextTurnSeat    Seat?
   winningSeat     Seat?
   endReason       String?
   createdByUserId String?
   startedAt       DateTime?
   finishedAt      DateTime?
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
 
-  createdBy    User?             @relation("roomCreator", fields: [createdByUserId], references: [id])
-  participants RoomParticipant[]
-  moves        Move[]
-  conversation Conversation?
+  createdBy       User?              @relation("matchCreator", fields: [createdByUserId], references: [id], onDelete: SetNull)
+  participants    MatchParticipant[]
+  moves           MatchMove[]
+  conversation    Conversation?      @relation("MatchConversation")
+  analyticsEvents AnalyticsEvent[]
 
   @@index([status])
   @@index([createdByUserId])
 }
 
-model RoomParticipant {
-  id                  String    @id @default(dbgenerated("cuid2()")) // playerId in Phase 0.2 API
-  roomId              String
+model MatchParticipant {
+  id                  String       @id @default(dbgenerated("cuid2()")) // playerId in Phase 0.2 API
+  matchId             String
   userId              String?
   displayNameSnapshot String
-  role                Role      @default(PLAYER)
+  role                Role         @default(PLAYER)
   seat                Seat?
-  joinedAt            DateTime  @default(now())
+  result              MatchResult?
+  joinedAt            DateTime     @default(now())
   leftAt              DateTime?
 
-  room  Room   @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  user  User?  @relation(fields: [userId], references: [id])
-  moves Move[]
+  match Match       @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  user  User?       @relation(fields: [userId], references: [id], onDelete: SetNull)
+  moves MatchMove[]
 
-  @@unique([roomId, seat])
-  @@unique([roomId, userId])
-  @@index([roomId])
+  @@unique([matchId, seat])
+  @@unique([matchId, userId])
+  @@index([matchId])
   @@index([userId])
 }
 
-model Move {
+model MatchMove {
   id            String   @id @default(dbgenerated("cuid2()"))
-  roomId        String
+  matchId       String
   participantId String
   moveNumber    Int
   x             Int
@@ -242,35 +310,82 @@ model Move {
   stateVersion  Int
   createdAt     DateTime @default(now())
 
-  room        Room            @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  participant RoomParticipant @relation(fields: [participantId], references: [id], onDelete: Cascade)
+  match       Match            @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  participant MatchParticipant @relation(fields: [participantId], references: [id], onDelete: Cascade)
 
-  @@unique([roomId, moveNumber])
-  @@unique([roomId, x, y])
-  @@unique([roomId, requestId])
-  @@index([roomId])
+  @@unique([matchId, moveNumber])
+  @@unique([matchId, x, y])
+  @@unique([matchId, requestId])
+  @@index([matchId])
   @@index([participantId])
 }
 
 model UserGameStats {
-  id               Int       @id @default(autoincrement())
-  userId           String
-  ruleType         RuleType
-  boardSize        Int
-  matchesPlayed    Int       @default(0)
-  wins             Int       @default(0)
-  losses           Int       @default(0)
-  draws            Int       @default(0)
-  botMatchesPlayed Int       @default(0)
-  botWins          Int       @default(0)
-  currentStreak    Int       @default(0)
-  bestStreak       Int       @default(0)
-  rating           Int?
-  lastPlayedAt     DateTime?
-  updatedAt        DateTime  @updatedAt
+  id                   Int       @id @default(autoincrement())
+  userId               String
+  ruleType             RuleType
+  boardSize            Int
+  matchesPlayed        Int       @default(0)
+  wins                 Int       @default(0)
+  losses               Int       @default(0)
+  draws                Int       @default(0)
+  botMatchesPlayed     Int       @default(0)
+  botWins              Int       @default(0)
+  currentStreak        Int       @default(0)
+  bestStreak           Int       @default(0)
+  rating               Int?
+  averageMoveTimeMs    Int?
+  totalPlayTimeSeconds Int       @default(0)
+  lastPlayedAt         DateTime?
+  updatedAt            DateTime  @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, ruleType, boardSize])
   @@index([userId])
+}
+
+model AchievementDefinition {
+  id          Int      @id @default(autoincrement())
+  code        String   @unique
+  name        String
+  description String
+  points      Int      @default(0)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  unlocks UserAchievement[]
+}
+
+model UserAchievement {
+  id            Int       @id @default(autoincrement())
+  userId        String
+  achievementId Int
+  unlockedAt    DateTime  @default(now())
+  progress      Int       @default(0)
+  completedAt   DateTime?
+
+  user        User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  achievement AchievementDefinition @relation(fields: [achievementId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, achievementId])
+  @@index([userId])
+  @@index([achievementId])
+}
+
+model AnalyticsEvent {
+  id         String   @id @default(dbgenerated("cuid2()"))
+  userId     String?
+  sessionId  String?
+  matchId    String?
+  eventType  String
+  properties Json?
+  createdAt  DateTime @default(now())
+
+  user    User?        @relation(fields: [userId], references: [id], onDelete: SetNull)
+  session UserSession? @relation(fields: [sessionId], references: [id], onDelete: SetNull)
+  match   Match?       @relation(fields: [matchId], references: [id], onDelete: SetNull)
+
+  @@index([eventType])
+  @@index([createdAt])
 }

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1,0 +1,567 @@
+import { createId } from "@paralleldrive/cuid2";
+import {
+  ConversationKind,
+  FriendshipStatus,
+  MatchResult,
+  MatchStatus,
+  MatchVisibility,
+  MessageKind,
+  Prisma,
+  Role,
+  RuleType,
+  Seat,
+  UserSession,
+} from "../generated/prisma/client";
+import { prisma } from "../lib/prisma";
+
+const directKeyForUsers = (a: string, b: string): string =>
+  [a, b].sort().join(":");
+
+type SeededUsers = {
+  alice: { id: string; displayName: string };
+  bob: { id: string; displayName: string };
+  carol: { id: string; displayName: string };
+  sessions: Record<string, UserSession>;
+};
+
+const seedUsers = async (): Promise<SeededUsers> => {
+  const [alice, bob, carol] = await Promise.all([
+    prisma.user.create({
+      data: {
+        username: "alice",
+        displayName: "Alice Demo",
+        email: "alice@example.com",
+        emailVerifiedAt: new Date(),
+        passwordHash: "demo-hash",
+        statusMessage: "Ready for ranked matches",
+      },
+    }),
+    prisma.user.create({
+      data: {
+        username: "bob",
+        displayName: "Bob Demo",
+        email: "bob@example.com",
+        emailVerifiedAt: new Date(),
+        passwordHash: "demo-hash",
+        statusMessage: "Send me a challenge",
+      },
+    }),
+    prisma.user.create({
+      data: {
+        username: "carol",
+        displayName: "Carol Demo",
+        email: "carol@example.com",
+        emailVerifiedAt: new Date(),
+        passwordHash: "demo-hash",
+        statusMessage: "Spectating and learning",
+      },
+    }),
+  ]);
+
+  const [aliceAvatar, bobAvatar] = await Promise.all([
+    prisma.avatarMedia.create({
+      data: {
+        uploadedById: alice.id,
+        url: "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=256&q=80",
+        provider: "seed",
+        storageKey: "demo/alice.jpg",
+        width: 256,
+        height: 256,
+        blurHash: "UEP?KXj[5Qoy?wj[IUj[00WV-;xYxZofRjt7",
+        contentType: "image/jpeg",
+      },
+    }),
+    prisma.avatarMedia.create({
+      data: {
+        uploadedById: bob.id,
+        url: "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&w=256&q=80",
+        provider: "seed",
+        storageKey: "demo/bob.jpg",
+        width: 256,
+        height: 256,
+        blurHash: "UGG9#kt7~qRj%LoKt7oLIpxuM{M{M{t7ofWB",
+        contentType: "image/jpeg",
+      },
+    }),
+  ]);
+
+  await Promise.all([
+    prisma.userProfile.create({
+      data: {
+        userId: alice.id,
+        avatarId: aliceAvatar.id,
+        tagline: "Competitive but friendly.",
+        countryCode: "US",
+        language: "en",
+        preferences: {
+          theme: "dark",
+          boardSize: 15,
+        } satisfies Prisma.JsonObject,
+      },
+    }),
+    prisma.userProfile.create({
+      data: {
+        userId: bob.id,
+        avatarId: bobAvatar.id,
+        tagline: "Enjoys fast games.",
+        countryCode: "GB",
+        language: "en",
+        preferences: { notifications: true } satisfies Prisma.JsonObject,
+      },
+    }),
+    prisma.userProfile.create({
+      data: {
+        userId: carol.id,
+        tagline: "Cheering from the sidelines.",
+        countryCode: "SG",
+        language: "en",
+        preferences: { spectate: true } satisfies Prisma.JsonObject,
+      },
+    }),
+  ]);
+
+  const sevenDaysFromNow = () => new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const sessions = await Promise.all([
+    prisma.userSession.create({
+      data: {
+        userId: alice.id,
+        sessionToken: createId(),
+        expiresAt: sevenDaysFromNow(),
+        ipAddress: "127.0.0.1",
+        userAgent: "seed/cli",
+      },
+    }),
+    prisma.userSession.create({
+      data: {
+        userId: bob.id,
+        sessionToken: createId(),
+        expiresAt: sevenDaysFromNow(),
+        ipAddress: "127.0.0.1",
+        userAgent: "seed/cli",
+      },
+    }),
+    prisma.userSession.create({
+      data: {
+        userId: carol.id,
+        sessionToken: createId(),
+        expiresAt: sevenDaysFromNow(),
+        ipAddress: "127.0.0.1",
+        userAgent: "seed/cli",
+      },
+    }),
+  ]);
+
+  return {
+    alice,
+    bob,
+    carol,
+    sessions: {
+      [alice.id]: sessions[0],
+      [bob.id]: sessions[1],
+      [carol.id]: sessions[2],
+    },
+  };
+};
+
+const seedFriendship = async (aliceId: string, bobId: string) => {
+  const lowId = aliceId < bobId ? aliceId : bobId;
+  const highId = aliceId < bobId ? bobId : aliceId;
+  const now = new Date();
+
+  await prisma.friendship.create({
+    data: {
+      userLowId: lowId,
+      userHighId: highId,
+      requestedById: aliceId,
+      status: FriendshipStatus.ACCEPTED,
+      createdAt: now,
+      respondedAt: now,
+      acceptedAt: now,
+    },
+  });
+};
+
+const seedDirectConversation = async (aliceId: string, bobId: string) => {
+  const now = new Date();
+  const firstMessageAt = new Date(now.getTime() - 5 * 60 * 1000);
+  const secondMessageAt = new Date(firstMessageAt.getTime() + 30 * 1000);
+
+  await prisma.conversation.create({
+    data: {
+      kind: ConversationKind.DIRECT,
+      directKey: directKeyForUsers(aliceId, bobId),
+      lastMessageAt: secondMessageAt,
+      participants: {
+        create: [
+          {
+            userId: aliceId,
+            joinedAt: firstMessageAt,
+            lastReadAt: secondMessageAt,
+          },
+          {
+            userId: bobId,
+            joinedAt: firstMessageAt,
+            lastReadAt: secondMessageAt,
+          },
+        ],
+      },
+      messages: {
+        create: [
+          {
+            senderUserId: aliceId,
+            kind: MessageKind.USER,
+            body: "Hey Bob, ready for a quick match?",
+            createdAt: firstMessageAt,
+          },
+          {
+            senderUserId: bobId,
+            kind: MessageKind.USER,
+            body: "Always! Let's invite Carol to spectate.",
+            createdAt: secondMessageAt,
+          },
+        ],
+      },
+    },
+  });
+};
+
+const seedMatch = async (aliceId: string, bobId: string, carolId: string) => {
+  const startedAt = new Date(Date.now() - 20 * 60 * 1000);
+  const finishedAt = new Date(Date.now() - 18 * 60 * 1000);
+
+  const match = await prisma.match.create({
+    data: {
+      status: MatchStatus.FINISHED,
+      visibility: MatchVisibility.PUBLIC,
+      ruleType: RuleType.GOMOKU,
+      boardSize: 15,
+      winningSeat: Seat.BLACK,
+      endReason: "five_in_a_row",
+      createdByUserId: aliceId,
+      startedAt,
+      finishedAt,
+      participants: {
+        create: [
+          {
+            userId: aliceId,
+            displayNameSnapshot: "Alice Demo",
+            role: Role.PLAYER,
+            seat: Seat.BLACK,
+            result: MatchResult.WIN,
+            joinedAt: startedAt,
+            leftAt: finishedAt,
+          },
+          {
+            userId: bobId,
+            displayNameSnapshot: "Bob Demo",
+            role: Role.PLAYER,
+            seat: Seat.WHITE,
+            result: MatchResult.LOSS,
+            joinedAt: startedAt,
+            leftAt: finishedAt,
+          },
+          {
+            userId: carolId,
+            displayNameSnapshot: "Carol Demo",
+            role: Role.SPECTATOR,
+            result: MatchResult.CANCELLED,
+            joinedAt: startedAt,
+            leftAt: finishedAt,
+          },
+        ],
+      },
+    },
+  });
+
+  const participants = await prisma.matchParticipant.findMany({
+    where: { matchId: match.id },
+  });
+  const black = participants.find(
+    (participant) => participant.seat === Seat.BLACK,
+  );
+  const white = participants.find(
+    (participant) => participant.seat === Seat.WHITE,
+  );
+
+  if (!black || !white) {
+    throw new Error("Seed match participants were not created as expected.");
+  }
+
+  await prisma.matchMove.createMany({
+    data: [
+      {
+        matchId: match.id,
+        participantId: black.id,
+        moveNumber: 1,
+        x: 7,
+        y: 7,
+        requestId: createId(),
+        baseVersion: 0,
+        stateVersion: 1,
+        createdAt: startedAt,
+      },
+      {
+        matchId: match.id,
+        participantId: white.id,
+        moveNumber: 2,
+        x: 7,
+        y: 8,
+        requestId: createId(),
+        baseVersion: 1,
+        stateVersion: 2,
+        createdAt: new Date(startedAt.getTime() + 10 * 1000),
+      },
+      {
+        matchId: match.id,
+        participantId: black.id,
+        moveNumber: 3,
+        x: 8,
+        y: 8,
+        requestId: createId(),
+        baseVersion: 2,
+        stateVersion: 3,
+        createdAt: new Date(startedAt.getTime() + 20 * 1000),
+      },
+      {
+        matchId: match.id,
+        participantId: white.id,
+        moveNumber: 4,
+        x: 6,
+        y: 7,
+        requestId: createId(),
+        baseVersion: 3,
+        stateVersion: 4,
+        createdAt: new Date(startedAt.getTime() + 30 * 1000),
+      },
+      {
+        matchId: match.id,
+        participantId: black.id,
+        moveNumber: 5,
+        x: 9,
+        y: 9,
+        requestId: createId(),
+        baseVersion: 4,
+        stateVersion: 5,
+        createdAt: new Date(startedAt.getTime() + 40 * 1000),
+      },
+      {
+        matchId: match.id,
+        participantId: white.id,
+        moveNumber: 6,
+        x: 6,
+        y: 8,
+        requestId: createId(),
+        baseVersion: 5,
+        stateVersion: 6,
+        createdAt: new Date(startedAt.getTime() + 50 * 1000),
+      },
+    ],
+  });
+
+  return { match, startedAt, finishedAt };
+};
+
+const seedStatsAndAchievements = async (
+  aliceId: string,
+  bobId: string,
+  carolId: string,
+  finishedAt: Date,
+) => {
+  await prisma.userGameStats.createMany({
+    data: [
+      {
+        userId: aliceId,
+        ruleType: RuleType.GOMOKU,
+        boardSize: 15,
+        matchesPlayed: 5,
+        wins: 4,
+        losses: 1,
+        draws: 0,
+        botMatchesPlayed: 2,
+        botWins: 2,
+        currentStreak: 3,
+        bestStreak: 4,
+        rating: 1200,
+        averageMoveTimeMs: 900,
+        totalPlayTimeSeconds: 1200,
+        lastPlayedAt: finishedAt,
+      },
+      {
+        userId: bobId,
+        ruleType: RuleType.GOMOKU,
+        boardSize: 15,
+        matchesPlayed: 4,
+        wins: 1,
+        losses: 3,
+        draws: 0,
+        botMatchesPlayed: 1,
+        botWins: 1,
+        currentStreak: 0,
+        bestStreak: 2,
+        rating: 1080,
+        averageMoveTimeMs: 1100,
+        totalPlayTimeSeconds: 900,
+        lastPlayedAt: finishedAt,
+      },
+      {
+        userId: carolId,
+        ruleType: RuleType.GOMOKU,
+        boardSize: 15,
+        matchesPlayed: 2,
+        wins: 0,
+        losses: 2,
+        draws: 0,
+        botMatchesPlayed: 0,
+        botWins: 0,
+        currentStreak: 0,
+        bestStreak: 0,
+        rating: 1020,
+        averageMoveTimeMs: 1400,
+        totalPlayTimeSeconds: 400,
+        lastPlayedAt: finishedAt,
+      },
+    ],
+  });
+
+  const firstWin = await prisma.achievementDefinition.create({
+    data: {
+      code: "first_win",
+      name: "First Victory",
+      description: "Win your first public match.",
+      points: 10,
+    },
+  });
+  const socialLink = await prisma.achievementDefinition.create({
+    data: {
+      code: "first_friend",
+      name: "Social Link",
+      description: "Add your first friend.",
+      points: 5,
+    },
+  });
+  const strategist = await prisma.achievementDefinition.create({
+    data: {
+      code: "ten_moves",
+      name: "Strategist",
+      description: "Record at least 10 moves across matches.",
+      points: 15,
+    },
+  });
+
+  await prisma.userAchievement.createMany({
+    data: [
+      {
+        userId: aliceId,
+        achievementId: firstWin.id,
+        progress: 1,
+        completedAt: finishedAt,
+      },
+      {
+        userId: aliceId,
+        achievementId: socialLink.id,
+        progress: 1,
+        completedAt: finishedAt,
+      },
+      {
+        userId: bobId,
+        achievementId: socialLink.id,
+        progress: 1,
+        completedAt: finishedAt,
+      },
+      {
+        userId: bobId,
+        achievementId: strategist.id,
+        progress: 10,
+        completedAt: finishedAt,
+      },
+    ],
+  });
+};
+
+const seedAnalyticsEvents = async (
+  matchId: string,
+  sessions: Record<string, UserSession>,
+  aliceId: string,
+  bobId: string,
+  carolId: string,
+  finishedAt: Date,
+) => {
+  const now = new Date();
+
+  await prisma.analyticsEvent.createMany({
+    data: [
+      {
+        id: createId(),
+        userId: aliceId,
+        sessionId: sessions[aliceId]?.id,
+        matchId,
+        eventType: "match.finished",
+        properties: {
+          winnerSeat: Seat.BLACK,
+          ruleType: RuleType.GOMOKU,
+          boardSize: 15,
+        } satisfies Prisma.JsonObject,
+        createdAt: finishedAt,
+      },
+      {
+        id: createId(),
+        userId: bobId,
+        sessionId: sessions[bobId]?.id,
+        matchId,
+        eventType: "match.spectated",
+        properties: {
+          viewer: "carol",
+          peakViewers: 1,
+        } satisfies Prisma.JsonObject,
+        createdAt: finishedAt,
+      },
+      {
+        id: createId(),
+        userId: carolId,
+        sessionId: sessions[carolId]?.id,
+        eventType: "friendship.accepted",
+        properties: {
+          accepted: true,
+        } satisfies Prisma.JsonObject,
+        createdAt: now,
+      },
+    ],
+  });
+};
+
+const main = async () => {
+  const existingUsers = await prisma.user.count();
+  if (existingUsers > 0) {
+    console.log(
+      "Database is not empty; skipping seed to avoid clobbering existing data.",
+    );
+    return;
+  }
+
+  const { alice, bob, carol, sessions } = await seedUsers();
+  await seedFriendship(alice.id, bob.id);
+  await seedDirectConversation(alice.id, bob.id);
+  const { match, finishedAt } = await seedMatch(alice.id, bob.id, carol.id);
+  await seedStatsAndAchievements(alice.id, bob.id, carol.id, finishedAt);
+  await seedAnalyticsEvents(
+    match.id,
+    sessions,
+    alice.id,
+    bob.id,
+    carol.id,
+    finishedAt,
+  );
+
+  console.log(
+    "Seed data created: users, friendship, chat, match, stats, achievements, and analytics.",
+  );
+};
+
+main()
+  .catch((error: unknown) => {
+    console.error("Failed to seed database:", error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
This pull request introduces a major refactor of the backend data model, replacing the previous "Room"-based game structure with a new, more robust "Match"-based domain model. It also adds support for user profiles, avatars, achievements, and analytics, and updates the Prisma schema and migrations accordingly. Additionally, it improves database seeding and ID generation logic.

**Domain Model Refactor and Schema Changes**

* Replaced `Room`, `RoomParticipant`, and `Move` models with new `Match`, `MatchParticipant`, and `MatchMove` models to better represent game sessions and participants. Updated related enums, fields, and foreign keys throughout the schema. [[1]](diffhunk://#diff-3619344c5d2c46a921708dea13c4fdacc3ef966533235d9ef5cc4d18750299f9R1-R347) [[2]](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7R27-L50) [[3]](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7R56-R84) [[4]](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7R93-R162) [[5]](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7L142-R223) [[6]](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7L182-R257)
* Replaced `ChatMessage` with `DirectMessage` and updated related relations. Added new conversation kinds (`GROUP`, `MATCH`) and removed the obsolete `ROOM` kind. [[1]](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7R27-L50) [[2]](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7L171-R238) [[3]](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7L182-R257)

**New Features**

* Added `UserProfile` and `AvatarMedia` models to support user profiles, avatars, and associated metadata.
* Introduced achievements (`AchievementDefinition`, `UserAchievement`) and analytics (`AnalyticsEvent`) models for tracking user progress and events.
* Added new fields to existing models (e.g., `User.statusMessage`, `OAuthAccount.scopes`, `UserSession.revokedAt`, `UserSession.ipAddress`, `UserSession.userAgent`, `Friendship.acceptedAt`, `Friendship.declinedAt`) for richer user and session data. [[1]](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7R93-R162) [[2]](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7L113-R181) [[3]](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7R194-R195)

**Prisma and Backend Logic Updates**

* Updated ID generation logic in `prisma.ts` to ensure all CUID-based models (including new ones) receive IDs as needed. [[1]](diffhunk://#diff-5cd3dcd34a1040ace069109e9985c9cdf2e6a33bc97cec7f095ca4d9705ffdd9L39-R56) [[2]](diffhunk://#diff-5cd3dcd34a1040ace069109e9985c9cdf2e6a33bc97cec7f095ca4d9705ffdd9L61-R68)
* Updated backend API route for creating a game: now creates a `Match` instead of a `Room`.

**Developer Experience Improvements**

* Added database seeding support: new `prisma:seed` script and migration config to run the seed file. Documented usage in `README.md`. [[1]](diffhunk://#diff-8d3b741039fe624dded05aa46e994d93ec459ac8d8a0cfc747f92ef447a9513aL13-R14) [[2]](diffhunk://#diff-7119b8e144ecbc3e148a897dc6288b6b8b0cfcbf7f4eeef11ad9b99595d66d4cR19-R21) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R67)