### PR TITLE
[codex] Implement authenticated Socket.IO lifecycle

### DIFF
--- a/app/components/presence-provider.tsx
+++ b/app/components/presence-provider.tsx
@@ -34,19 +34,28 @@ export function PresenceProvider({
     const nextSocket = createSocket(socketUrl);
     setSocket(nextSocket);
 
-    nextSocket.on("connect", () => {
+    const handleConnect = () => {
       nextSocket.emit("presence:subscribe");
-    });
+    };
 
-    nextSocket.on("presence:update", (users: string[]) => {
+    const handlePresenceUpdate = (users: string[]) => {
       setOnlineUsers(users);
-    });
+    };
 
-    nextSocket.on("connect_error", () => {
+    const handleUnavailable = () => {
       setOnlineUsers([]);
-    });
+    };
+
+    nextSocket.on("connect", handleConnect);
+    nextSocket.on("presence:update", handlePresenceUpdate);
+    nextSocket.on("connect_error", handleUnavailable);
+    nextSocket.on("disconnect", handleUnavailable);
 
     return () => {
+      nextSocket.off("connect", handleConnect);
+      nextSocket.off("presence:update", handlePresenceUpdate);
+      nextSocket.off("connect_error", handleUnavailable);
+      nextSocket.off("disconnect", handleUnavailable);
       nextSocket.disconnect();
       setSocket(null);
     };

--- a/app/lib/socket-client.test.ts
+++ b/app/lib/socket-client.test.ts
@@ -18,6 +18,10 @@ describe("createSocket", () => {
 
     expect(io).toHaveBeenCalledWith("https://localhost:8443", {
       path: "/socket.io",
+      reconnection: true,
+      reconnectionDelay: 500,
+      reconnectionDelayMax: 5000,
+      timeout: 10000,
       withCredentials: true,
     });
   });
@@ -27,6 +31,10 @@ describe("createSocket", () => {
 
     expect(io).toHaveBeenCalledWith("http://localhost:3001", {
       path: "/socket.io",
+      reconnection: true,
+      reconnectionDelay: 500,
+      reconnectionDelayMax: 5000,
+      timeout: 10000,
       withCredentials: true,
     });
   });
@@ -36,6 +44,10 @@ describe("createSocket", () => {
 
     expect(io).toHaveBeenCalledWith({
       path: "/socket.io",
+      reconnection: true,
+      reconnectionDelay: 500,
+      reconnectionDelayMax: 5000,
+      timeout: 10000,
       withCredentials: true,
     });
   });

--- a/app/lib/socket-client.ts
+++ b/app/lib/socket-client.ts
@@ -4,6 +4,15 @@ import { io } from "socket.io-client";
 
 type SocketLocation = Pick<Location, "hostname" | "port">;
 
+export const socketClientOptions = {
+  path: "/socket.io",
+  reconnection: true,
+  reconnectionDelay: 500,
+  reconnectionDelayMax: 5000,
+  timeout: 10000,
+  withCredentials: true,
+} as const;
+
 export function resolveSocketUrl(
   configuredUrl?: string,
   location: SocketLocation | undefined = typeof window === "undefined"
@@ -27,10 +36,5 @@ export function resolveSocketUrl(
 
 export function createSocket(configuredUrl?: string, location?: SocketLocation) {
   const socketUrl = resolveSocketUrl(configuredUrl, location);
-  const options = {
-    path: "/socket.io",
-    withCredentials: true,
-  };
-
-  return socketUrl ? io(socketUrl, options) : io(options);
+  return socketUrl ? io(socketUrl, socketClientOptions) : io(socketClientOptions);
 }

--- a/realtime/lib/presence.test.ts
+++ b/realtime/lib/presence.test.ts
@@ -4,11 +4,13 @@ import { removePresenceConnection, subscribeToPresence, type ConnectedUsers } fr
 
 const join = mock();
 const emit = mock();
+const socketEmit = mock();
 let connectedUsers: ConnectedUsers;
 
 beforeEach(() => {
   join.mockReset();
   emit.mockReset();
+  socketEmit.mockReset();
   connectedUsers = new Map();
 });
 
@@ -16,6 +18,7 @@ describe("subscribeToPresence", () => {
   test("joins the authenticated user's room and publishes active usernames", () => {
     const socket = {
       data: { user: { username: "ada" } },
+      emit: socketEmit,
       id: "socket-1",
       join,
     };
@@ -25,11 +28,30 @@ describe("subscribeToPresence", () => {
     expect(join).toHaveBeenCalledWith("user:ada");
     expect(connectedUsers.get("socket-1")).toBe("ada");
     expect(emit).toHaveBeenCalledWith("presence:update", ["ada"]);
+    expect(socketEmit).not.toHaveBeenCalled();
+  });
+
+  test("sends a snapshot to reconnecting sockets when the public presence set is unchanged", () => {
+    connectedUsers.set("socket-1", "ada");
+    const socket = {
+      data: { user: { username: "ada" } },
+      emit: socketEmit,
+      id: "socket-2",
+      join,
+    };
+
+    subscribeToPresence(socket, { emit }, connectedUsers);
+
+    expect(join).toHaveBeenCalledWith("user:ada");
+    expect(connectedUsers.get("socket-2")).toBe("ada");
+    expect(socketEmit).toHaveBeenCalledWith("presence:update", ["ada"]);
+    expect(emit).not.toHaveBeenCalled();
   });
 
   test("ignores sockets without a session-derived username", () => {
     const socket = {
       data: { user: {} },
+      emit: socketEmit,
       id: "socket-1",
       join,
     };
@@ -43,7 +65,7 @@ describe("subscribeToPresence", () => {
 });
 
 describe("removePresenceConnection", () => {
-  test("removes only the disconnected socket and republishes unique usernames", () => {
+  test("removes only the disconnected socket without broadcasting when the user is still online", () => {
     connectedUsers.set("socket-1", "ada");
     connectedUsers.set("socket-2", "ada");
     connectedUsers.set("socket-3", "grace");
@@ -51,6 +73,16 @@ describe("removePresenceConnection", () => {
     removePresenceConnection({ id: "socket-1" }, { emit }, connectedUsers);
 
     expect(connectedUsers.has("socket-1")).toBe(false);
-    expect(emit).toHaveBeenCalledWith("presence:update", ["ada", "grace"]);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  test("broadcasts when a user's final socket disconnects", () => {
+    connectedUsers.set("socket-1", "ada");
+    connectedUsers.set("socket-2", "grace");
+
+    removePresenceConnection({ id: "socket-1" }, { emit }, connectedUsers);
+
+    expect(connectedUsers.has("socket-1")).toBe(false);
+    expect(emit).toHaveBeenCalledWith("presence:update", ["grace"]);
   });
 });

--- a/realtime/lib/presence.ts
+++ b/realtime/lib/presence.ts
@@ -11,11 +11,19 @@ type PresenceSocket = {
     };
   };
   id: string;
+  emit(event: "presence:update", users: string[]): unknown;
   join(room: string): unknown;
 };
 
 export function getActiveUsernames(connectedUsers: ConnectedUsers) {
   return Array.from(new Set(connectedUsers.values()));
+}
+
+function hasSameUsernames(left: string[], right: string[]) {
+  if (left.length !== right.length) return false;
+
+  const rightUsernames = new Set(right);
+  return left.every((username) => rightUsernames.has(username));
 }
 
 export function subscribeToPresence(
@@ -26,9 +34,18 @@ export function subscribeToPresence(
   const username = socket.data.user?.username;
   if (!username) return;
 
+  const previousUsernames = getActiveUsernames(connectedUsers);
+
   void socket.join(`user:${username}`);
   connectedUsers.set(socket.id, username);
-  broadcaster.emit("presence:update", getActiveUsernames(connectedUsers));
+
+  const activeUsernames = getActiveUsernames(connectedUsers);
+  if (hasSameUsernames(previousUsernames, activeUsernames)) {
+    socket.emit("presence:update", activeUsernames);
+    return;
+  }
+
+  broadcaster.emit("presence:update", activeUsernames);
 }
 
 export function removePresenceConnection(
@@ -38,6 +55,12 @@ export function removePresenceConnection(
 ) {
   if (!connectedUsers.has(socket.id)) return;
 
+  const previousUsernames = getActiveUsernames(connectedUsers);
+
   connectedUsers.delete(socket.id);
-  broadcaster.emit("presence:update", getActiveUsernames(connectedUsers));
+
+  const activeUsernames = getActiveUsernames(connectedUsers);
+  if (!hasSameUsernames(previousUsernames, activeUsernames)) {
+    broadcaster.emit("presence:update", activeUsernames);
+  }
 }

--- a/realtime/lib/socket-lifecycle.test.ts
+++ b/realtime/lib/socket-lifecycle.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  createHeartbeatPayload,
+  readPositiveIntegerEnv,
+  startSocketLifecycle,
+} from "./socket-lifecycle";
+
+describe("createHeartbeatPayload", () => {
+  test("uses an ISO timestamp from the provided clock", () => {
+    const payload = createHeartbeatPayload(() => new Date("2026-05-10T12:30:00.000Z"));
+
+    expect(payload).toEqual({ timestamp: "2026-05-10T12:30:00.000Z" });
+  });
+});
+
+describe("readPositiveIntegerEnv", () => {
+  test("keeps valid positive integer values", () => {
+    expect(
+      readPositiveIntegerEnv({ SOCKET_PING_TIMEOUT_MS: "7500" }, "SOCKET_PING_TIMEOUT_MS", 1),
+    ).toBe(7500);
+  });
+
+  test("falls back for missing, non-integer, or non-positive values", () => {
+    expect(readPositiveIntegerEnv({}, "SOCKET_PING_TIMEOUT_MS", 1000)).toBe(1000);
+    expect(
+      readPositiveIntegerEnv({ SOCKET_PING_TIMEOUT_MS: "1.5" }, "SOCKET_PING_TIMEOUT_MS", 1000),
+    ).toBe(1000);
+    expect(
+      readPositiveIntegerEnv({ SOCKET_PING_TIMEOUT_MS: "0" }, "SOCKET_PING_TIMEOUT_MS", 1000),
+    ).toBe(1000);
+  });
+});
+
+describe("startSocketLifecycle", () => {
+  test("sends welcome immediately and schedules heartbeat payloads", () => {
+    const intervalHandle = 7 as unknown as ReturnType<typeof setInterval>;
+    const emit = mock();
+    const clearIntervalFn = mock();
+    const scheduledCallbacks: Array<() => void> = [];
+    const setIntervalFn = mock((callback: () => void, intervalMs: number) => {
+      scheduledCallbacks.push(callback);
+      expect(intervalMs).toBe(5000);
+      return intervalHandle;
+    });
+
+    const stop = startSocketLifecycle(
+      {
+        data: { user: { username: "ada" } },
+        emit,
+      },
+      {
+        clearIntervalFn,
+        heartbeatIntervalMs: 5000,
+        now: () => new Date("2026-05-10T12:30:00.000Z"),
+        setIntervalFn,
+      },
+    );
+
+    expect(emit).toHaveBeenCalledWith("welcome", {
+      message: "Connected to realtime service",
+      username: "ada",
+    });
+    expect(setIntervalFn).toHaveBeenCalledTimes(1);
+
+    scheduledCallbacks[0]?.();
+
+    expect(emit).toHaveBeenCalledWith("heartbeat", {
+      timestamp: "2026-05-10T12:30:00.000Z",
+    });
+
+    stop();
+
+    expect(clearIntervalFn).toHaveBeenCalledWith(intervalHandle);
+  });
+});

--- a/realtime/lib/socket-lifecycle.ts
+++ b/realtime/lib/socket-lifecycle.ts
@@ -1,0 +1,76 @@
+export const DEFAULT_SOCKET_HEARTBEAT_INTERVAL_MS = 15_000;
+export const DEFAULT_SOCKET_PING_INTERVAL_MS = 15_000;
+export const DEFAULT_SOCKET_PING_TIMEOUT_MS = 10_000;
+
+export type HeartbeatPayload = {
+  timestamp: string;
+};
+
+export type WelcomePayload = {
+  message: string;
+  username?: string;
+};
+
+type LifecycleSocket = {
+  data: {
+    user?: {
+      username?: string | null;
+    };
+  };
+  emit(event: "heartbeat", payload: HeartbeatPayload): unknown;
+  emit(event: "welcome", payload: WelcomePayload): unknown;
+};
+
+type IntervalHandle = ReturnType<typeof setInterval>;
+
+type SocketLifecycleOptions = {
+  clearIntervalFn?: (handle: IntervalHandle) => void;
+  heartbeatIntervalMs?: number;
+  now?: () => Date;
+  setIntervalFn?: (callback: () => void, intervalMs: number) => IntervalHandle;
+};
+
+export function readPositiveIntegerEnv(
+  env: Record<string, string | undefined>,
+  name: string,
+  fallback: number,
+) {
+  const value = env[name];
+  if (!value) return fallback;
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function createHeartbeatPayload(now: () => Date = () => new Date()): HeartbeatPayload {
+  return {
+    timestamp: now().toISOString(),
+  };
+}
+
+export function emitHeartbeat(socket: LifecycleSocket, now?: () => Date) {
+  socket.emit("heartbeat", createHeartbeatPayload(now));
+}
+
+export function startSocketLifecycle(
+  socket: LifecycleSocket,
+  {
+    clearIntervalFn = clearInterval,
+    heartbeatIntervalMs = DEFAULT_SOCKET_HEARTBEAT_INTERVAL_MS,
+    now = () => new Date(),
+    setIntervalFn = setInterval,
+  }: SocketLifecycleOptions = {},
+) {
+  const username = socket.data.user?.username ?? undefined;
+
+  socket.emit("welcome", {
+    message: "Connected to realtime service",
+    ...(username ? { username } : {}),
+  });
+
+  const heartbeatTimer = setIntervalFn(() => emitHeartbeat(socket, now), heartbeatIntervalMs);
+
+  return () => {
+    clearIntervalFn(heartbeatTimer);
+  };
+}

--- a/realtime/server.ts
+++ b/realtime/server.ts
@@ -13,6 +13,13 @@ import { registerMatchSubscription } from "./handlers/match-subscription";
 import { removePresenceConnection, subscribeToPresence, type ConnectedUsers } from "./lib/presence";
 import { matchRoomId } from "./lib/rooms";
 import { authenticateSocketSession } from "./lib/socket-auth";
+import {
+  DEFAULT_SOCKET_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_SOCKET_PING_INTERVAL_MS,
+  DEFAULT_SOCKET_PING_TIMEOUT_MS,
+  readPositiveIntegerEnv,
+  startSocketLifecycle,
+} from "./lib/socket-lifecycle";
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 const rootEnvPath = resolve(currentDirectory, "../.env");
@@ -24,6 +31,21 @@ if (existsSync(rootEnvPath)) {
 const hostname = process.env["SOCKET_HOST"] ?? "0.0.0.0";
 const port = Number(process.env["SOCKET_PORT"] || 3001);
 const socketPath = process.env["SOCKET_PATH"] ?? "/socket.io/";
+const socketHeartbeatIntervalMs = readPositiveIntegerEnv(
+  process.env,
+  "SOCKET_HEARTBEAT_INTERVAL_MS",
+  DEFAULT_SOCKET_HEARTBEAT_INTERVAL_MS,
+);
+const socketPingIntervalMs = readPositiveIntegerEnv(
+  process.env,
+  "SOCKET_PING_INTERVAL_MS",
+  DEFAULT_SOCKET_PING_INTERVAL_MS,
+);
+const socketPingTimeoutMs = readPositiveIntegerEnv(
+  process.env,
+  "SOCKET_PING_TIMEOUT_MS",
+  DEFAULT_SOCKET_PING_TIMEOUT_MS,
+);
 
 function readCorsOrigins(): string[] {
   const configuredOrigins = process.env["SOCKET_CORS_ORIGIN"];
@@ -37,6 +59,8 @@ const corsOrigins = readCorsOrigins();
 
 const engine = new Engine({
   path: socketPath,
+  pingInterval: socketPingIntervalMs,
+  pingTimeout: socketPingTimeoutMs,
   cors: {
     origin: corsOrigins,
     methods: ["GET", "POST"],
@@ -69,6 +93,11 @@ io.on("connection", (socket) => {
   console.log(`Socket.IO client connected: ${socket.id}`);
   console.log(`[realtime] connected: ${socket.id}`);
 
+  const stopSocketLifecycle = startSocketLifecycle(socket, {
+    heartbeatIntervalMs: socketHeartbeatIntervalMs,
+  });
+
+  subscribeToPresence(socket, io, connectedUsers);
   registerMatchSubscription(socket);
 
   socket.on("presence:subscribe", () => {
@@ -98,12 +127,13 @@ io.on("connection", (socket) => {
     }
   });
 
-  socket.on("queue:join", async (userId: string) => {
+  socket.on("queue:join", async () => {
+    const userId = socket.data.user?.id;
     if (!userId) return;
 
-    if (matchQueue.some((player) => player.userId === userId)) {
-      return;
-    }
+    matchQueue = matchQueue.filter(
+      (player) => player.userId !== userId && player.socketId !== socket.id,
+    );
 
     matchQueue.push({ socketId: socket.id, userId });
     console.log(`Player ${userId} joined the queue. Total waiting: ${matchQueue.length}`);
@@ -152,6 +182,7 @@ io.on("connection", (socket) => {
   socket.on("disconnect", (reason) => {
     console.log(`Socket.IO client disconnected: ${socket.id} (${reason})`);
 
+    stopSocketLifecycle();
     matchQueue = matchQueue.filter((player) => player.socketId !== socket.id);
 
     removePresenceConnection(socket, io, connectedUsers);


### PR DESCRIPTION
## Summary

Closes #24.

- Add an authenticated Socket.IO lifecycle helper for welcome and heartbeat events.
- Configure heartbeat and ping timing on the Bun realtime service.
- Register authenticated sockets for presence immediately and make reconnect snapshots idempotent.
- Use session-derived user ids for queue joins and clean up lifecycle, queue, and presence state on disconnect.
- Configure the browser Socket.IO client for credentialed reconnects and explicit listener cleanup.

## Validation

- `bun test`
- `bunx --bun tsc --noEmit`
- `bun run lint:js`
- `bun run format:check`
- `git diff --check`