### PR TITLE
Update PostgreSQL data volume path to major-versioned directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d database
 ```
 
+PostgreSQL 18 stores container data below a major-versioned directory. If the
+database container exits with an `unused mount/volume` error for
+`/var/lib/postgresql/data`, reset the disposable local development volume with
+the same `down -v` command above. Preserve and migrate the volume with
+`pg_upgrade` instead if it contains data you need to keep.
+
 ### Run the full stack with containers
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-transcendence}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     networks:
       - transcendence
     healthcheck:


### PR DESCRIPTION
This pull request updates the setup and documentation for the PostgreSQL service in the development environment. The main focus is to ensure compatibility with PostgreSQL 18, which changes the way container data is stored, and to provide guidance for resolving related volume errors.

**PostgreSQL 18 compatibility and documentation:**

* Updated the `docker-compose.yml` file to mount the `postgres_data` volume at `/var/lib/postgresql` instead of `/var/lib/postgresql/data`, aligning with PostgreSQL 18's new storage structure.
* Added documentation in `README.md` explaining the new data storage behavior in PostgreSQL 18, how to reset the development volume if you encounter an `unused mount/volume` error, and the recommendation to use `pg_upgrade` if you need to preserve existing data.