### PR TITLE
[codex] Implement matchmaking queue lifecycle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,7 @@ BETTER_AUTH_URL=http://localhost:3000
 # REALTIME_INTERNAL_URL=http://localhost:3001/internal/game-update
 # REALTIME_FRIENDSHIP_INTERNAL_URL=http://localhost:3001/internal/friendship-update
 # REALTIME_INTERNAL_SECRET=change_me_to_a_shared_internal_secret
+
+# Optional matchmaking lifecycle timeouts.
+# MATCHMAKING_WAITING_TIMEOUT_MS=600000
+# MATCH_IN_PROGRESS_ABANDONED_TIMEOUT_MS=1800000

--- a/app/api/matches/[id]/join/route.ts
+++ b/app/api/matches/[id]/join/route.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { Prisma } from "@/../generated/prisma/client";
 import { MatchStatus, Role, Seat } from "@/../generated/prisma/enums";
+import { getCurrentSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
 export const dynamic = "force-dynamic";
@@ -18,6 +19,18 @@ function getErrorMessage(error: unknown): string {
 }
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const context = await getCurrentSession();
+
+  if (!context) {
+    return Response.json(
+      {
+        error: "unauthorized",
+        message: "You need to sign in before joining a match.",
+      },
+      { status: 401 },
+    );
+  }
+
   try {
     const { id: matchId } = await params;
     const body = await request.json().catch(() => ({}));
@@ -27,7 +40,8 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       return Response.json({ error: "invalid_payload" }, { status: 400 });
     }
 
-    const displayName = validation.data.displayName ?? "Player 2";
+    const displayName =
+      validation.data.displayName ?? (context.user.displayName || context.user.username);
 
     const match = await prisma.match.findUnique({
       where: { id: matchId },
@@ -42,6 +56,13 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       return Response.json({ error: "match_not_available" }, { status: 409 });
     }
 
+    const alreadyJoined = match.participants.some(
+      (participant) => participant.userId === context.user.id,
+    );
+    if (alreadyJoined) {
+      return Response.json({ error: "already_in_match" }, { status: 409 });
+    }
+
     const alreadyHasWhite = match.participants.some((p) => p.seat === Seat.WHITE);
     if (alreadyHasWhite) {
       return Response.json({ error: "match_full" }, { status: 409 });
@@ -54,6 +75,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
           displayNameSnapshot: displayName,
           role: Role.PLAYER,
           seat: Seat.WHITE,
+          userId: context.user.id,
         },
       });
 

--- a/app/api/matches/queue/route.test.ts
+++ b/app/api/matches/queue/route.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getCurrentSession = mock();
+const cancelMatchmakingQueue = mock();
+const getMatchmakingQueueStatus = mock();
+const joinMatchmakingQueue = mock();
+
+await mock.module("@/lib/auth", () => ({
+  getCurrentSession,
+}));
+
+await mock.module("@/lib/matches/matchmaking", () => ({
+  cancelMatchmakingQueue,
+  getMatchmakingQueueStatus,
+  joinMatchmakingQueue,
+}));
+
+const route = await import("./route");
+
+const user = {
+  displayName: "Ada",
+  id: "user-ada",
+  username: "ada",
+};
+
+beforeEach(() => {
+  getCurrentSession.mockReset();
+  cancelMatchmakingQueue.mockReset();
+  getMatchmakingQueueStatus.mockReset();
+  joinMatchmakingQueue.mockReset();
+
+  getCurrentSession.mockResolvedValue({
+    user,
+  });
+});
+
+describe("/api/matches/queue", () => {
+  test("requires authentication before queueing", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const response = await route.POST();
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload).toMatchObject({
+      error: "unauthorized",
+    });
+    expect(joinMatchmakingQueue).not.toHaveBeenCalled();
+  });
+
+  test("joins the queue for the authenticated user", async () => {
+    joinMatchmakingQueue.mockResolvedValueOnce({
+      kind: "queued",
+      queuePosition: 1,
+    });
+
+    const response = await route.POST();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      kind: "queued",
+      queuePosition: 1,
+    });
+    expect(joinMatchmakingQueue).toHaveBeenCalledWith(user);
+  });
+
+  test("loads and cancels the authenticated user's queue state", async () => {
+    getMatchmakingQueueStatus.mockResolvedValueOnce({ kind: "not_queued" });
+    cancelMatchmakingQueue.mockResolvedValueOnce({ kind: "not_queued" });
+
+    const statusResponse = await route.GET();
+    const cancelResponse = await route.DELETE();
+
+    expect(statusResponse.status).toBe(200);
+    expect(await statusResponse.json()).toEqual({ kind: "not_queued" });
+    expect(cancelResponse.status).toBe(200);
+    expect(await cancelResponse.json()).toEqual({ kind: "not_queued" });
+    expect(getMatchmakingQueueStatus).toHaveBeenCalledWith(user);
+    expect(cancelMatchmakingQueue).toHaveBeenCalledWith(user);
+  });
+});

--- a/app/api/matches/queue/route.ts
+++ b/app/api/matches/queue/route.ts
@@ -1,0 +1,82 @@
+import { getCurrentSession } from "@/lib/auth";
+import {
+  cancelMatchmakingQueue,
+  getMatchmakingQueueStatus,
+  joinMatchmakingQueue,
+} from "@/lib/matches/matchmaking";
+
+export const dynamic = "force-dynamic";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+function unauthorizedResponse() {
+  return Response.json(
+    {
+      error: "unauthorized",
+      message: "You need to sign in before using matchmaking.",
+    },
+    { status: 401 },
+  );
+}
+
+export async function GET() {
+  const context = await getCurrentSession();
+
+  if (!context) {
+    return unauthorizedResponse();
+  }
+
+  try {
+    return Response.json(await getMatchmakingQueueStatus(context.user));
+  } catch (error) {
+    return Response.json(
+      {
+        detail: getErrorMessage(error),
+        error: "failed_to_load_queue_status",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST() {
+  const context = await getCurrentSession();
+
+  if (!context) {
+    return unauthorizedResponse();
+  }
+
+  try {
+    return Response.json(await joinMatchmakingQueue(context.user));
+  } catch (error) {
+    return Response.json(
+      {
+        detail: getErrorMessage(error),
+        error: "failed_to_join_queue",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE() {
+  const context = await getCurrentSession();
+
+  if (!context) {
+    return unauthorizedResponse();
+  }
+
+  try {
+    return Response.json(await cancelMatchmakingQueue(context.user));
+  } catch (error) {
+    return Response.json(
+      {
+        detail: getErrorMessage(error),
+        error: "failed_to_cancel_queue",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/matches/route.ts
+++ b/app/api/matches/route.ts
@@ -1,5 +1,6 @@
 import { Role, MatchStatus, Seat } from "../../../generated/prisma/enums";
 import { getCurrentSession } from "../../lib/auth";
+import { cleanupStaleMatchSessions } from "../../lib/matches/matchmaking";
 import { standardGomokuBoardSize } from "../../lib/matches/move-rules";
 import { prisma } from "../../lib/prisma";
 
@@ -26,11 +27,13 @@ export async function POST() {
     const match = await prisma.match.create({
       data: {
         boardSize: standardGomokuBoardSize,
+        createdByUserId: context.user.id,
         participants: {
           create: {
-            displayNameSnapshot: "Player 1",
+            displayNameSnapshot: context.user.displayName || context.user.username,
             role: Role.PLAYER,
             seat: Seat.BLACK,
+            userId: context.user.id,
           },
         },
       },
@@ -64,6 +67,8 @@ export async function POST() {
 }
 
 export async function GET() {
+  await cleanupStaleMatchSessions();
+
   const matches = await prisma.match.findMany({
     where: { status: MatchStatus.WAITING },
     orderBy: { createdAt: "desc" },

--- a/app/lib/matches/matchmaking.test.ts
+++ b/app/lib/matches/matchmaking.test.ts
@@ -1,0 +1,353 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  MatchResult,
+  MatchStatus,
+  MatchVisibility,
+  Role,
+  RuleType,
+  Seat,
+} from "../../../generated/prisma/enums";
+
+const transaction = mock();
+const executeRaw = mock();
+const createMatch = mock();
+const findMatches = mock();
+const updateMatch = mock();
+const updateMatches = mock();
+const createParticipant = mock();
+const findParticipant = mock();
+const updateParticipants = mock();
+
+const tx = {
+  $executeRaw: executeRaw,
+  match: {
+    create: createMatch,
+    findMany: findMatches,
+    update: updateMatch,
+    updateMany: updateMatches,
+  },
+  matchParticipant: {
+    create: createParticipant,
+    findFirst: findParticipant,
+    updateMany: updateParticipants,
+  },
+};
+
+await mock.module("../prisma", () => ({
+  prisma: {
+    $transaction: transaction,
+  },
+}));
+
+const {
+  cancelMatchmakingQueue,
+  cleanupStaleMatchSessions,
+  endReasonAbandoned,
+  endReasonQueueCancelled,
+  endReasonQueueExpired,
+  joinMatchmakingQueue,
+} = await import("./matchmaking");
+
+const now = new Date("2026-05-12T08:00:00.000Z");
+const createdAt = new Date("2026-05-12T07:59:00.000Z");
+const user = {
+  displayName: "Ada",
+  id: "user-ada",
+  username: "ada",
+};
+
+function participant(overrides: Record<string, unknown> = {}) {
+  return {
+    displayNameSnapshot: "Ada",
+    id: "participant-black",
+    joinedAt: createdAt,
+    leftAt: null,
+    matchId: "match-1",
+    result: null,
+    role: Role.PLAYER,
+    seat: Seat.BLACK,
+    user: {
+      displayName: "Ada",
+      username: "ada",
+    },
+    userId: "user-ada",
+    ...overrides,
+  };
+}
+
+function match(overrides: Record<string, unknown> = {}) {
+  return {
+    boardSize: 15,
+    createdAt,
+    createdByUserId: "user-ada",
+    endReason: null,
+    finishedAt: null,
+    id: "match-1",
+    nextTurnSeat: null,
+    participants: [participant()],
+    ruleType: RuleType.GOMOKU,
+    startedAt: null,
+    stateVersion: 0,
+    status: MatchStatus.WAITING,
+    updatedAt: createdAt,
+    visibility: MatchVisibility.PUBLIC,
+    winningSeat: null,
+    ...overrides,
+  };
+}
+
+const serviceOptions = {
+  inProgressTimeoutMs: 0,
+  now,
+  useAdvisoryLock: false,
+  waitingTimeoutMs: 0,
+};
+
+beforeEach(() => {
+  transaction.mockReset();
+  executeRaw.mockReset();
+  createMatch.mockReset();
+  findMatches.mockReset();
+  updateMatch.mockReset();
+  updateMatches.mockReset();
+  createParticipant.mockReset();
+  findParticipant.mockReset();
+  updateParticipants.mockReset();
+
+  transaction.mockImplementation((callback: (transactionClient: typeof tx) => unknown) =>
+    callback(tx),
+  );
+});
+
+describe("joinMatchmakingQueue", () => {
+  test("creates one waiting match for the first queued user", async () => {
+    const queuedMatch = match();
+
+    findParticipant.mockResolvedValueOnce(null);
+    findMatches.mockResolvedValueOnce([]);
+    createMatch.mockResolvedValueOnce(queuedMatch);
+
+    const result = await joinMatchmakingQueue(user, serviceOptions);
+
+    expect(result).toMatchObject({
+      kind: "queued",
+      queuePosition: 1,
+      session: {
+        matchId: "match-1",
+        participantId: "participant-black",
+        seat: Seat.BLACK,
+        status: MatchStatus.WAITING,
+      },
+    });
+    expect(createMatch.mock.calls[0]?.[0]).toMatchObject({
+      data: {
+        createdByUserId: "user-ada",
+        participants: {
+          create: {
+            displayNameSnapshot: "Ada",
+            seat: Seat.BLACK,
+            userId: "user-ada",
+          },
+        },
+        status: MatchStatus.WAITING,
+      },
+    });
+  });
+
+  test("pairs the next compatible queued user into the same match", async () => {
+    const opponent = participant({
+      displayNameSnapshot: "Grace",
+      id: "participant-black",
+      user: {
+        displayName: "Grace",
+        username: "grace",
+      },
+      userId: "user-grace",
+    });
+    const waitingMatch = match({
+      createdByUserId: "user-grace",
+      participants: [opponent],
+    });
+    const joiner = participant({
+      displayNameSnapshot: "Ada",
+      id: "participant-white",
+      seat: Seat.WHITE,
+      user: null,
+      userId: "user-ada",
+    });
+
+    findParticipant.mockResolvedValueOnce(null);
+    findMatches.mockResolvedValueOnce([waitingMatch]);
+    createParticipant.mockResolvedValueOnce(joiner);
+    updateMatch.mockResolvedValueOnce({});
+
+    const result = await joinMatchmakingQueue(user, serviceOptions);
+
+    expect(result).toMatchObject({
+      kind: "matched",
+      opponent: {
+        session: {
+          matchId: "match-1",
+          participantId: "participant-black",
+          seat: Seat.BLACK,
+          status: MatchStatus.IN_PROGRESS,
+        },
+        username: "grace",
+      },
+      session: {
+        matchId: "match-1",
+        participantId: "participant-white",
+        seat: Seat.WHITE,
+        status: MatchStatus.IN_PROGRESS,
+      },
+    });
+    expect(createParticipant).toHaveBeenCalledWith({
+      data: {
+        displayNameSnapshot: "Ada",
+        matchId: "match-1",
+        role: Role.PLAYER,
+        seat: Seat.WHITE,
+        userId: "user-ada",
+      },
+    });
+    expect(updateMatch).toHaveBeenCalledWith({
+      data: {
+        nextTurnSeat: Seat.BLACK,
+        startedAt: now,
+        status: MatchStatus.IN_PROGRESS,
+      },
+      where: {
+        id: "match-1",
+      },
+    });
+  });
+
+  test("reuses an existing queued session instead of creating duplicates", async () => {
+    findParticipant.mockResolvedValueOnce({
+      ...participant(),
+      match: match(),
+    });
+
+    const result = await joinMatchmakingQueue(user, serviceOptions);
+
+    expect(result).toMatchObject({
+      kind: "queued",
+      session: {
+        matchId: "match-1",
+        participantId: "participant-black",
+      },
+    });
+    expect(findMatches).not.toHaveBeenCalled();
+    expect(createMatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("cancelMatchmakingQueue", () => {
+  test("cancels a waiting queue match without touching other matches", async () => {
+    findParticipant.mockResolvedValueOnce({
+      ...participant(),
+      match: match(),
+    });
+    updateMatches.mockResolvedValueOnce({ count: 1 });
+    updateParticipants.mockResolvedValueOnce({ count: 1 });
+
+    const result = await cancelMatchmakingQueue(user, serviceOptions);
+
+    expect(result).toEqual({
+      kind: "cancelled",
+      matchId: "match-1",
+    });
+    expect(updateMatches).toHaveBeenCalledWith({
+      data: {
+        endReason: endReasonQueueCancelled,
+        finishedAt: now,
+        nextTurnSeat: null,
+        status: MatchStatus.CANCELLED,
+      },
+      where: {
+        id: "match-1",
+        status: MatchStatus.WAITING,
+      },
+    });
+    expect(updateParticipants).toHaveBeenCalledWith({
+      data: {
+        leftAt: now,
+        result: MatchResult.CANCELLED,
+      },
+      where: {
+        leftAt: null,
+        matchId: "match-1",
+        result: null,
+      },
+    });
+  });
+
+  test("reports an already-started match instead of cancelling it", async () => {
+    findParticipant.mockResolvedValueOnce({
+      ...participant({ id: "participant-white", seat: Seat.WHITE }),
+      match: match({
+        nextTurnSeat: Seat.BLACK,
+        startedAt: now,
+        status: MatchStatus.IN_PROGRESS,
+      }),
+    });
+
+    const result = await cancelMatchmakingQueue(user, serviceOptions);
+
+    expect(result).toMatchObject({
+      kind: "already_matched",
+      session: {
+        matchId: "match-1",
+        status: MatchStatus.IN_PROGRESS,
+      },
+    });
+    expect(updateMatches).not.toHaveBeenCalled();
+    expect(updateParticipants).not.toHaveBeenCalled();
+  });
+});
+
+describe("cleanupStaleMatchSessions", () => {
+  test("expires stale waiting matches and abandoned in-progress matches", async () => {
+    findMatches.mockResolvedValueOnce([{ id: "waiting-1" }]);
+    updateMatches.mockResolvedValueOnce({ count: 1 });
+    updateParticipants.mockResolvedValueOnce({ count: 1 });
+    findMatches.mockResolvedValueOnce([{ id: "game-1" }]);
+    updateMatches.mockResolvedValueOnce({ count: 1 });
+    updateParticipants.mockResolvedValueOnce({ count: 2 });
+
+    const result = await cleanupStaleMatchSessions({
+      inProgressTimeoutMs: 2_000,
+      now,
+      useAdvisoryLock: false,
+      waitingTimeoutMs: 1_000,
+    });
+
+    expect(result).toEqual({
+      inProgressCancelled: 1,
+      waitingCancelled: 1,
+    });
+    expect(updateMatches.mock.calls[0]?.[0]).toMatchObject({
+      data: {
+        endReason: endReasonQueueExpired,
+        status: MatchStatus.CANCELLED,
+      },
+      where: {
+        id: {
+          in: ["waiting-1"],
+        },
+      },
+    });
+    expect(updateMatches.mock.calls[1]?.[0]).toMatchObject({
+      data: {
+        endReason: endReasonAbandoned,
+        status: MatchStatus.CANCELLED,
+      },
+      where: {
+        id: {
+          in: ["game-1"],
+        },
+      },
+    });
+  });
+});

--- a/app/lib/matches/matchmaking.ts
+++ b/app/lib/matches/matchmaking.ts
@@ -1,0 +1,618 @@
+import { Prisma } from "../../../generated/prisma/client";
+import {
+  MatchResult,
+  MatchStatus,
+  MatchVisibility,
+  Role,
+  RuleType,
+  Seat,
+} from "../../../generated/prisma/enums";
+import { prisma } from "../prisma";
+import { standardGomokuBoardSize } from "./move-rules";
+
+const matchmakingLockKey = 42_300_030;
+const defaultWaitingTimeoutMs = 10 * 60 * 1000;
+const defaultInProgressTimeoutMs = 30 * 60 * 1000;
+
+export const endReasonQueueCancelled = "queue_cancelled";
+export const endReasonQueueExpired = "queue_expired";
+export const endReasonAbandoned = "abandoned";
+
+type MatchmakingTransaction = Prisma.TransactionClient;
+
+export type MatchmakingUser = {
+  displayName?: string | null;
+  id: string;
+  name?: string | null;
+  username?: string | null;
+};
+
+type QueueParticipant = {
+  id: string;
+  userId: string | null;
+  displayNameSnapshot: string;
+  role: Role;
+  seat: Seat | null;
+  joinedAt?: Date;
+  leftAt?: Date | null;
+  user?: {
+    username: string;
+    displayName: string;
+  } | null;
+};
+
+type QueueMatch = {
+  id: string;
+  status: MatchStatus;
+  visibility: MatchVisibility;
+  boardSize: number;
+  stateVersion?: number;
+  nextTurnSeat: Seat | null;
+  winningSeat?: Seat | null;
+  endReason?: string | null;
+  createdAt: Date;
+  startedAt: Date | null;
+  participants: QueueParticipant[];
+};
+
+export type MatchmakingSession = {
+  matchId: string;
+  participantId: string;
+  role: Role;
+  seat: Seat | null;
+  status: MatchStatus;
+  displayName: string;
+  createdAt: string;
+  startedAt: string | null;
+};
+
+export type MatchedQueueNotification = {
+  session: MatchmakingSession;
+  username: string | null;
+};
+
+export type JoinMatchmakingQueueResult =
+  | {
+      kind: "queued";
+      session: MatchmakingSession;
+      queuePosition: number;
+    }
+  | {
+      kind: "matched";
+      session: MatchmakingSession;
+      opponent?: MatchedQueueNotification;
+    };
+
+export type CancelMatchmakingQueueResult =
+  | {
+      kind: "cancelled";
+      matchId: string;
+    }
+  | {
+      kind: "not_queued";
+    }
+  | {
+      kind: "already_matched";
+      session: MatchmakingSession;
+    };
+
+export type MatchmakingQueueStatus =
+  | {
+      kind: "queued";
+      session: MatchmakingSession;
+      queuePosition: number;
+    }
+  | {
+      kind: "matched";
+      session: MatchmakingSession;
+    }
+  | {
+      kind: "not_queued";
+    };
+
+export type CleanupMatchSessionsResult = {
+  waitingCancelled: number;
+  inProgressCancelled: number;
+};
+
+type LifecycleOptions = {
+  now?: Date;
+  waitingTimeoutMs?: number;
+  inProgressTimeoutMs?: number;
+  useAdvisoryLock?: boolean;
+};
+
+type QueueOptions = LifecycleOptions & {
+  boardSize?: number;
+};
+
+function readPositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveWaitingTimeoutMs(options: LifecycleOptions): number {
+  return (
+    options.waitingTimeoutMs ??
+    readPositiveInteger(process.env["MATCHMAKING_WAITING_TIMEOUT_MS"], defaultWaitingTimeoutMs)
+  );
+}
+
+function resolveInProgressTimeoutMs(options: LifecycleOptions): number {
+  return (
+    options.inProgressTimeoutMs ??
+    readPositiveInteger(
+      process.env["MATCH_IN_PROGRESS_ABANDONED_TIMEOUT_MS"],
+      defaultInProgressTimeoutMs,
+    )
+  );
+}
+
+function timeoutCutoff(now: Date, timeoutMs: number): Date | null {
+  return timeoutMs > 0 ? new Date(now.getTime() - timeoutMs) : null;
+}
+
+async function acquireMatchmakingLock(tx: MatchmakingTransaction, options: LifecycleOptions) {
+  if (options.useAdvisoryLock === false) {
+    return;
+  }
+
+  await tx.$executeRaw(Prisma.sql`SELECT pg_advisory_xact_lock(${matchmakingLockKey})`);
+}
+
+function getDisplayName(user: MatchmakingUser): string {
+  const displayName = user.displayName?.trim() || user.name?.trim() || user.username?.trim();
+  return displayName || "Player";
+}
+
+function serializeSession(match: QueueMatch, participant: QueueParticipant): MatchmakingSession {
+  return {
+    createdAt: match.createdAt.toISOString(),
+    displayName: participant.displayNameSnapshot,
+    matchId: match.id,
+    participantId: participant.id,
+    role: participant.role,
+    seat: participant.seat,
+    startedAt: match.startedAt ? match.startedAt.toISOString() : null,
+    status: match.status,
+  };
+}
+
+function notificationFor(
+  match: QueueMatch,
+  participant: QueueParticipant,
+): MatchedQueueNotification {
+  return {
+    session: serializeSession(match, participant),
+    username: participant.user?.username ?? null,
+  };
+}
+
+async function findActiveParticipant(
+  tx: MatchmakingTransaction,
+  userId: string,
+  boardSize: number,
+) {
+  return tx.matchParticipant.findFirst({
+    where: {
+      leftAt: null,
+      role: Role.PLAYER,
+      userId,
+      match: {
+        boardSize,
+        status: {
+          in: [MatchStatus.WAITING, MatchStatus.IN_PROGRESS],
+        },
+      },
+    },
+    include: {
+      match: {
+        include: {
+          participants: {
+            include: {
+              user: {
+                select: {
+                  displayName: true,
+                  username: true,
+                },
+              },
+            },
+            orderBy: {
+              joinedAt: "asc",
+            },
+          },
+        },
+      },
+    },
+    orderBy: {
+      joinedAt: "desc",
+    },
+  });
+}
+
+async function findWaitingOpponentMatch(
+  tx: MatchmakingTransaction,
+  userId: string,
+  boardSize: number,
+) {
+  const candidates = await tx.match.findMany({
+    where: {
+      boardSize,
+      ruleType: RuleType.GOMOKU,
+      status: MatchStatus.WAITING,
+      visibility: MatchVisibility.PUBLIC,
+      participants: {
+        none: {
+          userId,
+        },
+        some: {
+          leftAt: null,
+          role: Role.PLAYER,
+          seat: Seat.BLACK,
+          userId: {
+            not: null,
+          },
+        },
+      },
+    },
+    include: {
+      participants: {
+        include: {
+          user: {
+            select: {
+              displayName: true,
+              username: true,
+            },
+          },
+        },
+        orderBy: {
+          joinedAt: "asc",
+        },
+      },
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+    take: 10,
+  });
+
+  return candidates.find(
+    (match) =>
+      match.participants.filter(
+        (participant) => participant.leftAt === null && participant.role === Role.PLAYER,
+      ).length === 1 && match.participants[0]?.seat === Seat.BLACK,
+  );
+}
+
+async function cancelMatches(
+  tx: MatchmakingTransaction,
+  matchIds: string[],
+  now: Date,
+  endReason: string,
+) {
+  if (matchIds.length === 0) {
+    return 0;
+  }
+
+  const updatedMatches = await tx.match.updateMany({
+    where: {
+      id: {
+        in: matchIds,
+      },
+      status: {
+        in: [MatchStatus.WAITING, MatchStatus.IN_PROGRESS],
+      },
+    },
+    data: {
+      endReason,
+      finishedAt: now,
+      nextTurnSeat: null,
+      status: MatchStatus.CANCELLED,
+    },
+  });
+
+  await tx.matchParticipant.updateMany({
+    where: {
+      leftAt: null,
+      matchId: {
+        in: matchIds,
+      },
+      result: null,
+    },
+    data: {
+      leftAt: now,
+      result: MatchResult.CANCELLED,
+    },
+  });
+
+  return updatedMatches.count;
+}
+
+async function cleanupStaleMatchSessionsInTransaction(
+  tx: MatchmakingTransaction,
+  options: LifecycleOptions,
+): Promise<CleanupMatchSessionsResult> {
+  const now = options.now ?? new Date();
+  const waitingCutoff = timeoutCutoff(now, resolveWaitingTimeoutMs(options));
+  const inProgressCutoff = timeoutCutoff(now, resolveInProgressTimeoutMs(options));
+
+  let waitingCancelled = 0;
+  let inProgressCancelled = 0;
+
+  if (waitingCutoff) {
+    const staleWaitingMatches = await tx.match.findMany({
+      where: {
+        status: MatchStatus.WAITING,
+        updatedAt: {
+          lt: waitingCutoff,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    waitingCancelled = await cancelMatches(
+      tx,
+      staleWaitingMatches.map((match) => match.id),
+      now,
+      endReasonQueueExpired,
+    );
+  }
+
+  if (inProgressCutoff) {
+    const staleInProgressMatches = await tx.match.findMany({
+      where: {
+        status: MatchStatus.IN_PROGRESS,
+        updatedAt: {
+          lt: inProgressCutoff,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    inProgressCancelled = await cancelMatches(
+      tx,
+      staleInProgressMatches.map((match) => match.id),
+      now,
+      endReasonAbandoned,
+    );
+  }
+
+  return {
+    inProgressCancelled,
+    waitingCancelled,
+  };
+}
+
+export async function cleanupStaleMatchSessions(
+  options: LifecycleOptions = {},
+): Promise<CleanupMatchSessionsResult> {
+  return prisma.$transaction(async (tx) => {
+    await acquireMatchmakingLock(tx, options);
+    return cleanupStaleMatchSessionsInTransaction(tx, options);
+  });
+}
+
+export async function joinMatchmakingQueue(
+  user: MatchmakingUser,
+  options: QueueOptions = {},
+): Promise<JoinMatchmakingQueueResult> {
+  const now = options.now ?? new Date();
+  const boardSize = options.boardSize ?? standardGomokuBoardSize;
+
+  return prisma.$transaction(async (tx) => {
+    await acquireMatchmakingLock(tx, options);
+    await cleanupStaleMatchSessionsInTransaction(tx, { ...options, now });
+
+    const activeParticipant = await findActiveParticipant(tx, user.id, boardSize);
+    if (activeParticipant) {
+      const match = activeParticipant.match as QueueMatch;
+      const session = serializeSession(match, activeParticipant);
+
+      if (match.status === MatchStatus.IN_PROGRESS) {
+        return {
+          kind: "matched",
+          session,
+        };
+      }
+
+      return {
+        kind: "queued",
+        queuePosition: 1,
+        session,
+      };
+    }
+
+    const opponentMatch = await findWaitingOpponentMatch(tx, user.id, boardSize);
+    if (opponentMatch) {
+      const joiner = await tx.matchParticipant.create({
+        data: {
+          displayNameSnapshot: getDisplayName(user),
+          matchId: opponentMatch.id,
+          role: Role.PLAYER,
+          seat: Seat.WHITE,
+          userId: user.id,
+        },
+      });
+
+      await tx.match.update({
+        where: {
+          id: opponentMatch.id,
+        },
+        data: {
+          nextTurnSeat: Seat.BLACK,
+          startedAt: now,
+          status: MatchStatus.IN_PROGRESS,
+        },
+      });
+
+      const matchedMatch: QueueMatch = {
+        ...opponentMatch,
+        nextTurnSeat: Seat.BLACK,
+        participants: [...opponentMatch.participants, joiner],
+        startedAt: now,
+        status: MatchStatus.IN_PROGRESS,
+      };
+      const opponent = opponentMatch.participants[0];
+
+      return {
+        kind: "matched",
+        opponent: opponent ? notificationFor(matchedMatch, opponent) : undefined,
+        session: serializeSession(matchedMatch, joiner),
+      };
+    }
+
+    const queuedMatch = await tx.match.create({
+      data: {
+        boardSize,
+        createdByUserId: user.id,
+        participants: {
+          create: {
+            displayNameSnapshot: getDisplayName(user),
+            role: Role.PLAYER,
+            seat: Seat.BLACK,
+            userId: user.id,
+          },
+        },
+        ruleType: RuleType.GOMOKU,
+        status: MatchStatus.WAITING,
+        visibility: MatchVisibility.PUBLIC,
+      },
+      include: {
+        participants: {
+          include: {
+            user: {
+              select: {
+                displayName: true,
+                username: true,
+              },
+            },
+          },
+          orderBy: {
+            joinedAt: "asc",
+          },
+        },
+      },
+    });
+    const participant = queuedMatch.participants[0];
+
+    if (!participant) {
+      throw new Error("Queued match participant was not created.");
+    }
+
+    return {
+      kind: "queued",
+      queuePosition: 1,
+      session: serializeSession(queuedMatch, participant),
+    };
+  });
+}
+
+export async function cancelMatchmakingQueue(
+  user: MatchmakingUser,
+  options: QueueOptions = {},
+): Promise<CancelMatchmakingQueueResult> {
+  const now = options.now ?? new Date();
+  const boardSize = options.boardSize ?? standardGomokuBoardSize;
+
+  return prisma.$transaction(async (tx) => {
+    await acquireMatchmakingLock(tx, options);
+    await cleanupStaleMatchSessionsInTransaction(tx, { ...options, now });
+
+    const activeParticipant = await findActiveParticipant(tx, user.id, boardSize);
+    if (!activeParticipant) {
+      return { kind: "not_queued" };
+    }
+
+    const match = activeParticipant.match as QueueMatch;
+    if (match.status === MatchStatus.IN_PROGRESS) {
+      return {
+        kind: "already_matched",
+        session: serializeSession(match, activeParticipant),
+      };
+    }
+
+    const updated = await tx.match.updateMany({
+      where: {
+        id: match.id,
+        status: MatchStatus.WAITING,
+      },
+      data: {
+        endReason: endReasonQueueCancelled,
+        finishedAt: now,
+        nextTurnSeat: null,
+        status: MatchStatus.CANCELLED,
+      },
+    });
+
+    if (updated.count !== 1) {
+      const refreshedParticipant = await findActiveParticipant(tx, user.id, boardSize);
+      if (refreshedParticipant?.match.status === MatchStatus.IN_PROGRESS) {
+        return {
+          kind: "already_matched",
+          session: serializeSession(refreshedParticipant.match as QueueMatch, refreshedParticipant),
+        };
+      }
+
+      return { kind: "not_queued" };
+    }
+
+    await tx.matchParticipant.updateMany({
+      where: {
+        leftAt: null,
+        matchId: match.id,
+        result: null,
+      },
+      data: {
+        leftAt: now,
+        result: MatchResult.CANCELLED,
+      },
+    });
+
+    return {
+      kind: "cancelled",
+      matchId: match.id,
+    };
+  });
+}
+
+export async function getMatchmakingQueueStatus(
+  user: MatchmakingUser,
+  options: QueueOptions = {},
+): Promise<MatchmakingQueueStatus> {
+  const now = options.now ?? new Date();
+  const boardSize = options.boardSize ?? standardGomokuBoardSize;
+
+  return prisma.$transaction(async (tx) => {
+    await acquireMatchmakingLock(tx, options);
+    await cleanupStaleMatchSessionsInTransaction(tx, { ...options, now });
+
+    const activeParticipant = await findActiveParticipant(tx, user.id, boardSize);
+    if (!activeParticipant) {
+      return { kind: "not_queued" };
+    }
+
+    const match = activeParticipant.match as QueueMatch;
+    const session = serializeSession(match, activeParticipant);
+
+    if (match.status === MatchStatus.IN_PROGRESS) {
+      return {
+        kind: "matched",
+        session,
+      };
+    }
+
+    return {
+      kind: "queued",
+      queuePosition: 1,
+      session,
+    };
+  });
+}

--- a/realtime/handlers/matchmaking-queue.ts
+++ b/realtime/handlers/matchmaking-queue.ts
@@ -1,0 +1,92 @@
+import type { Server, Socket } from "socket.io";
+
+import {
+  cancelMatchmakingQueue,
+  type JoinMatchmakingQueueResult,
+  type MatchmakingUser,
+  type MatchmakingSession,
+  joinMatchmakingQueue,
+} from "@/lib/matches/matchmaking";
+
+type SocketUser = Partial<MatchmakingUser> & {
+  id?: string;
+};
+
+function getAuthenticatedUser(socket: Socket): MatchmakingUser | null {
+  const user = socket.data.user as SocketUser | undefined;
+
+  if (!user?.id) {
+    return null;
+  }
+
+  return {
+    displayName: user.displayName ?? null,
+    id: user.id,
+    name: user.name ?? null,
+    username: user.username ?? null,
+  };
+}
+
+function emitMatched(socket: Socket, session: MatchmakingSession) {
+  socket.emit("queue:matched", session);
+  socket.emit("queue:status", {
+    kind: "matched",
+    session,
+  });
+}
+
+function emitJoinResult(socket: Socket, io: Server, result: JoinMatchmakingQueueResult) {
+  if (result.kind === "queued") {
+    socket.emit("queue:status", {
+      kind: "queued",
+      queuePosition: result.queuePosition,
+      session: result.session,
+    });
+    return;
+  }
+
+  emitMatched(socket, result.session);
+
+  if (result.opponent?.username) {
+    io.to(`user:${result.opponent.username}`).emit("queue:matched", result.opponent.session);
+    io.to(`user:${result.opponent.username}`).emit("queue:status", {
+      kind: "matched",
+      session: result.opponent.session,
+    });
+  }
+}
+
+export function registerMatchmakingQueue(socket: Socket, io: Server) {
+  socket.on("queue:join", async () => {
+    const user = getAuthenticatedUser(socket);
+
+    if (!user) {
+      socket.emit("queue:error", { error: "unauthorized" });
+      return;
+    }
+
+    try {
+      emitJoinResult(socket, io, await joinMatchmakingQueue(user));
+    } catch (error) {
+      console.error("Failed to join matchmaking queue", error);
+      socket.emit("queue:error", { error: "failed_to_join_queue" });
+    }
+  });
+
+  socket.on("queue:leave", async () => {
+    const user = getAuthenticatedUser(socket);
+
+    if (!user) {
+      socket.emit("queue:error", { error: "unauthorized" });
+      return;
+    }
+
+    try {
+      const result = await cancelMatchmakingQueue(user);
+      socket.emit("queue:status", result);
+    } catch (error) {
+      console.error("Failed to leave matchmaking queue", error);
+      socket.emit("queue:error", { error: "failed_to_cancel_queue" });
+    }
+  });
+}

--- a/realtime/server.ts
+++ b/realtime/server.ts
@@ -11,6 +11,7 @@ import { prisma } from "@/lib/prisma";
 import { isGameUpdatePayload } from "../shared/match-events-validation";
 import { readRealtimeInternalSecret } from "../shared/realtime-internal";
 import { registerMatchSubscription } from "./handlers/match-subscription";
+import { registerMatchmakingQueue } from "./handlers/matchmaking-queue";
 import { resolveFriendshipNotificationTarget } from "./lib/friendship-notifications";
 import { handleInternalFriendshipUpdate } from "./lib/internal-friendship-update";
 import { removePresenceConnection, subscribeToPresence, type ConnectedUsers } from "./lib/presence";
@@ -93,13 +94,6 @@ io.use(authenticateSocketSession);
 
 const connectedUsers: ConnectedUsers = new Map();
 
-type QueuedPlayer = {
-  socketId: string;
-  userId: string;
-};
-
-let matchQueue: QueuedPlayer[] = [];
-
 io.on("connection", (socket) => {
   console.log(`Socket.IO client connected: ${socket.id}`);
 
@@ -118,6 +112,7 @@ io.on("connection", (socket) => {
   });
 
   subscribeToPresence(socket, io, connectedUsers);
+  registerMatchmakingQueue(socket, io);
   registerMatchSubscription(socket);
 
   socket.on("presence:subscribe", () => {
@@ -148,69 +143,10 @@ io.on("connection", (socket) => {
     }
   });
 
-  socket.on("queue:join", async () => {
-    const userId = socket.data.user?.id;
-    if (!userId) return;
-
-    matchQueue = matchQueue.filter(
-      (player) => player.userId !== userId && player.socketId !== socket.id,
-    );
-
-    matchQueue.push({ socketId: socket.id, userId });
-    console.log(`Player ${userId} joined the queue. Total waiting: ${matchQueue.length}`);
-
-    if (matchQueue.length >= 2) {
-      const player1 = matchQueue.shift()!;
-      const player2 = matchQueue.shift()!;
-
-      try {
-        const match = await prisma.match.create({
-          data: {
-            status: "IN_PROGRESS",
-            nextTurnSeat: "BLACK",
-            participants: {
-              create: [
-                {
-                  userId: player1.userId,
-                  displayNameSnapshot: "Player 1",
-                  role: "PLAYER",
-                  seat: "BLACK",
-                },
-                {
-                  userId: player2.userId,
-                  displayNameSnapshot: "Player 2",
-                  role: "PLAYER",
-                  seat: "WHITE",
-                },
-              ],
-            },
-          },
-        });
-
-        io.to(player1.socketId).emit("queue:matched", {
-          matchId: match.id,
-        });
-
-        io.to(player2.socketId).emit("queue:matched", {
-          matchId: match.id,
-        });
-
-        console.log(`Created match ${match.id} for ${player1.userId} and ${player2.userId}`);
-      } catch (error) {
-        console.error("Failed to create match from queue", error);
-      }
-    }
-  });
-
-  socket.on("queue:leave", () => {
-    matchQueue = matchQueue.filter((player) => player.socketId !== socket.id);
-  });
-
   socket.on("disconnect", (reason) => {
     console.log(`Socket.IO client disconnected: ${socket.id} (${reason})`);
 
     stopSocketLifecycle();
-    matchQueue = matchQueue.filter((player) => player.socketId !== socket.id);
 
     removePresenceConnection(socket, io, connectedUsers);
   });


### PR DESCRIPTION
## Summary
- add a persistent matchmaking queue service backed by existing Match and MatchParticipant records
- expose authenticated queue status, join, and cancel operations at `/api/matches/queue`
- wire Socket.IO `queue:join`, `queue:leave`, `queue:status`, and `queue:matched` through the same persistent service
- clean up stale waiting and abandoned in-progress sessions, with optional timeout env knobs

## Why
Issue #30 asks for automatic authenticated 1v1 matchmaking, safe queue cancellation, and lifecycle cleanup so paired users land in exactly one match room without zombie sessions.

Closes #30.

## Validation
- `bun test`
- `bun run lint:js`
- `bunx --bun tsc --noEmit`
- `bun run format:check`