### PR TITLE
[codex] Avoid dev watcher exhaustion

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 node_modules
 .next
 .docker-data
+.transcendence-docker-data
 generated
 bun-debug.log*
 npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ bun-debug.log*
 npm-debug.log*
 .next
 .docker-data
+.transcendence-docker-data
 generated
 bun.lockb
 tsconfig.tsbuildinfo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,20 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
+  "files.watcherExclude": {
+    "**/.docker-data/**": true,
+    "**/.next/**": true,
+    "**/.playwright-browsers/**": true,
+    "**/generated/**": true,
+    "**/node_modules/**": true
+  },
+  "search.exclude": {
+    "**/.docker-data/**": true,
+    "**/.next/**": true,
+    "**/.playwright-browsers/**": true,
+    "**/generated/**": true,
+    "**/node_modules/**": true
+  },
   "oxc.typeAware": true,
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 COMPOSE_BASE = docker-compose.yml
 COMPOSE_DEV = docker-compose.dev.yml
 COMPOSE = docker compose -f $(COMPOSE_BASE) -f $(COMPOSE_DEV)
-DOCKER_DATA_DIR = .docker-data
+DOCKER_DATA_DIR ?= ../.transcendence-docker-data
+export DOCKER_DATA_DIR
 
 .DEFAULT_GOAL := help
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ The root install intentionally skips dependency lifecycle scripts. Generate the 
 ### Docker data location
 
 Keep Docker Engine's `data-root` on a local filesystem such as `goinfre`. This
-repo stores project-owned container data in bind-mounted directories under
-`.docker-data/`, which lives beside the repo on `sgoinfre` when the repo is
-checked out there:
+repo stores project-owned container data in bind-mounted directories under the
+path set by `DOCKER_DATA_DIR`, which defaults to a sibling directory named
+`../.transcendence-docker-data` when using the `make` targets:
 
-- `.docker-data/caddy` for Caddy local CA/cert state
-- `.docker-data/app` for container-only development caches such as
+- `../.transcendence-docker-data/caddy` for Caddy local CA/cert state
+- `../.transcendence-docker-data/app` for container-only development caches such as
   `node_modules`, `.next`, and generated Prisma files
 
 Uploaded profile images are stored in `public/uploads/`, which is also ignored
@@ -45,7 +45,7 @@ PostgreSQL stays in a Docker named volume. On the 42 lab machines, rootless
 Docker cannot initialize PostgreSQL data on the NFS-backed `sgoinfre` mount
 because the image needs ownership changes during startup.
 
-Because `.docker-data/` and `public/uploads/` are bind mounts,
+Because `DOCKER_DATA_DIR` and `public/uploads/` are bind mounts,
 `docker compose down -v` does not remove them. Use `make db-reset` or
 `make fclean` when you want to delete the local Docker data directories as well.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,9 +11,10 @@ services:
       SOCKET_PUBLIC_URL: https://localhost:8443
     volumes:
       - .:/app
-      - ./.docker-data/app/node_modules:/app/node_modules
-      - ./.docker-data/app/next:/app/.next
-      - ./.docker-data/app/generated:/app/generated
+      - hidden_legacy_docker_data:/app/.docker-data
+      - ${DOCKER_DATA_DIR:-../.transcendence-docker-data}/app/node_modules:/app/node_modules
+      - ${DOCKER_DATA_DIR:-../.transcendence-docker-data}/app/next:/app/.next
+      - ${DOCKER_DATA_DIR:-../.transcendence-docker-data}/app/generated:/app/generated
     healthcheck:
       start_period: 40s
 
@@ -33,6 +34,10 @@ services:
       SOCKET_CORS_ORIGIN: https://localhost:8443
     volumes:
       - .:/app
-      - ./.docker-data/app/node_modules:/app/node_modules
+      - hidden_legacy_docker_data:/app/.docker-data
+      - ${DOCKER_DATA_DIR:-../.transcendence-docker-data}/app/node_modules:/app/node_modules
     healthcheck:
       start_period: 5s
+
+volumes:
+  hidden_legacy_docker_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,8 +88,8 @@ services:
       - "8443:8443"
     volumes:
       - ./infra/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
-      - ./.docker-data/caddy/data:/data
-      - ./.docker-data/caddy/config:/config
+      - ${DOCKER_DATA_DIR:-../.transcendence-docker-data}/caddy/data:/data
+      - ${DOCKER_DATA_DIR:-../.transcendence-docker-data}/caddy/config:/config
     networks:
       - transcendence
 


### PR DESCRIPTION
## Summary

This PR keeps the Next.js Turbopack dev server from exhausting the low inotify watcher limit on 42 lab machines.

## What Changed

- Added VS Code watcher and search excludes for generated dependency/cache folders.
- Moved project-owned Docker dev caches from the repo-local `.docker-data` folder to a sibling `../.transcendence-docker-data` directory by default.
- Masked `/app/.docker-data` inside dev containers so older repo-local caches are not visible to Turbopack through the `/app` bind mount.
- Updated the README to document the new `DOCKER_DATA_DIR` default.

## Why

VS Code was able to consume nearly the full host `fs.inotify.max_user_watches` budget by watching repo-local generated cache folders. Turbopack then failed while trying to watch the app directory with `OS file watch limit reached`.

## Validation

- `DOCKER_DATA_DIR=../.transcendence-docker-data docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet`
- `make dev-detached`
- Confirmed app logs show `Next.js 16.2.6 (Turbopack)` and `Ready in 412ms`.
- Confirmed `https://localhost:8443/api/health` returns app/database `ok`.
