### PR TITLE
Fix live screen updates when removing friends or declining requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,5 @@ BETTER_AUTH_URL=http://localhost:3000
 # SOCKET_PUBLIC_URL=http://localhost:3001
 # SOCKET_CORS_ORIGIN=http://localhost:3000,https://localhost:8443
 # REALTIME_INTERNAL_URL=http://localhost:3001/internal/game-update
+# REALTIME_FRIENDSHIP_INTERNAL_URL=http://localhost:3001/internal/friendship-update
+# REALTIME_INTERNAL_SECRET=change_me_to_a_shared_internal_secret

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ bun run dev:realtime
 This host-shell path still serves plain HTTP on `http://localhost:3000`. Set
 `REALTIME_INTERNAL_URL=http://localhost:3001/internal/game-update` in `.env` so
 the Next route handlers can publish match updates to the host-side realtime
-service.
+service. Friendship refreshes are derived from that URL unless you set
+`REALTIME_FRIENDSHIP_INTERNAL_URL` explicitly. Internal friendship publishes use
+`REALTIME_INTERNAL_SECRET`, falling back to `BETTER_AUTH_SECRET`, as the shared
+service-to-service header secret.
 
 ### Prisma workflow
 

--- a/app/[locale]/friends/actions.ts
+++ b/app/[locale]/friends/actions.ts
@@ -3,32 +3,8 @@
 import { revalidatePath } from "next/cache";
 
 import { getCurrentSession } from "@/lib/auth";
+import { deleteFriendshipAndNotify, getLowHighIds } from "@/lib/friendships/friendship-mutations";
 import { prisma } from "@/lib/prisma";
-
-function getLowHighIds(id1: string, id2: string) {
-  return id1 < id2 ? { userLowId: id1, userHighId: id2 } : { userLowId: id2, userHighId: id1 };
-}
-
-async function notifyFriendshipUpdate(userLowId: string, userHighId: string) {
-  try {
-    const userLow = await prisma.user.findUnique({ where: { id: userLowId } });
-    const userHigh = await prisma.user.findUnique({ where: { id: userHighId } });
-
-    if (!userLow || !userHigh) return;
-
-    const socketUrl = process.env["REALTIME_INTERNAL_URL"]
-      ? process.env["REALTIME_INTERNAL_URL"].replace("/game-update", "/friendship-update")
-      : "http://realtime:3001/internal/friendship-update";
-
-    await fetch(socketUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ usernames: [userLow.username, userHigh.username] }),
-    });
-  } catch (err) {
-    console.error("Failed to notify realtime server", err);
-  }
-}
 
 export async function sendFriendRequest(targetUsername: string) {
   const session = await getCurrentSession();
@@ -88,10 +64,7 @@ export async function respondToRequest(friendshipId: number, accept: boolean) {
       },
     });
   } else {
-    await prisma.friendship.delete({
-      where: { id: friendshipId },
-    });
-    await notifyFriendshipUpdate(friendship.userLowId, friendship.userHighId);
+    await deleteFriendshipAndNotify(friendship);
   }
 
   revalidatePath("/", "layout");
@@ -108,11 +81,7 @@ export async function removeFriend(friendshipId: number) {
   if (friendship.userLowId !== session.user.id && friendship.userHighId !== session.user.id) {
     return { error: "Unauthorized." };
   }
-  await prisma.friendship.delete({
-    where: { id: friendshipId },
-  });
-
-  await notifyFriendshipUpdate(friendship.userLowId, friendship.userHighId);
+  await deleteFriendshipAndNotify(friendship);
 
   revalidatePath("/", "layout");
   return { success: true };

--- a/app/[locale]/friends/actions.ts
+++ b/app/[locale]/friends/actions.ts
@@ -9,6 +9,27 @@ function getLowHighIds(id1: string, id2: string) {
   return id1 < id2 ? { userLowId: id1, userHighId: id2 } : { userLowId: id2, userHighId: id1 };
 }
 
+async function notifyFriendshipUpdate(userLowId: string, userHighId: string) {
+  try {
+    const userLow = await prisma.user.findUnique({ where: { id: userLowId } });
+    const userHigh = await prisma.user.findUnique({ where: { id: userHighId } });
+
+    if (!userLow || !userHigh) return;
+
+    const socketUrl = process.env["REALTIME_INTERNAL_URL"]
+      ? process.env["REALTIME_INTERNAL_URL"].replace("/game-update", "/friendship-update")
+      : "http://realtime:3001/internal/friendship-update";
+
+    await fetch(socketUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ usernames: [userLow.username, userHigh.username] }),
+    });
+  } catch (err) {
+    console.error("Failed to notify realtime server", err);
+  }
+}
+
 export async function sendFriendRequest(targetUsername: string) {
   const session = await getCurrentSession();
   if (!session) return { error: "Please sign in to add friends." };
@@ -70,6 +91,7 @@ export async function respondToRequest(friendshipId: number, accept: boolean) {
     await prisma.friendship.delete({
       where: { id: friendshipId },
     });
+    await notifyFriendshipUpdate(friendship.userLowId, friendship.userHighId);
   }
 
   revalidatePath("/", "layout");
@@ -89,6 +111,9 @@ export async function removeFriend(friendshipId: number) {
   await prisma.friendship.delete({
     where: { id: friendshipId },
   });
+
+  await notifyFriendshipUpdate(friendship.userLowId, friendship.userHighId);
+
   revalidatePath("/", "layout");
   return { success: true };
 }

--- a/app/[locale]/friends/friends-layout.tsx
+++ b/app/[locale]/friends/friends-layout.tsx
@@ -142,7 +142,7 @@ export default function FriendsContent({
 
     await respondToRequest(friendshipId, accept);
 
-    if (request) {
+    if (accept && request) {
       socket?.emit("friendship:notify", request.username);
     }
 
@@ -154,13 +154,7 @@ export default function FriendsContent({
       return;
     }
 
-    const friend = friends.find((item) => item.id === friendshipId);
-
     await removeFriend(friendshipId);
-
-    if (friend) {
-      socket?.emit("friendship:notify", friend.username);
-    }
 
     router.refresh();
   };

--- a/app/[locale]/profile/[username]/actions.test.ts
+++ b/app/[locale]/profile/[username]/actions.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getCurrentSession = mock();
+const findFriendship = mock();
+const createFriendship = mock();
+const updateFriendship = mock();
+const deleteFriendshipAndNotify = mock();
+const revalidatePath = mock();
+
+await mock.module("next/cache", () => ({
+  revalidatePath,
+}));
+
+await mock.module("@/lib/auth", () => ({
+  getCurrentSession,
+}));
+
+await mock.module("@/lib/prisma", () => ({
+  prisma: {
+    friendship: {
+      create: createFriendship,
+      findUnique: findFriendship,
+      update: updateFriendship,
+    },
+  },
+}));
+
+await mock.module("@/lib/friendships/friendship-mutations", () => ({
+  deleteFriendshipAndNotify,
+  getLowHighIds: (id1: string, id2: string) =>
+    id1 < id2 ? { userLowId: id1, userHighId: id2 } : { userLowId: id2, userHighId: id1 },
+}));
+
+const { processFriendAction } = await import("./actions");
+
+const friendship = {
+  id: 42,
+  userLowId: "user-a",
+  userHighId: "user-b",
+  requestedById: "user-a",
+  status: "ACCEPTED",
+};
+
+beforeEach(() => {
+  getCurrentSession.mockReset();
+  findFriendship.mockReset();
+  createFriendship.mockReset();
+  updateFriendship.mockReset();
+  deleteFriendshipAndNotify.mockReset();
+  revalidatePath.mockReset();
+
+  getCurrentSession.mockResolvedValue({
+    user: { id: "user-a" },
+  });
+  findFriendship.mockResolvedValue(friendship);
+  deleteFriendshipAndNotify.mockResolvedValue(undefined);
+});
+
+describe("processFriendAction", () => {
+  test("uses the shared delete-and-notify path for profile removals", async () => {
+    const result = await processFriendAction("user-b", "REMOVE");
+
+    expect(result).toEqual({ success: true });
+    expect(deleteFriendshipAndNotify).toHaveBeenCalledWith(friendship);
+    expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
+  });
+
+  test("uses the shared delete-and-notify path for declined requests", async () => {
+    const pendingFriendship = {
+      ...friendship,
+      requestedById: "user-b",
+      status: "PENDING",
+    };
+
+    findFriendship.mockResolvedValueOnce(pendingFriendship);
+
+    const result = await processFriendAction("user-b", "DECLINE");
+
+    expect(result).toEqual({ success: true });
+    expect(deleteFriendshipAndNotify).toHaveBeenCalledWith(pendingFriendship);
+  });
+});

--- a/app/[locale]/profile/[username]/actions.ts
+++ b/app/[locale]/profile/[username]/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 
 import { getCurrentSession } from "@/lib/auth";
+import { deleteFriendshipAndNotify, getLowHighIds } from "@/lib/friendships/friendship-mutations";
 import { prisma } from "@/lib/prisma";
 
 export async function processFriendAction(
@@ -16,8 +17,7 @@ export async function processFriendAction(
     return { error: "Unauthorized" };
   }
 
-  const userLowId = loggedInUserId < targetUserId ? loggedInUserId : targetUserId;
-  const userHighId = loggedInUserId < targetUserId ? targetUserId : loggedInUserId;
+  const { userLowId, userHighId } = getLowHighIds(loggedInUserId, targetUserId);
 
   try {
     const existing = await prisma.friendship.findUnique({
@@ -51,9 +51,7 @@ export async function processFriendAction(
     } else if (action === "DECLINE" || action === "REMOVE" || action === "CANCEL") {
       if (!existing) return { error: "Not found" };
 
-      await prisma.friendship.delete({
-        where: { userLowId_userHighId: { userLowId, userHighId } },
-      });
+      await deleteFriendshipAndNotify(existing);
     }
 
     revalidatePath("/", "layout");

--- a/app/[locale]/profile/[username]/profile-actions.tsx
+++ b/app/[locale]/profile/[username]/profile-actions.tsx
@@ -44,7 +44,9 @@ export default function ProfileActions({
       const result = await processFriendAction(targetUserId, action);
 
       if (result?.success || !result?.error) {
-        socket?.emit("friendship:notify", targetUsername);
+        if (action === "ADD" || action === "ACCEPT") {
+          socket?.emit("friendship:notify", targetUsername);
+        }
         router.refresh();
       }
     });

--- a/app/lib/friendships/friendship-mutations.test.ts
+++ b/app/lib/friendships/friendship-mutations.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const deleteFriendship = mock();
+const findManyUsers = mock();
+const publishFriendshipUpdate = mock();
+const consoleError = mock();
+const originalConsoleError = console.error;
+
+await mock.module("@/lib/prisma", () => ({
+  prisma: {
+    friendship: {
+      delete: deleteFriendship,
+    },
+    user: {
+      findMany: findManyUsers,
+    },
+  },
+}));
+
+await mock.module("./realtime-publisher", () => ({
+  publishFriendshipUpdate,
+}));
+
+const { deleteFriendshipAndNotify, getLowHighIds } = await import("./friendship-mutations");
+
+beforeEach(() => {
+  deleteFriendship.mockReset();
+  findManyUsers.mockReset();
+  publishFriendshipUpdate.mockReset();
+  consoleError.mockReset();
+  console.error = consoleError as unknown as typeof console.error;
+
+  deleteFriendship.mockResolvedValue({});
+  publishFriendshipUpdate.mockResolvedValue(undefined);
+  findManyUsers.mockResolvedValue([
+    { id: "user-high", username: "bob" },
+    { id: "user-low", username: "alice" },
+  ]);
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+describe("getLowHighIds", () => {
+  test("orders friendship ids for the composite key", () => {
+    expect(getLowHighIds("user-z", "user-a")).toEqual({
+      userLowId: "user-a",
+      userHighId: "user-z",
+    });
+  });
+});
+
+describe("deleteFriendshipAndNotify", () => {
+  test("deletes by friendship id and publishes refreshes for both users", async () => {
+    await deleteFriendshipAndNotify({
+      id: 42,
+      userLowId: "user-low",
+      userHighId: "user-high",
+    });
+
+    expect(deleteFriendship).toHaveBeenCalledWith({
+      where: { id: 42 },
+    });
+    expect(findManyUsers).toHaveBeenCalledWith({
+      where: {
+        id: {
+          in: ["user-low", "user-high"],
+        },
+      },
+      select: {
+        id: true,
+        username: true,
+      },
+    });
+    expect(publishFriendshipUpdate).toHaveBeenCalledWith(["alice", "bob"]);
+  });
+
+  test("keeps the delete successful when realtime notification fails", async () => {
+    publishFriendshipUpdate.mockRejectedValueOnce(new Error("realtime down"));
+
+    await deleteFriendshipAndNotify({
+      id: 42,
+      userLowId: "user-low",
+      userHighId: "user-high",
+    });
+
+    expect(deleteFriendship).toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to notify realtime server",
+      expect.any(Error),
+    );
+  });
+});

--- a/app/lib/friendships/friendship-mutations.ts
+++ b/app/lib/friendships/friendship-mutations.ts
@@ -1,0 +1,49 @@
+import { prisma } from "@/lib/prisma";
+
+import { publishFriendshipUpdate } from "./realtime-publisher";
+
+type FriendshipSnapshot = {
+  id: number;
+  userHighId: string;
+  userLowId: string;
+};
+
+export function getLowHighIds(id1: string, id2: string) {
+  return id1 < id2 ? { userLowId: id1, userHighId: id2 } : { userLowId: id2, userHighId: id1 };
+}
+
+export async function notifyFriendshipUpdateForUserIds(userLowId: string, userHighId: string) {
+  const users = await prisma.user.findMany({
+    where: {
+      id: {
+        in: [userLowId, userHighId],
+      },
+    },
+    select: {
+      id: true,
+      username: true,
+    },
+  });
+
+  const usernameById = new Map(users.map((user) => [user.id, user.username]));
+  const userLowUsername = usernameById.get(userLowId);
+  const userHighUsername = usernameById.get(userHighId);
+
+  if (!userLowUsername || !userHighUsername) {
+    return;
+  }
+
+  await publishFriendshipUpdate([userLowUsername, userHighUsername]);
+}
+
+export async function deleteFriendshipAndNotify(friendship: FriendshipSnapshot) {
+  await prisma.friendship.delete({
+    where: { id: friendship.id },
+  });
+
+  try {
+    await notifyFriendshipUpdateForUserIds(friendship.userLowId, friendship.userHighId);
+  } catch (error) {
+    console.error("Failed to notify realtime server", error);
+  }
+}

--- a/app/lib/friendships/realtime-publisher.test.ts
+++ b/app/lib/friendships/realtime-publisher.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { internalRealtimeSecretHeader } from "../../../shared/realtime-internal";
+import { publishFriendshipUpdate, resolveFriendshipUpdateUrl } from "./realtime-publisher";
+
+const fetchMock = mock(async () => new Response(null, { status: 200 }));
+const originalFetch = globalThis.fetch;
+const envKeys = [
+  "BETTER_AUTH_SECRET",
+  "REALTIME_FRIENDSHIP_INTERNAL_URL",
+  "REALTIME_INTERNAL_SECRET",
+  "REALTIME_INTERNAL_URL",
+  "REALTIME_PUBLISH_TIMEOUT_MS",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]])) as Record<
+  (typeof envKeys)[number],
+  string | undefined
+>;
+
+function restoreEnv() {
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+async function expectRejectsWithMessage(action: () => Promise<unknown>, message: string) {
+  let thrown: unknown;
+
+  try {
+    await action();
+  } catch (error) {
+    thrown = error;
+  }
+
+  expect(thrown).toBeInstanceOf(Error);
+
+  if (thrown instanceof Error) {
+    expect(thrown.message).toContain(message);
+  }
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  for (const key of envKeys) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreEnv();
+});
+
+describe("resolveFriendshipUpdateUrl", () => {
+  test("uses the explicit friendship endpoint when configured", () => {
+    process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"] =
+      "http://localhost:3001/internal/friendship-update";
+    process.env["REALTIME_INTERNAL_URL"] = "http://localhost:3001/internal/game-update";
+
+    expect(resolveFriendshipUpdateUrl()).toBe("http://localhost:3001/internal/friendship-update");
+  });
+
+  test("derives the friendship endpoint from the game endpoint", () => {
+    process.env["REALTIME_INTERNAL_URL"] = "http://localhost:3001/internal/game-update";
+
+    expect(resolveFriendshipUpdateUrl()).toBe("http://localhost:3001/internal/friendship-update");
+  });
+});
+
+describe("publishFriendshipUpdate", () => {
+  test("posts unique usernames with the internal header and no-store cache", async () => {
+    process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"] =
+      "http://localhost:3001/internal/friendship-update";
+    process.env["REALTIME_INTERNAL_SECRET"] = "friend-secret";
+
+    await publishFriendshipUpdate(["alice", "bob", "alice"], 5000);
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+
+    expect(call).toBeDefined();
+
+    const [url, init] = call!;
+
+    expect(url).toBe("http://localhost:3001/internal/friendship-update");
+    expect(init).toMatchObject({
+      method: "POST",
+      cache: "no-store",
+      body: JSON.stringify({ usernames: ["alice", "bob"] }),
+    });
+    expect(init.headers).toEqual({
+      "Content-Type": "application/json",
+      [internalRealtimeSecretHeader]: "friend-secret",
+    });
+  });
+
+  test("falls back to the Better Auth secret when no dedicated secret is configured", async () => {
+    process.env["BETTER_AUTH_SECRET"] = "auth-secret";
+
+    await publishFriendshipUpdate(["alice"]);
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+
+    expect(call?.[1].headers).toMatchObject({
+      [internalRealtimeSecretHeader]: "auth-secret",
+    });
+  });
+
+  test("throws on missing secrets and failed realtime responses", async () => {
+    await expectRejectsWithMessage(
+      () => publishFriendshipUpdate(["alice"]),
+      "Missing REALTIME_INTERNAL_SECRET",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    process.env["REALTIME_INTERNAL_SECRET"] = "friend-secret";
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    await expectRejectsWithMessage(
+      () => publishFriendshipUpdate(["alice"]),
+      "Failed to publish friendship:refresh(503)",
+    );
+  });
+});

--- a/app/lib/friendships/realtime-publisher.ts
+++ b/app/lib/friendships/realtime-publisher.ts
@@ -1,0 +1,86 @@
+import {
+  friendshipUpdatePath,
+  internalRealtimeSecretHeader,
+  readRealtimeInternalSecret,
+  type FriendshipUpdatePayload,
+} from "../../../shared/realtime-internal";
+
+const defaultFriendshipUpdateUrl = "http://realtime:3001/internal/friendship-update";
+const gameUpdatePathSuffix = "/internal/game-update";
+
+function readPositiveTimeoutMs(timeoutMs: number) {
+  return Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 2000;
+}
+
+function replaceInternalPath(rawUrl: string) {
+  try {
+    const url = new URL(rawUrl);
+    url.pathname = friendshipUpdatePath;
+    url.search = "";
+    url.hash = "";
+
+    return url.toString();
+  } catch {
+    if (rawUrl.endsWith(gameUpdatePathSuffix)) {
+      return `${rawUrl.slice(0, -gameUpdatePathSuffix.length)}${friendshipUpdatePath}`;
+    }
+
+    return defaultFriendshipUpdateUrl;
+  }
+}
+
+export function resolveFriendshipUpdateUrl(env: NodeJS.ProcessEnv = process.env) {
+  const friendshipUrl = env["REALTIME_FRIENDSHIP_INTERNAL_URL"];
+
+  if (friendshipUrl) {
+    return friendshipUrl;
+  }
+
+  const gameUpdateUrl = env["REALTIME_INTERNAL_URL"];
+
+  if (!gameUpdateUrl) {
+    return defaultFriendshipUpdateUrl;
+  }
+
+  return replaceInternalPath(gameUpdateUrl);
+}
+
+export async function publishFriendshipUpdate(
+  usernames: string[],
+  timeoutMs = Number(process.env["REALTIME_PUBLISH_TIMEOUT_MS"] ?? 2000),
+) {
+  const uniqueUsernames = Array.from(new Set(usernames));
+
+  if (uniqueUsernames.length === 0) {
+    return;
+  }
+
+  const internalSecret = readRealtimeInternalSecret();
+
+  if (!internalSecret) {
+    throw new Error("Missing REALTIME_INTERNAL_SECRET or BETTER_AUTH_SECRET");
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), readPositiveTimeoutMs(timeoutMs));
+  const payload: FriendshipUpdatePayload = { usernames: uniqueUsernames };
+
+  try {
+    const response = await fetch(resolveFriendshipUpdateUrl(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [internalRealtimeSecretHeader]: internalSecret,
+      },
+      body: JSON.stringify(payload),
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to publish friendship:refresh(${response.status})`);
+    }
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-https://localhost:8443}
       REALTIME_INTERNAL_URL: http://realtime:3001/internal/game-update
+      REALTIME_FRIENDSHIP_INTERNAL_URL: http://realtime:3001/internal/friendship-update
+      REALTIME_INTERNAL_SECRET: ${REALTIME_INTERNAL_SECRET:-}
       SOCKET_PUBLIC_URL: ${SOCKET_PUBLIC_URL:-https://localhost:8443}
     depends_on:
       database:
@@ -56,6 +58,7 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-transcendence}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@database:5432/${POSTGRES_DB:-transcendence}?schema=public
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-https://localhost:8443}
+      REALTIME_INTERNAL_SECRET: ${REALTIME_INTERNAL_SECRET:-}
       SOCKET_HOST: 0.0.0.0
       SOCKET_PORT: 3001
       SOCKET_CORS_ORIGIN: ${SOCKET_CORS_ORIGIN:-https://localhost:8443}

--- a/realtime/lib/internal-friendship-update.test.ts
+++ b/realtime/lib/internal-friendship-update.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { internalRealtimeSecretHeader } from "../../shared/realtime-internal";
+import { handleInternalFriendshipUpdate } from "./internal-friendship-update";
+
+const emit = mock((_event: string) => {});
+const to = mock((_room: string) => ({ emit }));
+const log = mock((_message: string) => {});
+
+function jsonRequest(body: unknown, secret = "shared-secret") {
+  return new Request("http://realtime/internal/friendship-update", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      [internalRealtimeSecretHeader]: secret,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  emit.mockReset();
+  to.mockReset();
+  log.mockReset();
+  to.mockImplementation(() => ({ emit }));
+});
+
+describe("handleInternalFriendshipUpdate", () => {
+  test("rejects requests without the shared internal secret", async () => {
+    const response = await handleInternalFriendshipUpdate(
+      jsonRequest({ usernames: ["alice"] }),
+      { to },
+      null,
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(payload).toEqual({ error: "internal_secret_unconfigured" });
+    expect(to).not.toHaveBeenCalled();
+  });
+
+  test("rejects requests with the wrong shared internal secret", async () => {
+    const response = await handleInternalFriendshipUpdate(
+      jsonRequest({ usernames: ["alice"] }, "wrong-secret"),
+      { to },
+      "shared-secret",
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload).toEqual({ error: "unauthorized" });
+    expect(to).not.toHaveBeenCalled();
+  });
+
+  test("rejects malformed payloads without throwing", async () => {
+    const invalidPayloads = [null, { usernames: "alice" }, { usernames: ["alice", 42] }];
+
+    for (const payload of invalidPayloads) {
+      const response = await handleInternalFriendshipUpdate(
+        jsonRequest(payload),
+        { to },
+        "shared-secret",
+        { log },
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: "invalid_payload" });
+    }
+
+    expect(to).not.toHaveBeenCalled();
+  });
+
+  test("emits friendship refreshes to the requested user rooms", async () => {
+    const response = await handleInternalFriendshipUpdate(
+      jsonRequest({ usernames: ["alice", "bob"] }),
+      { to },
+      "shared-secret",
+      { log },
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ ok: true });
+    expect(to.mock.calls.map((call) => call[0])).toEqual(["user:alice", "user:bob"]);
+    expect(emit.mock.calls.map((call) => call[0])).toEqual([
+      "friendship:refresh",
+      "friendship:refresh",
+    ]);
+    expect(log).toHaveBeenCalledTimes(2);
+  });
+});

--- a/realtime/lib/internal-friendship-update.ts
+++ b/realtime/lib/internal-friendship-update.ts
@@ -1,0 +1,53 @@
+import {
+  internalRealtimeSecretHeader,
+  isFriendshipUpdatePayload,
+  readRealtimeInternalSecret,
+} from "../../shared/realtime-internal";
+
+type RoomEmitter = {
+  emit(event: string): void;
+};
+
+type FriendshipUpdateServer = {
+  to(room: string): RoomEmitter;
+};
+
+type FriendshipUpdateLogger = Pick<Console, "log">;
+
+function getUnauthorizedResponse() {
+  return Response.json({ error: "unauthorized" }, { status: 401 });
+}
+
+export async function handleInternalFriendshipUpdate(
+  request: Request,
+  io: FriendshipUpdateServer,
+  internalSecret = readRealtimeInternalSecret(),
+  logger: FriendshipUpdateLogger = console,
+) {
+  if (!internalSecret) {
+    return Response.json({ error: "internal_secret_unconfigured" }, { status: 503 });
+  }
+
+  if (request.headers.get(internalRealtimeSecretHeader) !== internalSecret) {
+    return getUnauthorizedResponse();
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return Response.json({ error: "invalid_payload" }, { status: 400 });
+  }
+
+  if (!isFriendshipUpdatePayload(payload)) {
+    return Response.json({ error: "invalid_payload" }, { status: 400 });
+  }
+
+  for (const username of payload.usernames) {
+    io.to(`user:${username}`).emit("friendship:refresh");
+    logger.log(`[realtime] broadcast friendship:refresh to user:${username}`);
+  }
+
+  return Response.json({ ok: true });
+}

--- a/realtime/server.ts
+++ b/realtime/server.ts
@@ -9,8 +9,10 @@ import { Server } from "socket.io";
 import { prisma } from "@/lib/prisma";
 
 import { isGameUpdatePayload } from "../shared/match-events-validation";
+import { readRealtimeInternalSecret } from "../shared/realtime-internal";
 import { registerMatchSubscription } from "./handlers/match-subscription";
 import { resolveFriendshipNotificationTarget } from "./lib/friendship-notifications";
+import { handleInternalFriendshipUpdate } from "./lib/internal-friendship-update";
 import { removePresenceConnection, subscribeToPresence, type ConnectedUsers } from "./lib/presence";
 import { matchRoomId } from "./lib/rooms";
 import { authenticateSocketSession } from "./lib/socket-auth";
@@ -36,6 +38,7 @@ if (existsSync(rootEnvPath)) {
 const hostname = process.env["SOCKET_HOST"] ?? "0.0.0.0";
 const port = Number(process.env["SOCKET_PORT"] || 3001);
 const socketPath = process.env["SOCKET_PATH"] ?? "/socket.io/";
+const realtimeInternalSecret = readRealtimeInternalSecret(process.env);
 const socketHeartbeatIntervalMs = readPositiveIntegerEnv(
   process.env,
   "SOCKET_HEARTBEAT_INTERVAL_MS",
@@ -240,27 +243,6 @@ async function handleInternalGameUpdate(request: Request) {
   });
 }
 
-async function handleInternalFriendshipUpdate(request: Request) {
-  let payload: { usernames: string[] };
-
-  try {
-    payload = await request.json();
-  } catch {
-    return Response.json({ error: "invalid_payload" }, { status: 400 });
-  }
-
-  if (!payload.usernames || !Array.isArray(payload.usernames)) {
-    return Response.json({ error: "invalid_payload" }, { status: 400 });
-  }
-
-  for (const username of payload.usernames) {
-    io.to(`user:${username}`).emit("friendship:refresh");
-    console.log(`[realtime] broadcast friendship:refresh to user:${username}`);
-  }
-
-  return Response.json({ ok: true });
-}
-
 Bun.serve({
   hostname,
   port,
@@ -281,7 +263,7 @@ Bun.serve({
     }
 
     if (url.pathname === "/internal/friendship-update" && request.method === "POST") {
-      return handleInternalFriendshipUpdate(request);
+      return handleInternalFriendshipUpdate(request, io, realtimeInternalSecret);
     }
 
     if (url.pathname === socketPath) {

--- a/realtime/server.ts
+++ b/realtime/server.ts
@@ -240,6 +240,27 @@ async function handleInternalGameUpdate(request: Request) {
   });
 }
 
+async function handleInternalFriendshipUpdate(request: Request) {
+  let payload: { usernames: string[] };
+
+  try {
+    payload = await request.json();
+  } catch {
+    return Response.json({ error: "invalid_payload" }, { status: 400 });
+  }
+
+  if (!payload.usernames || !Array.isArray(payload.usernames)) {
+    return Response.json({ error: "invalid_payload" }, { status: 400 });
+  }
+
+  for (const username of payload.usernames) {
+    io.to(`user:${username}`).emit("friendship:refresh");
+    console.log(`[realtime] broadcast friendship:refresh to user:${username}`);
+  }
+
+  return Response.json({ ok: true });
+}
+
 Bun.serve({
   hostname,
   port,
@@ -257,6 +278,10 @@ Bun.serve({
 
     if (url.pathname === "/internal/game-update" && request.method === "POST") {
       return handleInternalGameUpdate(request);
+    }
+
+    if (url.pathname === "/internal/friendship-update" && request.method === "POST") {
+      return handleInternalFriendshipUpdate(request);
     }
 
     if (url.pathname === socketPath) {

--- a/shared/realtime-internal.ts
+++ b/shared/realtime-internal.ts
@@ -1,0 +1,28 @@
+export const friendshipUpdatePath = "/internal/friendship-update";
+export const internalRealtimeSecretHeader = "x-realtime-internal-secret";
+
+export type FriendshipUpdatePayload = {
+  usernames: string[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 64;
+}
+
+export function isFriendshipUpdatePayload(payload: unknown): payload is FriendshipUpdatePayload {
+  if (!isRecord(payload)) {
+    return false;
+  }
+
+  const usernames = payload["usernames"];
+
+  return Array.isArray(usernames) && usernames.every(isNonEmptyString);
+}
+
+export function readRealtimeInternalSecret(env: NodeJS.ProcessEnv = process.env) {
+  return env["REALTIME_INTERNAL_SECRET"]?.trim() || env["BETTER_AUTH_SECRET"]?.trim() || null;
+}


### PR DESCRIPTION
What this changes
This update ensures that when a user removes a friend or declines a friend request, the other person's screen updates immediately without them needing to manually refresh the page.

Why it was broken
There was a conflict in the sequence of events. The frontend was deleting the friendship record from the database, but the socket server was required to verify that same record before allowing the screen to update. Because the record was already gone, the server saw no connection between the users and blocked the update, treating it as an unauthorised request.

How it was fixed
The responsibility has been moved away from the frontend. Now, the Next.js backend handles the entire process. After it safely deletes the friendship from the database, it directly contacts the socket server through a brand new internal route (/internal/friendship-update). The socket server then securely updates the screens for both players, completely avoiding the previous conflict.