### PR TITLE
[codex] Implement realtime match state synchronization

### DIFF
--- a/app/api/matches/[id]/join/route.test.ts
+++ b/app/api/matches/[id]/join/route.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { MatchStatus, MatchVisibility, Role, RuleType, Seat } from "@/../generated/prisma/enums";
+
+const getCurrentSession = mock();
+const findMatch = mock();
+const transaction = mock();
+const createParticipant = mock();
+const updateMatch = mock();
+const publishGameUpdate = mock();
+
+const tx = {
+  match: {
+    update: updateMatch,
+  },
+  matchParticipant: {
+    create: createParticipant,
+  },
+};
+
+await mock.module("@/lib/auth", () => ({
+  getCurrentSession,
+}));
+
+await mock.module("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: transaction,
+    match: {
+      findUnique: findMatch,
+    },
+  },
+}));
+
+await mock.module("@/lib/matches/realtime-publisher", () => ({
+  publishGameUpdate,
+}));
+
+const route = await import("./route");
+
+const createdAt = new Date("2026-05-12T00:00:00.000Z");
+const startedAt = new Date("2026-05-12T00:01:00.000Z");
+
+function request() {
+  return new Request("http://localhost/api/matches/match-1/join", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({}),
+  });
+}
+
+function context(matchId = "match-1") {
+  return {
+    params: Promise.resolve({ id: matchId }),
+  };
+}
+
+function hostParticipant() {
+  return {
+    displayNameSnapshot: "Black",
+    id: "black-player",
+    joinedAt: createdAt,
+    leftAt: null,
+    matchId: "match-1",
+    result: null,
+    role: Role.PLAYER,
+    seat: Seat.BLACK,
+    userId: "user-black",
+  };
+}
+
+function joinerParticipant() {
+  return {
+    displayNameSnapshot: "White",
+    id: "white-player",
+    joinedAt: startedAt,
+    leftAt: null,
+    matchId: "match-1",
+    result: null,
+    role: Role.PLAYER,
+    seat: Seat.WHITE,
+    userId: "user-white",
+  };
+}
+
+function waitingMatch() {
+  return {
+    boardSize: 15,
+    createdAt,
+    createdByUserId: "user-black",
+    endReason: null,
+    finishedAt: null,
+    id: "match-1",
+    nextTurnSeat: null,
+    participants: [hostParticipant()],
+    ruleType: RuleType.GOMOKU,
+    startedAt: null,
+    stateVersion: 0,
+    status: MatchStatus.WAITING,
+    updatedAt: createdAt,
+    visibility: MatchVisibility.PUBLIC,
+    winningSeat: null,
+  };
+}
+
+function updatedMatch() {
+  return {
+    ...waitingMatch(),
+    moves: [],
+    nextTurnSeat: Seat.BLACK,
+    participants: [hostParticipant(), joinerParticipant()],
+    startedAt,
+    stateVersion: 1,
+    status: MatchStatus.IN_PROGRESS,
+  };
+}
+
+beforeEach(() => {
+  getCurrentSession.mockReset();
+  findMatch.mockReset();
+  transaction.mockReset();
+  createParticipant.mockReset();
+  updateMatch.mockReset();
+  publishGameUpdate.mockReset();
+
+  getCurrentSession.mockResolvedValue({
+    user: {
+      displayName: "White",
+      id: "user-white",
+      username: "white",
+    },
+  });
+  transaction.mockImplementation((callback: (transactionClient: typeof tx) => unknown) =>
+    callback(tx),
+  );
+  createParticipant.mockResolvedValue(joinerParticipant());
+  updateMatch.mockResolvedValue(updatedMatch());
+  publishGameUpdate.mockResolvedValue(undefined);
+});
+
+describe("POST /api/matches/:id/join", () => {
+  test("requires authentication before joining", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const response = await route.POST(request(), context());
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload).toMatchObject({ error: "unauthorized" });
+    expect(findMatch).not.toHaveBeenCalled();
+  });
+
+  test("starts the match, increments state version, and publishes the update", async () => {
+    findMatch.mockResolvedValueOnce(waitingMatch());
+
+    const response = await route.POST(request(), context());
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      matchId: "match-1",
+      participantId: "white-player",
+      seat: Seat.WHITE,
+      stateVersion: 1,
+    });
+    expect(updateMatch).toHaveBeenCalledWith({
+      data: {
+        nextTurnSeat: Seat.BLACK,
+        startedAt: expect.any(Date),
+        stateVersion: {
+          increment: 1,
+        },
+        status: MatchStatus.IN_PROGRESS,
+      },
+      include: {
+        moves: {
+          orderBy: { moveNumber: "asc" },
+        },
+        participants: {
+          orderBy: { joinedAt: "asc" },
+        },
+      },
+      where: { id: "match-1" },
+    });
+    expect(publishGameUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        matchId: "match-1",
+        moves: [],
+        nextTurnSeat: Seat.BLACK,
+        participants: [
+          expect.objectContaining({ participantId: "black-player", seat: Seat.BLACK }),
+          expect.objectContaining({ participantId: "white-player", seat: Seat.WHITE }),
+        ],
+        stateVersion: 1,
+        status: MatchStatus.IN_PROGRESS,
+      }),
+      2000,
+    );
+  });
+});

--- a/app/api/matches/[id]/join/route.ts
+++ b/app/api/matches/[id]/join/route.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import { Prisma } from "@/../generated/prisma/client";
 import { MatchStatus, Role, Seat } from "@/../generated/prisma/enums";
 import { getCurrentSession } from "@/lib/auth";
+import { buildGameUpdatePayload } from "@/lib/matches/game-update";
+import { publishGameUpdate } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 
 export const dynamic = "force-dynamic";
@@ -68,7 +70,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       return Response.json({ error: "match_full" }, { status: 409 });
     }
 
-    const { joiner } = await prisma.$transaction(async (tx) => {
+    const { joiner, updatedMatch } = await prisma.$transaction(async (tx) => {
       const joiner = await tx.matchParticipant.create({
         data: {
           matchId,
@@ -79,23 +81,48 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
         },
       });
 
-      await tx.match.update({
+      const updatedMatch = await tx.match.update({
         where: { id: matchId },
         data: {
+          stateVersion: {
+            increment: 1,
+          },
           status: MatchStatus.IN_PROGRESS,
           nextTurnSeat: Seat.BLACK,
           startedAt: new Date(),
         },
+        include: {
+          moves: {
+            orderBy: { moveNumber: "asc" },
+          },
+          participants: {
+            orderBy: { joinedAt: "asc" },
+          },
+        },
       });
 
-      return { joiner };
+      return { joiner, updatedMatch };
     });
+
+    const gameUpdate = buildGameUpdatePayload({
+      match: updatedMatch,
+      participants: updatedMatch.participants,
+      moves: updatedMatch.moves,
+    });
+
+    try {
+      const timeoutMs = Number(process.env["REALTIME_PUBLISH_TIMEOUT_MS"] ?? 2000);
+      await publishGameUpdate(gameUpdate, timeoutMs);
+    } catch (publishError) {
+      console.error(`[matches/${matchId}] realtime publish failed:`, getErrorMessage(publishError));
+    }
 
     return Response.json({
       matchId,
       participantId: joiner.id,
       role: joiner.role,
       seat: joiner.seat,
+      stateVersion: updatedMatch.stateVersion,
     });
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {

--- a/app/api/matches/[id]/moves/route.ts
+++ b/app/api/matches/[id]/moves/route.ts
@@ -1,8 +1,10 @@
 import { Prisma } from "@/../generated/prisma/client";
 import { MatchStatus } from "@/../generated/prisma/enums";
+import { getCurrentSession } from "@/lib/auth";
 import { buildGameUpdatePayload } from "@/lib/matches/game-update";
 import { submitMoveRequestSchema } from "@/lib/matches/move-request-validation";
 import { evaluateMoveOutcome, validateMoveSubmission } from "@/lib/matches/move-rules";
+import { isActiveParticipantForUser } from "@/lib/matches/participant-access";
 import { publishGameUpdate } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 
@@ -37,6 +39,12 @@ function mapUniqueConstraintError(error: Prisma.PrismaClientKnownRequestError) {
 }
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const context = await getCurrentSession();
+
+  if (!context) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
   try {
     const { id: matchId } = await params;
     const body = await request.json().catch(() => null);
@@ -64,6 +72,13 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
         return {
           kind: "error" as const,
           payload: { error: "match_not_found", status: 404 },
+        };
+      }
+
+      if (!isActiveParticipantForUser(match.participants, participantId, context.user.id)) {
+        return {
+          kind: "error" as const,
+          payload: { error: "participant_not_found", status: 403 },
         };
       }
 

--- a/app/api/matches/[id]/resign/route.ts
+++ b/app/api/matches/[id]/resign/route.ts
@@ -1,7 +1,9 @@
 import { Prisma } from "@/../generated/prisma/client";
+import { getCurrentSession } from "@/lib/auth";
 import { buildGameUpdatePayload } from "@/lib/matches/game-update";
 import { resignMatchRequestSchema } from "@/lib/matches/move-request-validation";
 import { validateResignation } from "@/lib/matches/move-rules";
+import { isActiveParticipantForUser } from "@/lib/matches/participant-access";
 import { publishGameUpdate } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 
@@ -12,6 +14,12 @@ function getErrorMessage(error: unknown): string {
 }
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const context = await getCurrentSession();
+
+  if (!context) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
   try {
     const { id: matchId } = await params;
     const body = await request.json().catch(() => null);
@@ -39,6 +47,13 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
         return {
           kind: "error" as const,
           payload: { error: "match_not_found", status: 404 },
+        };
+      }
+
+      if (!isActiveParticipantForUser(match.participants, participantId, context.user.id)) {
+        return {
+          kind: "error" as const,
+          payload: { error: "participant_not_found", status: 403 },
         };
       }
 

--- a/app/api/matches/[id]/rules-routes.test.ts
+++ b/app/api/matches/[id]/rules-routes.test.ts
@@ -17,6 +17,7 @@ const createMove = mock();
 const updateMatchMany = mock();
 const updateParticipant = mock();
 const publishGameUpdate = mock();
+const getCurrentSession = mock();
 
 const tx = {
   match: {
@@ -40,6 +41,10 @@ await mock.module("@/lib/prisma", () => ({
 
 await mock.module("@/lib/matches/realtime-publisher", () => ({
   publishGameUpdate,
+}));
+
+await mock.module("@/lib/auth", () => ({
+  getCurrentSession,
 }));
 
 const movesRoute = await import("./moves/route");
@@ -69,7 +74,7 @@ function participants() {
     {
       id: "black-player",
       matchId: "match-1",
-      userId: null,
+      userId: "user-black",
       displayNameSnapshot: "Black",
       role: Role.PLAYER,
       seat: Seat.BLACK,
@@ -80,7 +85,7 @@ function participants() {
     {
       id: "white-player",
       matchId: "match-1",
-      userId: null,
+      userId: "user-white",
       displayNameSnapshot: "White",
       role: Role.PLAYER,
       seat: Seat.WHITE,
@@ -151,11 +156,17 @@ beforeEach(() => {
   updateMatchMany.mockReset();
   updateParticipant.mockReset();
   publishGameUpdate.mockReset();
+  getCurrentSession.mockReset();
 
   transaction.mockImplementation((callback: (transactionClient: typeof tx) => unknown) =>
     callback(tx),
   );
   publishGameUpdate.mockResolvedValue(undefined);
+  getCurrentSession.mockResolvedValue({
+    user: {
+      id: "user-black",
+    },
+  });
 });
 
 describe("POST /api/matches/:id/moves", () => {

--- a/app/api/matches/[id]/state/route.test.ts
+++ b/app/api/matches/[id]/state/route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const findUnique = mock();
 const buildBoard = mock();
+const getCurrentSession = mock();
 
 await mock.module("@/lib/prisma", () => ({
   prisma: {
@@ -13,6 +14,10 @@ await mock.module("@/lib/prisma", () => ({
 
 await mock.module("@/lib/game/state-builder", () => ({
   buildBoard,
+}));
+
+await mock.module("@/lib/auth", () => ({
+  getCurrentSession,
 }));
 
 const route = await import("./route");
@@ -46,7 +51,7 @@ function matchRecord() {
     participants: [
       {
         id: "participant-black",
-        userId: "user-black",
+        userId: "user-current",
         displayNameSnapshot: "Black",
         role: "PLAYER",
         seat: "BLACK",
@@ -80,7 +85,13 @@ function matchRecord() {
 beforeEach(() => {
   findUnique.mockReset();
   buildBoard.mockReset();
+  getCurrentSession.mockReset();
   buildBoard.mockReturnValue([[{ occupied: false }]]);
+  getCurrentSession.mockResolvedValue({
+    user: {
+      id: "user-current",
+    },
+  });
 });
 
 describe("GET /api/matches/:id/state", () => {
@@ -90,6 +101,17 @@ describe("GET /api/matches/:id/state", () => {
 
     expect(response.status).toBe(400);
     expect(payload["error"]).toBe("missing_participant_id");
+    expect(findUnique).not.toHaveBeenCalled();
+  });
+
+  test("requires authentication before loading match state", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const response = await route.GET(request("participant-black"), context());
+    const payload = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(401);
+    expect(payload["error"]).toBe("unauthorized");
     expect(findUnique).not.toHaveBeenCalled();
   });
 

--- a/app/api/matches/[id]/state/route.ts
+++ b/app/api/matches/[id]/state/route.ts
@@ -1,4 +1,6 @@
+import { getCurrentSession } from "@/lib/auth";
 import { buildBoard } from "@/lib/game/state-builder";
+import { isActiveParticipantForUser } from "@/lib/matches/participant-access";
 import { prisma } from "@/lib/prisma";
 
 export const dynamic = "force-dynamic";
@@ -8,6 +10,12 @@ function getErrorMessage(error: unknown): string {
 }
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const context = await getCurrentSession();
+
+  if (!context) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
   try {
     const { id: matchId } = await params;
     const participantId = new URL(request.url).searchParams.get("participantId");
@@ -30,8 +38,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       return Response.json({ error: "match_not_found" }, { status: 404 });
     }
 
-    const participant = match.participants.find((item) => item.id === participantId);
-    if (!participant) {
+    if (!isActiveParticipantForUser(match.participants, participantId, context.user.id)) {
       return Response.json({ error: "participant_not_found" }, { status: 403 });
     }
 

--- a/app/api/matches/route.ts
+++ b/app/api/matches/route.ts
@@ -1,7 +1,9 @@
 import { Role, MatchStatus, Seat } from "../../../generated/prisma/enums";
 import { getCurrentSession } from "../../lib/auth";
+import { buildGameUpdatePayload } from "../../lib/matches/game-update";
 import { cleanupStaleMatchSessions } from "../../lib/matches/matchmaking";
 import { standardGomokuBoardSize } from "../../lib/matches/move-rules";
+import { publishGameUpdate } from "../../lib/matches/realtime-publisher";
 import { prisma } from "../../lib/prisma";
 
 export const dynamic = "force-dynamic";
@@ -47,11 +49,28 @@ export async function POST() {
       throw new Error("Match participant was not created.");
     }
 
+    const gameUpdate = buildGameUpdatePayload({
+      match,
+      participants: match.participants,
+      moves: [],
+    });
+
+    try {
+      const timeoutMs = Number(process.env["REALTIME_PUBLISH_TIMEOUT_MS"] ?? 2000);
+      await publishGameUpdate(gameUpdate, timeoutMs);
+    } catch (publishError) {
+      console.error(
+        `[matches/${match.id}] realtime publish failed:`,
+        getErrorMessage(publishError),
+      );
+    }
+
     return Response.json({
       matchId: match.id,
       participantId: creator.id,
       role: creator.role,
       seat: creator.seat,
+      stateVersion: match.stateVersion,
       status: match.status,
       createdAt: match.createdAt,
     });

--- a/app/components/human-match-room.tsx
+++ b/app/components/human-match-room.tsx
@@ -22,10 +22,11 @@ import {
 import {
   getGameUpdateForSession,
   getSessionSeat,
+  selectLatestGameUpdateForSession,
   toInitialGameUpdate,
   type MatchStateResponse,
 } from "@/lib/matches/match-state";
-import { submitMove } from "@/lib/matches/submit-move";
+import { MoveSubmissionError, submitMove } from "@/lib/matches/submit-move";
 import { cn } from "@/lib/utils";
 
 import type { Cell, GameUpdatePayload, ParticipantSummary, Seat } from "../../shared/match-events";
@@ -60,6 +61,15 @@ function getErrorMessage(payload: unknown, fallback: string) {
       (value): value is string => typeof value === "string" && value.length > 0,
     ) ?? fallback
   );
+}
+
+function getErrorCode(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const errorPayload = payload as { error?: unknown };
+  return typeof errorPayload.error === "string" ? errorPayload.error : null;
 }
 
 function formatPoint(position: { x: number; y: number }) {
@@ -107,11 +117,6 @@ export default function HumanMatchRoom({
   const [isSubmittingMove, setIsSubmittingMove] = useState(false);
   const [isResigning, setIsResigning] = useState(false);
 
-  const { status: socketStatus, lastUpdate } = useSocketGame(
-    session.matchId,
-    session.participantId,
-  );
-
   useEffect(() => {
     if (initialState?.matchId === session.matchId) {
       setState(initialState);
@@ -156,9 +161,14 @@ export default function HumanMatchRoom({
     void loadState();
   }, [loadState]);
 
-  const liveUpdate = getGameUpdateForSession(lastUpdate, session);
   const initialUpdate = toInitialGameUpdate(state, session);
-  const effectiveUpdate = liveUpdate ?? initialUpdate;
+  const { status: socketStatus, lastUpdate } = useSocketGame(
+    session.matchId,
+    session.participantId,
+    initialUpdate?.stateVersion ?? null,
+  );
+  const liveUpdate = getGameUpdateForSession(lastUpdate, session);
+  const effectiveUpdate = selectLatestGameUpdateForSession(initialUpdate, liveUpdate, session);
   const board = effectiveUpdate?.board ?? state?.board ?? emptyBoard(state?.boardSize ?? 15);
   const mySeat = getSessionSeat(state, session) ?? session.seat;
   const participantBySeat = useMemo(() => {
@@ -169,8 +179,8 @@ export default function HumanMatchRoom({
     };
   }, [effectiveUpdate?.participants]);
   const moveHistory = useMemo(
-    () => mergeMoveHistory(state?.moves ?? [], effectiveUpdate?.lastMove ?? null),
-    [effectiveUpdate?.lastMove, state?.moves],
+    () => effectiveUpdate?.moves ?? state?.moves ?? [],
+    [effectiveUpdate?.moves, state?.moves],
   );
   const canResign = effectiveUpdate?.status === "IN_PROGRESS" && mySeat !== null;
   const matchStatus = effectiveUpdate?.status ?? state?.status;
@@ -194,6 +204,9 @@ export default function HumanMatchRoom({
       await loadState();
     } catch (error) {
       setMoveError(error instanceof Error ? error.message : "Network error while submitting move");
+      if (error instanceof MoveSubmissionError && error.code === "stale_state") {
+        await loadState();
+      }
     } finally {
       setIsSubmittingMove(false);
     }
@@ -221,7 +234,11 @@ export default function HumanMatchRoom({
 
       if (!response.ok) {
         const errorPayload = await response.json().catch(() => null);
+        const errorCode = getErrorCode(errorPayload);
         setMoveError(getErrorMessage(errorPayload, `Resign request failed (${response.status})`));
+        if (errorCode === "stale_state") {
+          await loadState();
+        }
         return;
       }
 
@@ -556,27 +573,6 @@ function MoveHistory({
       })}
     </div>
   );
-}
-
-function mergeMoveHistory(
-  moves: MatchMove[],
-  lastMove: GameUpdatePayload["lastMove"],
-): MatchMove[] {
-  if (!lastMove || moves.some((move) => move.moveNumber === lastMove.moveNumber)) {
-    return moves;
-  }
-
-  return [
-    ...moves,
-    {
-      baseVersion: null,
-      moveNumber: lastMove.moveNumber,
-      participantId: lastMove.participantId,
-      position: lastMove.position,
-      requestId: lastMove.requestId,
-      stateVersion: lastMove.stateVersion,
-    },
-  ];
 }
 
 function statusLine(update: GameUpdatePayload | null, mySeat: Seat | null) {

--- a/app/hooks/useSocketGame.ts
+++ b/app/hooks/useSocketGame.ts
@@ -9,20 +9,36 @@ import type { GameUpdatePayload } from "../../shared/match-events";
 
 type SubscribeStatus = "idle" | "connecting" | "subscribed" | "error";
 
-export function useSocketGame(matchId: string | null, participantId: string | null) {
+export function useSocketGame(
+  matchId: string | null,
+  participantId: string | null,
+  knownStateVersion: number | null = null,
+) {
   const socketRef = useRef<Socket | null>(null);
+  const knownStateVersionRef = useRef(knownStateVersion);
+  const latestStateVersionRef = useRef(knownStateVersion ?? -1);
   const [status, setStatus] = useState<SubscribeStatus>("idle");
   const [lastUpdate, setLastUpdate] = useState<GameUpdatePayload | null>(null);
+
+  useEffect(() => {
+    knownStateVersionRef.current = knownStateVersion;
+
+    if (typeof knownStateVersion === "number") {
+      latestStateVersionRef.current = Math.max(latestStateVersionRef.current, knownStateVersion);
+    }
+  }, [knownStateVersion]);
 
   useEffect(() => {
     if (!matchId || !participantId) {
       setStatus("idle");
       setLastUpdate(null);
+      latestStateVersionRef.current = -1;
       return;
     }
 
     setStatus("connecting");
     setLastUpdate(null);
+    latestStateVersionRef.current = knownStateVersionRef.current ?? -1;
 
     const socket = createSocket();
     socketRef.current = socket;
@@ -30,7 +46,12 @@ export function useSocketGame(matchId: string | null, participantId: string | nu
     let active = true;
 
     socket.on("connect", () => {
-      socket.emit("match:subscribe", { matchId, participantId });
+      const lastSeenStateVersion = latestStateVersionRef.current;
+      socket.emit("match:subscribe", {
+        matchId,
+        participantId,
+        ...(lastSeenStateVersion >= 0 ? { lastSeenStateVersion } : {}),
+      });
     });
 
     socket.on("match:subscribed", () => {
@@ -38,7 +59,12 @@ export function useSocketGame(matchId: string | null, participantId: string | nu
     });
 
     socket.on("game:update", (payload: GameUpdatePayload) => {
-      if (active) {
+      if (active && payload.matchId === matchId) {
+        if (payload.stateVersion <= latestStateVersionRef.current) {
+          return;
+        }
+
+        latestStateVersionRef.current = payload.stateVersion;
         setLastUpdate(payload);
       }
     });
@@ -50,6 +76,18 @@ export function useSocketGame(matchId: string | null, participantId: string | nu
     socket.on("error", () => {
       if (active) {
         setStatus("error");
+      }
+    });
+
+    socket.on("match:error", () => {
+      if (active) {
+        setStatus("error");
+      }
+    });
+
+    socket.on("disconnect", () => {
+      if (active) {
+        setStatus("connecting");
       }
     });
 

--- a/app/lib/matches/game-update.ts
+++ b/app/lib/matches/game-update.ts
@@ -1,7 +1,7 @@
 import type { Match, MatchMove, MatchParticipant } from "@/../generated/prisma/client";
 import { buildBoard } from "@/lib/game/state-builder";
 
-import type { GameUpdatePayload, LastMove } from "../../../shared/match-events";
+import type { GameUpdatePayload, LastMove, MoveSummary } from "../../../shared/match-events";
 
 type GameUpdateMatch = Pick<
   Match,
@@ -19,7 +19,7 @@ type GameUpdateParticipant = Pick<MatchParticipant, "displayNameSnapshot" | "id"
 
 type GameUpdateMove = Pick<
   MatchMove,
-  "moveNumber" | "participantId" | "requestId" | "stateVersion" | "x" | "y"
+  "baseVersion" | "moveNumber" | "participantId" | "requestId" | "stateVersion" | "x" | "y"
 >;
 
 function toLastMove(move: GameUpdateMove | null): LastMove | null {
@@ -28,6 +28,17 @@ function toLastMove(move: GameUpdateMove | null): LastMove | null {
   }
 
   return {
+    moveNumber: move.moveNumber,
+    participantId: move.participantId,
+    position: { x: move.x, y: move.y },
+    requestId: move.requestId,
+    stateVersion: move.stateVersion,
+  };
+}
+
+function toMoveSummary(move: GameUpdateMove): MoveSummary {
+  return {
+    baseVersion: move.baseVersion,
     moveNumber: move.moveNumber,
     participantId: move.participantId,
     position: { x: move.x, y: move.y },
@@ -67,5 +78,6 @@ export function buildGameUpdatePayload({
     })),
     board: buildBoard(match.boardSize, participants, sortedMoves),
     lastMove: toLastMove(latestMove),
+    moves: sortedMoves.map(toMoveSummary),
   };
 }

--- a/app/lib/matches/match-state.test.ts
+++ b/app/lib/matches/match-state.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   getGameUpdateForSession,
   getSessionSeat,
+  selectLatestGameUpdateForSession,
   type MatchStateResponse,
   toInitialGameUpdate,
 } from "./match-state";
@@ -97,9 +98,54 @@ describe("match state helpers", () => {
         participantId: "white-player",
       },
     });
+    expect(update?.moves).toHaveLength(2);
     expect(update?.participants).toHaveLength(2);
     expect(getSessionSeat(state, { matchId: "match-1", participantId: "black-player" })).toBe(
       "BLACK",
     );
+  });
+
+  test("keeps restored state when a duplicate or stale live event arrives", () => {
+    const restored = toInitialGameUpdate(state, {
+      matchId: "match-1",
+      participantId: "black-player",
+    });
+    const staleLive = restored
+      ? {
+          ...restored,
+          stateVersion: 2,
+        }
+      : null;
+
+    expect(
+      selectLatestGameUpdateForSession(restored, staleLive, {
+        matchId: "match-1",
+        participantId: "black-player",
+      })?.stateVersion,
+    ).toBe(3);
+  });
+
+  test("uses newer live updates for the active session", () => {
+    const restored = toInitialGameUpdate(state, {
+      matchId: "match-1",
+      participantId: "black-player",
+    });
+    const live = restored
+      ? {
+          ...restored,
+          nextTurnSeat: "BLACK" as const,
+          stateVersion: 4,
+        }
+      : null;
+
+    expect(
+      selectLatestGameUpdateForSession(restored, live, {
+        matchId: "match-1",
+        participantId: "black-player",
+      }),
+    ).toMatchObject({
+      nextTurnSeat: "BLACK",
+      stateVersion: 4,
+    });
   });
 });

--- a/app/lib/matches/match-state.ts
+++ b/app/lib/matches/match-state.ts
@@ -92,6 +92,33 @@ export function toInitialGameUpdate(
           stateVersion: restoredLastMove.stateVersion,
         }
       : null,
+    moves: state.moves.map((move) => ({
+      baseVersion: move.baseVersion,
+      moveNumber: move.moveNumber,
+      participantId: move.participantId,
+      position: move.position,
+      requestId: move.requestId,
+      stateVersion: move.stateVersion,
+    })),
     board: state.board,
   };
+}
+
+export function selectLatestGameUpdateForSession(
+  restoredUpdate: GameUpdatePayload | null,
+  liveUpdate: GameUpdatePayload | null,
+  session: MatchSessionIdentity | null,
+): GameUpdatePayload | null {
+  const restored = getGameUpdateForSession(restoredUpdate, session);
+  const live = getGameUpdateForSession(liveUpdate, session);
+
+  if (!restored) {
+    return live;
+  }
+
+  if (!live) {
+    return restored;
+  }
+
+  return live.stateVersion >= restored.stateVersion ? live : restored;
 }

--- a/app/lib/matches/matchmaking.test.ts
+++ b/app/lib/matches/matchmaking.test.ts
@@ -215,6 +215,9 @@ describe("joinMatchmakingQueue", () => {
       data: {
         nextTurnSeat: Seat.BLACK,
         startedAt: now,
+        stateVersion: {
+          increment: 1,
+        },
         status: MatchStatus.IN_PROGRESS,
       },
       where: {

--- a/app/lib/matches/matchmaking.ts
+++ b/app/lib/matches/matchmaking.ts
@@ -449,15 +449,20 @@ export async function joinMatchmakingQueue(
         data: {
           nextTurnSeat: Seat.BLACK,
           startedAt: now,
+          stateVersion: {
+            increment: 1,
+          },
           status: MatchStatus.IN_PROGRESS,
         },
       });
+      const startedStateVersion = (opponentMatch.stateVersion ?? 0) + 1;
 
       const matchedMatch: QueueMatch = {
         ...opponentMatch,
         nextTurnSeat: Seat.BLACK,
         participants: [...opponentMatch.participants, joiner],
         startedAt: now,
+        stateVersion: startedStateVersion,
         status: MatchStatus.IN_PROGRESS,
       };
       const opponent = opponentMatch.participants[0];

--- a/app/lib/matches/participant-access.ts
+++ b/app/lib/matches/participant-access.ts
@@ -1,0 +1,18 @@
+type ParticipantAccessSnapshot = {
+  id: string;
+  leftAt: Date | string | null;
+  userId: string | null;
+};
+
+export function isActiveParticipantForUser(
+  participants: ParticipantAccessSnapshot[],
+  participantId: string,
+  userId: string,
+) {
+  return participants.some(
+    (participant) =>
+      participant.id === participantId &&
+      participant.userId === userId &&
+      participant.leftAt === null,
+  );
+}

--- a/app/lib/matches/realtime-publisher.test.ts
+++ b/app/lib/matches/realtime-publisher.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GameUpdatePayload } from "../../../shared/match-events";
+import { internalRealtimeSecretHeader } from "../../../shared/realtime-internal";
+import { publishGameUpdate, resolveGameUpdateUrl } from "./realtime-publisher";
+
+const fetchMock = mock(async () => new Response(null, { status: 200 }));
+const originalFetch = globalThis.fetch;
+const envKeys = [
+  "BETTER_AUTH_SECRET",
+  "REALTIME_INTERNAL_SECRET",
+  "REALTIME_INTERNAL_URL",
+  "REALTIME_PUBLISH_TIMEOUT_MS",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]])) as Record<
+  (typeof envKeys)[number],
+  string | undefined
+>;
+
+const payload: GameUpdatePayload = {
+  board: [[{ occupied: false }]],
+  boardSize: 1,
+  endReason: null,
+  lastMove: null,
+  matchId: "match-1",
+  moves: [],
+  nextTurnSeat: null,
+  participants: [],
+  stateVersion: 0,
+  status: "WAITING",
+  visibility: "PUBLIC",
+  winningSeat: null,
+};
+
+function restoreEnv() {
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+async function expectRejectsWithMessage(action: () => Promise<unknown>, message: string) {
+  let thrown: unknown;
+
+  try {
+    await action();
+  } catch (error) {
+    thrown = error;
+  }
+
+  expect(thrown).toBeInstanceOf(Error);
+
+  if (thrown instanceof Error) {
+    expect(thrown.message).toContain(message);
+  }
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  for (const key of envKeys) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreEnv();
+});
+
+describe("resolveGameUpdateUrl", () => {
+  test("uses the explicit game update endpoint when configured", () => {
+    process.env["REALTIME_INTERNAL_URL"] = "http://localhost:3001/internal/game-update";
+
+    expect(resolveGameUpdateUrl()).toBe("http://localhost:3001/internal/game-update");
+  });
+});
+
+describe("publishGameUpdate", () => {
+  test("posts full game state with the internal header and no-store cache", async () => {
+    process.env["REALTIME_INTERNAL_URL"] = "http://localhost:3001/internal/game-update";
+    process.env["REALTIME_INTERNAL_SECRET"] = "game-secret";
+
+    await publishGameUpdate(payload, 5000);
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+
+    expect(call).toBeDefined();
+
+    const [url, init] = call!;
+
+    expect(url).toBe("http://localhost:3001/internal/game-update");
+    expect(init).toMatchObject({
+      body: JSON.stringify(payload),
+      cache: "no-store",
+      method: "POST",
+    });
+    expect(init.headers).toEqual({
+      "Content-Type": "application/json",
+      [internalRealtimeSecretHeader]: "game-secret",
+    });
+  });
+
+  test("falls back to the Better Auth secret when no dedicated secret is configured", async () => {
+    process.env["BETTER_AUTH_SECRET"] = "auth-secret";
+
+    await publishGameUpdate(payload);
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+
+    expect(call?.[1].headers).toMatchObject({
+      [internalRealtimeSecretHeader]: "auth-secret",
+    });
+  });
+
+  test("throws on missing secrets and failed realtime responses", async () => {
+    await expectRejectsWithMessage(
+      () => publishGameUpdate(payload),
+      "Missing REALTIME_INTERNAL_SECRET",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    process.env["REALTIME_INTERNAL_SECRET"] = "game-secret";
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    await expectRejectsWithMessage(
+      () => publishGameUpdate(payload),
+      "Failed to publish game:update(503)",
+    );
+  });
+});

--- a/app/lib/matches/realtime-publisher.ts
+++ b/app/lib/matches/realtime-publisher.ts
@@ -1,20 +1,38 @@
 import type { GameUpdatePayload } from "../../../shared/match-events";
+import {
+  internalRealtimeSecretHeader,
+  readRealtimeInternalSecret,
+} from "../../../shared/realtime-internal";
+
+const defaultGameUpdateUrl = "http://realtime:3001/internal/game-update";
+
+function readPositiveTimeoutMs(timeoutMs: number) {
+  return Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 2000;
+}
+
+export function resolveGameUpdateUrl(env: NodeJS.ProcessEnv = process.env) {
+  return env["REALTIME_INTERNAL_URL"] ?? defaultGameUpdateUrl;
+}
 
 export async function publishGameUpdate(
   payload: GameUpdatePayload,
   timeoutMs = Number(process.env["REALTIME_PUBLISH_TIMEOUT_MS"] ?? 2000),
 ) {
-  const realtimeInternalUrl =
-    process.env["REALTIME_INTERNAL_URL"] ?? "http://realtime:3001/internal/game-update";
+  const internalSecret = readRealtimeInternalSecret();
+
+  if (!internalSecret) {
+    throw new Error("Missing REALTIME_INTERNAL_SECRET or BETTER_AUTH_SECRET");
+  }
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const timeoutId = setTimeout(() => controller.abort(), readPositiveTimeoutMs(timeoutMs));
 
   try {
-    const response = await fetch(realtimeInternalUrl, {
+    const response = await fetch(resolveGameUpdateUrl(), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        [internalRealtimeSecretHeader]: internalSecret,
       },
       body: JSON.stringify(payload),
       cache: "no-store",

--- a/app/lib/matches/submit-move.ts
+++ b/app/lib/matches/submit-move.ts
@@ -23,6 +23,18 @@ type ErrorResponse = {
   error?: string;
 };
 
+export class MoveSubmissionError extends Error {
+  code: string | null;
+  status: number;
+
+  constructor(message: string, status: number, code: string | null) {
+    super(message);
+    this.name = "MoveSubmissionError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
 export async function submitMove({
   matchId,
   participantId,
@@ -51,13 +63,14 @@ export async function submitMove({
 
   if (!response.ok) {
     const errorPayload = (await response.json().catch(() => null)) as ErrorResponse | null;
+    const code = typeof errorPayload?.error === "string" ? errorPayload.error : null;
     const message =
       errorPayload?.message ??
       errorPayload?.detail ??
       errorPayload?.error ??
       `Request failed with status ${response.status}`;
 
-    throw new Error(message);
+    throw new MoveSubmissionError(message, response.status, code);
   }
 
   const result = (await response.json()) as SubmitMoveResponse;

--- a/realtime/handlers/match-subscription.test.ts
+++ b/realtime/handlers/match-subscription.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { Socket } from "socket.io";
+
+import { registerMatchSubscription } from "./match-subscription";
+
+const findFirst = mock();
+const join = mock();
+const emit = mock();
+const on = mock();
+
+const db = {
+  match: {
+    findFirst,
+  },
+};
+
+const createdAt = new Date("2026-05-12T00:00:00.000Z");
+
+function buildSocket(userId: string | null = "user-black") {
+  const handlers = new Map<string, (payload: unknown) => Promise<void>>();
+  on.mockImplementation((event: string, handler: (payload: unknown) => Promise<void>) => {
+    handlers.set(event, handler);
+  });
+
+  return {
+    handlers,
+    socket: {
+      data: {
+        user: userId ? { id: userId } : null,
+      },
+      emit,
+      id: "socket-1",
+      join,
+      on,
+    } as unknown as Socket,
+  };
+}
+
+function matchRecord() {
+  return {
+    boardSize: 2,
+    endReason: null,
+    id: "match-1",
+    moves: [
+      {
+        baseVersion: 0,
+        createdAt,
+        id: "move-1",
+        matchId: "match-1",
+        moveNumber: 1,
+        participantId: "black-player",
+        requestId: "request-1",
+        stateVersion: 1,
+        x: 0,
+        y: 0,
+      },
+    ],
+    nextTurnSeat: "WHITE",
+    participants: [
+      {
+        displayNameSnapshot: "Black",
+        id: "black-player",
+        leftAt: null,
+        matchId: "match-1",
+        role: "PLAYER",
+        seat: "BLACK",
+        userId: "user-black",
+      },
+      {
+        displayNameSnapshot: "White",
+        id: "white-player",
+        leftAt: null,
+        matchId: "match-1",
+        role: "PLAYER",
+        seat: "WHITE",
+        userId: "user-white",
+      },
+    ],
+    stateVersion: 1,
+    status: "IN_PROGRESS",
+    visibility: "PUBLIC",
+    winningSeat: null,
+  };
+}
+
+beforeEach(() => {
+  findFirst.mockReset();
+  join.mockReset();
+  emit.mockReset();
+  on.mockReset();
+  join.mockResolvedValue(undefined);
+});
+
+describe("registerMatchSubscription", () => {
+  test("rejects malformed subscribe payloads", async () => {
+    const { handlers, socket } = buildSocket();
+    registerMatchSubscription(socket, db);
+
+    await handlers.get("match:subscribe")?.({ matchId: "" });
+
+    expect(emit).toHaveBeenCalledWith("match:error", { error: "invalid_payload" });
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  test("rejects subscriptions when the socket user does not own the participant", async () => {
+    const { handlers, socket } = buildSocket("user-other");
+    registerMatchSubscription(socket, db);
+    findFirst.mockResolvedValueOnce(null);
+
+    await handlers.get("match:subscribe")?.({
+      matchId: "match-1",
+      participantId: "black-player",
+    });
+
+    expect(findFirst).toHaveBeenCalledWith({
+      include: {
+        moves: {
+          orderBy: { moveNumber: "asc" },
+        },
+        participants: true,
+      },
+      where: {
+        id: "match-1",
+        participants: {
+          some: {
+            id: "black-player",
+            leftAt: null,
+            userId: "user-other",
+          },
+        },
+      },
+    });
+    expect(emit).toHaveBeenCalledWith("match:error", { error: "participant_not_found" });
+    expect(join).not.toHaveBeenCalled();
+  });
+
+  test("joins authorized participants and sends a current full-state snapshot", async () => {
+    const { handlers, socket } = buildSocket();
+    registerMatchSubscription(socket, db);
+    findFirst.mockResolvedValueOnce(matchRecord());
+
+    await handlers.get("match:subscribe")?.({
+      lastSeenStateVersion: 0,
+      matchId: "match-1",
+      participantId: "black-player",
+    });
+
+    expect(join).toHaveBeenCalledWith("match: match-1");
+    expect(emit).toHaveBeenCalledWith("match:subscribed", {
+      matchId: "match-1",
+      stateVersion: 1,
+    });
+    expect(emit).toHaveBeenCalledWith(
+      "game:update",
+      expect.objectContaining({
+        board: [
+          [{ moveNumber: 1, occupied: true, seat: "BLACK" }, { occupied: false }],
+          [{ occupied: false }, { occupied: false }],
+        ],
+        matchId: "match-1",
+        moves: [
+          expect.objectContaining({
+            moveNumber: 1,
+            position: { x: 0, y: 0 },
+            stateVersion: 1,
+          }),
+        ],
+        nextTurnSeat: "WHITE",
+        stateVersion: 1,
+      }),
+    );
+  });
+});

--- a/realtime/handlers/match-subscription.ts
+++ b/realtime/handlers/match-subscription.ts
@@ -1,22 +1,78 @@
 import type { Socket } from "socket.io";
 
+import { buildGameUpdatePayload } from "@/lib/matches/game-update";
+import { isActiveParticipantForUser } from "@/lib/matches/participant-access";
+import { prisma } from "@/lib/prisma";
+
 import { isMatchSubscribePayload } from "../../shared/match-events-validation";
 import { matchRoomId } from "../lib/rooms";
 
-export function registerMatchSubscription(socket: Socket) {
+type MatchSubscriptionStore = Pick<typeof prisma, "match">;
+
+function emitMatchError(socket: Socket, error: string) {
+  socket.emit("match:error", { error });
+}
+
+export function registerMatchSubscription(socket: Socket, db: MatchSubscriptionStore = prisma) {
   socket.on("match:subscribe", async (payload: unknown) => {
     if (!isMatchSubscribePayload(payload)) {
-      socket.emit("error", { reason: "invalid_payload" });
+      emitMatchError(socket, "invalid_payload");
       return;
     }
 
     const { matchId, participantId } = payload;
+    const userId = socket.data.user?.id;
 
-    const room = matchRoomId(matchId);
-    await socket.join(room);
+    if (typeof userId !== "string" || userId.length === 0) {
+      emitMatchError(socket, "unauthorized");
+      return;
+    }
 
-    console.log(`[realtime] ${socket.id} joined room ${room} as ${participantId}`);
+    try {
+      const match = await db.match.findFirst({
+        where: {
+          id: matchId,
+          participants: {
+            some: {
+              id: participantId,
+              leftAt: null,
+              userId,
+            },
+          },
+        },
+        include: {
+          moves: {
+            orderBy: { moveNumber: "asc" },
+          },
+          participants: true,
+        },
+      });
 
-    socket.emit("match:subscribed", { matchId });
+      if (!match || !isActiveParticipantForUser(match.participants, participantId, userId)) {
+        emitMatchError(socket, "participant_not_found");
+        return;
+      }
+
+      const room = matchRoomId(matchId);
+      await socket.join(room);
+
+      console.log(`[realtime] ${socket.id} joined room ${room} as ${participantId}`);
+
+      socket.emit("match:subscribed", {
+        matchId,
+        stateVersion: match.stateVersion,
+      });
+      socket.emit(
+        "game:update",
+        buildGameUpdatePayload({
+          match,
+          participants: match.participants,
+          moves: match.moves,
+        }),
+      );
+    } catch (error) {
+      console.error("Failed to subscribe to match updates", error);
+      emitMatchError(socket, "failed_to_subscribe");
+    }
   });
 }

--- a/realtime/lib/internal-game-update.test.ts
+++ b/realtime/lib/internal-game-update.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GameUpdatePayload } from "../../shared/match-events";
+import { internalRealtimeSecretHeader } from "../../shared/realtime-internal";
+import { handleInternalGameUpdate } from "./internal-game-update";
+
+const emit = mock((_event: string, _payload: GameUpdatePayload) => {});
+const to = mock((_room: string) => ({ emit }));
+const log = mock((_message: string) => {});
+
+const payload: GameUpdatePayload = {
+  board: [[{ occupied: false }]],
+  boardSize: 1,
+  endReason: null,
+  lastMove: null,
+  matchId: "match-1",
+  moves: [],
+  nextTurnSeat: null,
+  participants: [],
+  stateVersion: 0,
+  status: "WAITING",
+  visibility: "PUBLIC",
+  winningSeat: null,
+};
+
+function jsonRequest(body: unknown, secret = "shared-secret") {
+  return new Request("http://realtime/internal/game-update", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      [internalRealtimeSecretHeader]: secret,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  emit.mockReset();
+  to.mockReset();
+  log.mockReset();
+  to.mockImplementation(() => ({ emit }));
+});
+
+describe("handleInternalGameUpdate", () => {
+  test("rejects requests without the shared internal secret", async () => {
+    const response = await handleInternalGameUpdate(jsonRequest(payload), { to }, null);
+    const responsePayload = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(responsePayload).toEqual({ error: "internal_secret_unconfigured" });
+    expect(to).not.toHaveBeenCalled();
+  });
+
+  test("rejects requests with the wrong shared internal secret", async () => {
+    const response = await handleInternalGameUpdate(
+      jsonRequest(payload, "wrong-secret"),
+      { to },
+      "shared-secret",
+    );
+    const responsePayload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(responsePayload).toEqual({ error: "unauthorized" });
+    expect(to).not.toHaveBeenCalled();
+  });
+
+  test("rejects malformed payloads without broadcasting", async () => {
+    const response = await handleInternalGameUpdate(
+      jsonRequest({ ...payload, moves: undefined }),
+      { to },
+      "shared-secret",
+      { log },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_payload" });
+    expect(to).not.toHaveBeenCalled();
+  });
+
+  test("broadcasts valid game updates to the match room", async () => {
+    const response = await handleInternalGameUpdate(jsonRequest(payload), { to }, "shared-secret", {
+      log,
+    });
+    const responsePayload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(responsePayload).toEqual({ ok: true, room: "match: match-1" });
+    expect(to).toHaveBeenCalledWith("match: match-1");
+    expect(emit).toHaveBeenCalledWith("game:update", payload);
+    expect(log).toHaveBeenCalledTimes(1);
+  });
+});

--- a/realtime/lib/internal-game-update.ts
+++ b/realtime/lib/internal-game-update.ts
@@ -1,0 +1,58 @@
+import type { GameUpdatePayload } from "../../shared/match-events";
+import { isGameUpdatePayload } from "../../shared/match-events-validation";
+import {
+  internalRealtimeSecretHeader,
+  readRealtimeInternalSecret,
+} from "../../shared/realtime-internal";
+import { matchRoomId } from "./rooms";
+
+type RoomEmitter = {
+  emit(event: "game:update", payload: GameUpdatePayload): void;
+};
+
+type GameUpdateServer = {
+  to(room: string): RoomEmitter;
+};
+
+type GameUpdateLogger = Pick<Console, "log">;
+
+function getUnauthorizedResponse() {
+  return Response.json({ error: "unauthorized" }, { status: 401 });
+}
+
+export async function handleInternalGameUpdate(
+  request: Request,
+  io: GameUpdateServer,
+  internalSecret = readRealtimeInternalSecret(),
+  logger: GameUpdateLogger = console,
+) {
+  if (!internalSecret) {
+    return Response.json({ error: "internal_secret_unconfigured" }, { status: 503 });
+  }
+
+  if (request.headers.get(internalRealtimeSecretHeader) !== internalSecret) {
+    return getUnauthorizedResponse();
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return Response.json({ error: "invalid_payload" }, { status: 400 });
+  }
+
+  if (!isGameUpdatePayload(payload)) {
+    return Response.json({ error: "invalid_payload" }, { status: 400 });
+  }
+
+  const room = matchRoomId(payload.matchId);
+
+  io.to(room).emit("game:update", payload);
+  logger.log(`[realtime] broadcast game:update to ${room}`);
+
+  return Response.json({
+    ok: true,
+    room,
+  });
+}

--- a/realtime/server.ts
+++ b/realtime/server.ts
@@ -8,14 +8,13 @@ import { Server } from "socket.io";
 
 import { prisma } from "@/lib/prisma";
 
-import { isGameUpdatePayload } from "../shared/match-events-validation";
 import { readRealtimeInternalSecret } from "../shared/realtime-internal";
 import { registerMatchSubscription } from "./handlers/match-subscription";
 import { registerMatchmakingQueue } from "./handlers/matchmaking-queue";
 import { resolveFriendshipNotificationTarget } from "./lib/friendship-notifications";
 import { handleInternalFriendshipUpdate } from "./lib/internal-friendship-update";
+import { handleInternalGameUpdate } from "./lib/internal-game-update";
 import { removePresenceConnection, subscribeToPresence, type ConnectedUsers } from "./lib/presence";
-import { matchRoomId } from "./lib/rooms";
 import { authenticateSocketSession } from "./lib/socket-auth";
 import {
   DEFAULT_SOCKET_HEARTBEAT_INTERVAL_MS,
@@ -154,31 +153,6 @@ io.on("connection", (socket) => {
 
 const engineHandler = engine.handler();
 
-async function handleInternalGameUpdate(request: Request) {
-  let payload: unknown;
-
-  try {
-    payload = await request.json();
-  } catch {
-    return Response.json({ error: "invalid_payload" }, { status: 400 });
-  }
-
-  if (!isGameUpdatePayload(payload)) {
-    return Response.json({ error: "invalid_payload" }, { status: 400 });
-  }
-
-  const room = matchRoomId(payload.matchId);
-
-  io.to(room).emit("game:update", payload);
-
-  console.log(`[realtime] broadcast game:update to ${room}`);
-
-  return Response.json({
-    ok: true,
-    room,
-  });
-}
-
 Bun.serve({
   hostname,
   port,
@@ -195,7 +169,7 @@ Bun.serve({
     }
 
     if (url.pathname === "/internal/game-update" && request.method === "POST") {
-      return handleInternalGameUpdate(request);
+      return handleInternalGameUpdate(request, io, realtimeInternalSecret);
     }
 
     if (url.pathname === "/internal/friendship-update" && request.method === "POST") {

--- a/shared/match-events-validation.test.ts
+++ b/shared/match-events-validation.test.ts
@@ -11,6 +11,24 @@ const basePayload = {
   nextTurnSeat: "WHITE",
   winningSeat: null,
   endReason: null,
+  moves: [
+    {
+      baseVersion: 0,
+      moveNumber: 1,
+      participantId: "white-player",
+      position: { x: 0, y: 0 },
+      requestId: "request-0",
+      stateVersion: 1,
+    },
+    {
+      baseVersion: 1,
+      moveNumber: 2,
+      participantId: "black-player",
+      position: { x: 1, y: 1 },
+      requestId: "request-1",
+      stateVersion: 2,
+    },
+  ],
   participants: [
     {
       participantId: "black-player",

--- a/shared/match-events-validation.ts
+++ b/shared/match-events-validation.ts
@@ -30,6 +30,9 @@ const lastMoveSchema = z.object({
   requestId: z.string().nullable(),
   stateVersion: z.number().int(),
 });
+const moveSummarySchema = lastMoveSchema.extend({
+  baseVersion: z.number().int().nullable(),
+});
 
 export const gameUpdatePayloadSchema = z.object({
   board: z.array(z.array(cellSchema)),
@@ -37,6 +40,7 @@ export const gameUpdatePayloadSchema = z.object({
   endReason: z.string().nullable(),
   lastMove: lastMoveSchema.nullable(),
   matchId: z.string(),
+  moves: z.array(moveSummarySchema),
   nextTurnSeat: seatSchema.nullable(),
   participants: z.array(participantSummarySchema),
   stateVersion: z.number().int(),
@@ -46,6 +50,7 @@ export const gameUpdatePayloadSchema = z.object({
 });
 
 export const matchSubscribePayloadSchema = z.object({
+  lastSeenStateVersion: z.number().int().nonnegative().optional(),
   matchId: z.string().min(1),
   participantId: z.string().min(1),
 });

--- a/shared/match-events.ts
+++ b/shared/match-events.ts
@@ -1,10 +1,12 @@
 export type MatchSubscribePayload = {
   matchId: string;
   participantId: string;
+  lastSeenStateVersion?: number;
 };
 
 export type MatchSubscribedPayload = {
   matchId: string;
+  stateVersion: number;
 };
 
 export type Seat = "BLACK" | "WHITE";
@@ -28,6 +30,10 @@ export interface LastMove {
   stateVersion: number;
 }
 
+export interface MoveSummary extends LastMove {
+  baseVersion: number | null;
+}
+
 export interface GameUpdatePayload {
   matchId: string;
   status: MatchStatus;
@@ -40,5 +46,6 @@ export interface GameUpdatePayload {
   endReason: string | null;
   participants: ParticipantSummary[];
   lastMove: LastMove | null;
+  moves: MoveSummary[];
   board: Cell[][];
 }


### PR DESCRIPTION
## Summary

Implements issue #31 by making match state synchronization server-authoritative across the HTTP and Socket.IO boundary.

## Changes

- Adds full-state realtime match payloads, including move history, so reconnecting clients can rebuild the same move order and turn state.
- Protects the internal realtime game-update endpoint with the shared realtime secret.
- Authorizes socket match subscriptions and match state/move/resign routes against the authenticated participant.
- Publishes lifecycle updates for match creation, join/start, moves, resignations, and terminal match completion.
- Adds client-side state-version gating and stale-state reload recovery for refresh/reconnect-safe play.
- Adds focused coverage for payload validation, realtime publishing, socket subscription authorization, route authorization, join/start publishing, and stale/duplicate update handling.

## Validation

- `bun test`
- `bun run lint`
- `bun run build`
- `bun run test:e2e -- tests/e2e/human-lobby.e2e.ts --project=chromium`

Closes #31