### PR TITLE
[codex] Enable Cache Components

### DIFF
--- a/app/[locale]/account/page.tsx
+++ b/app/[locale]/account/page.tsx
@@ -1,10 +1,11 @@
 import { Bell, Globe2, KeyRound, LockKeyhole, ShieldCheck, Trash2, UserRound } from "lucide-react";
 import { getFormatter, getTranslations, setRequestLocale } from "next-intl/server";
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 
 import { Badge, PageHeader, PageShell, Surface } from "@/components/gomoku-ui";
 import { LocaleSwitcher } from "@/components/locale-switcher";
 import { LogoutButton } from "@/components/logout-button";
+import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
 import { getCurrentSession, serializeUserForResponse } from "@/lib/auth";
 
@@ -46,7 +47,15 @@ type AccountPageProps = {
   }>;
 };
 
-export default async function AccountPage({ params }: AccountPageProps) {
+export default function AccountPage({ params }: AccountPageProps) {
+  return (
+    <Suspense fallback={<PageLoadingShell />}>
+      <AccountPageContent params={params} />
+    </Suspense>
+  );
+}
+
+async function AccountPageContent({ params }: AccountPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 

--- a/app/[locale]/friends/page.tsx
+++ b/app/[locale]/friends/page.tsx
@@ -1,5 +1,7 @@
 import { setRequestLocale } from "next-intl/server";
+import { Suspense } from "react";
 
+import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
 import { getCurrentSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
@@ -20,7 +22,15 @@ function getSearchQuery(query: string | string[] | undefined) {
   return rawQuery?.trim() ?? "";
 }
 
-export default async function FriendsPage({ params, searchParams }: FriendsPageProps) {
+export default function FriendsPage({ params, searchParams }: FriendsPageProps) {
+  return (
+    <Suspense fallback={<PageLoadingShell />}>
+      <FriendsPageContent params={params} searchParams={searchParams} />
+    </Suspense>
+  );
+}
+
+async function FriendsPageContent({ params, searchParams }: FriendsPageProps) {
   const { locale } = await params;
   const { query } = await searchParams;
   setRequestLocale(locale);

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -7,10 +7,10 @@ import { notFound } from "next/navigation";
 import "../../node_modules/shadcn/dist/tailwind.css";
 import "../../node_modules/tw-animate-css/dist/tw-animate.css";
 import "../globals.css";
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 
 import AppSidebar from "@/components/app-sidebar";
-import { PresenceProvider } from "@/components/presence-provider";
+import { PresenceProvider, PresenceSessionSync } from "@/components/presence-provider";
 import { routing } from "@/i18n/routing";
 import { getCurrentSession } from "@/lib/auth";
 import { cn } from "@/lib/utils";
@@ -61,15 +61,16 @@ export default async function RootLayout({ children, params }: RootLayoutProps) 
   }
 
   setRequestLocale(locale);
-  const context = await getCurrentSession();
-  const username = context?.user?.username;
   const socketUrl = process.env["SOCKET_PUBLIC_URL"];
 
   return (
     <html lang={locale} className={cn("dark font-sans", manrope.variable, cormorant.variable)}>
       <body>
         <NextIntlClientProvider>
-          <PresenceProvider currentUsername={username} socketUrl={socketUrl}>
+          <PresenceProvider socketUrl={socketUrl}>
+            <Suspense fallback={null}>
+              <PresenceSession />
+            </Suspense>
             <a className="skip-link" href="#app-main">
               Skip to Content
             </a>
@@ -81,7 +82,9 @@ export default async function RootLayout({ children, params }: RootLayoutProps) 
               <div className="absolute bottom-[-5rem] left-[var(--sidebar-width)] h-80 w-[720px] rotate-180 bg-[url('/ui/bamboo-accent.svg')] bg-contain bg-left-bottom bg-no-repeat opacity-[0.08] mix-blend-screen" />
             </div>
             <div className="app-frame relative z-10">
-              <AppSidebar />
+              <Suspense fallback={<AppSidebarFallback />}>
+                <AppSidebar />
+              </Suspense>
               <div id="app-main" className="app-content">
                 {children}
               </div>
@@ -90,5 +93,45 @@ export default async function RootLayout({ children, params }: RootLayoutProps) 
         </NextIntlClientProvider>
       </body>
     </html>
+  );
+}
+
+async function PresenceSession() {
+  const context = await getCurrentSession();
+
+  return <PresenceSessionSync username={context?.user.username} />;
+}
+
+function AppSidebarFallback() {
+  return (
+    <>
+      <aside className="app-sidebar" aria-hidden="true">
+        <div className="sidebar-brand">
+          <div className="size-[52px] rounded-md bg-white/[0.08]" />
+          <span className="grid flex-1 gap-2">
+            <span className="h-5 w-36 rounded-sm bg-white/[0.08]" />
+            <span className="h-3 w-28 rounded-sm bg-white/[0.05]" />
+          </span>
+        </div>
+        <div className="mt-8 grid gap-3">
+          <div className="h-4 w-12 rounded-sm bg-white/[0.05]" />
+          <div className="h-11 rounded-md bg-white/[0.05]" />
+          <div className="h-11 rounded-md bg-white/[0.05]" />
+          <div className="h-11 rounded-md bg-white/[0.05]" />
+        </div>
+        <div className="mt-8 grid gap-3">
+          <div className="h-4 w-14 rounded-sm bg-white/[0.05]" />
+          <div className="h-11 rounded-md bg-white/[0.05]" />
+          <div className="h-11 rounded-md bg-white/[0.05]" />
+          <div className="h-11 rounded-md bg-white/[0.05]" />
+        </div>
+        <div className="mt-auto h-28 rounded-md bg-white/[0.05]" />
+      </aside>
+      <header className="mobile-topbar" aria-hidden="true">
+        <div className="size-10 rounded-md bg-white/[0.08]" />
+        <div className="h-5 flex-1 rounded-sm bg-white/[0.06]" />
+        <div className="size-10 rounded-md bg-white/[0.06]" />
+      </header>
+    </>
   );
 }

--- a/app/[locale]/leaderboard/page.tsx
+++ b/app/[locale]/leaderboard/page.tsx
@@ -1,11 +1,12 @@
 import { AlertTriangle, BarChart3, Globe2, Medal, Trophy, Users } from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { connection } from "next/server";
+import { Suspense } from "react";
 
 import { Badge, MetricCard, PageHeader, PageShell, Surface } from "@/components/gomoku-ui";
 import LeaderboardTable from "@/components/leaderboardtable";
+import { PageLoadingShell } from "@/components/page-loading-shell";
 import { getLeaderboardEntries, type LeaderboardEntry } from "@/lib/leaderboard";
-
-export const dynamic = "force-dynamic";
 
 type LeaderBoardProps = {
   params: Promise<{
@@ -13,9 +14,18 @@ type LeaderBoardProps = {
   }>;
 };
 
-export default async function LeaderBoard({ params }: LeaderBoardProps) {
+export default function LeaderBoard({ params }: LeaderBoardProps) {
+  return (
+    <Suspense fallback={<PageLoadingShell />}>
+      <LeaderBoardContent params={params} />
+    </Suspense>
+  );
+}
+
+async function LeaderBoardContent({ params }: LeaderBoardProps) {
   const { locale } = await params;
   setRequestLocale(locale);
+  await connection();
 
   const t = await getTranslations({ locale, namespace: "leaderboard" });
   let entries: LeaderboardEntry[] = [];

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -1,8 +1,10 @@
 import { ShieldCheck, Sparkles } from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Suspense } from "react";
 
 import { BoardShowpiece, PageShell } from "@/components/gomoku-ui";
 import { LoginForm } from "@/components/login-form";
+import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
 import { getCurrentSession } from "@/lib/auth";
 
@@ -12,7 +14,15 @@ type LoginPageProps = {
   }>;
 };
 
-export default async function LoginPage({ params }: LoginPageProps) {
+export default function LoginPage({ params }: LoginPageProps) {
+  return (
+    <Suspense fallback={<PageLoadingShell wide={false} />}>
+      <LoginPageContent params={params} />
+    </Suspense>
+  );
+}
+
+async function LoginPageContent({ params }: LoginPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 

--- a/app/[locale]/messages/page.tsx
+++ b/app/[locale]/messages/page.tsx
@@ -1,5 +1,7 @@
 import { setRequestLocale } from "next-intl/server";
+import { Suspense } from "react";
 
+import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
 import { getCurrentSession } from "@/lib/auth";
 
@@ -11,7 +13,15 @@ type MessagesPageProps = {
   }>;
 };
 
-export default async function MessagesPage({ params }: MessagesPageProps) {
+export default function MessagesPage({ params }: MessagesPageProps) {
+  return (
+    <Suspense fallback={<PageLoadingShell />}>
+      <MessagesPageContent params={params} />
+    </Suspense>
+  );
+}
+
+async function MessagesPageContent({ params }: MessagesPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -3,8 +3,6 @@ import { use } from "react";
 
 import HomeDashboard from "@/components/home-dashboard";
 
-export const dynamic = "force-dynamic";
-
 type HomeProps = {
   params: Promise<{
     locale: string;

--- a/app/[locale]/profile/[username]/page.tsx
+++ b/app/[locale]/profile/[username]/page.tsx
@@ -11,8 +11,10 @@ import {
 } from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 
 import { Badge, MetricCard, PageShell, Surface } from "@/components/gomoku-ui";
+import { PageLoadingShell } from "@/components/page-loading-shell";
 import { getCurrentSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
@@ -35,7 +37,15 @@ const recentMatches = [
 
 const achievements = ["sharpOpening", "calmEndgame", "fastRematch"] as const;
 
-export default async function ProfilePage({ params }: ProfilePageProps) {
+export default function ProfilePage({ params }: ProfilePageProps) {
+  return (
+    <Suspense fallback={<PageLoadingShell />}>
+      <PublicProfilePageContent params={params} />
+    </Suspense>
+  );
+}
+
+async function PublicProfilePageContent({ params }: ProfilePageProps) {
   const { locale, username } = await params;
   setRequestLocale(locale);
   const t = await getTranslations({ locale, namespace: "profile" });

--- a/app/[locale]/profile/edit/page.tsx
+++ b/app/[locale]/profile/edit/page.tsx
@@ -1,7 +1,9 @@
 import { ArrowLeft } from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Suspense } from "react";
 
 import { AvatarToken, Badge, PageHeader, PageShell, Surface } from "@/components/gomoku-ui";
+import { PageLoadingShell } from "@/components/page-loading-shell";
 import { Link, redirect } from "@/i18n/navigation";
 import { getCurrentSession } from "@/lib/auth";
 
@@ -14,7 +16,15 @@ type EditProfilePageProps = {
   }>;
 };
 
-export default async function EditProfilePage({ params }: EditProfilePageProps) {
+export default function EditProfilePage({ params }: EditProfilePageProps) {
+  return (
+    <Suspense fallback={<PageLoadingShell />}>
+      <EditProfilePageContent params={params} />
+    </Suspense>
+  );
+}
+
+async function EditProfilePageContent({ params }: EditProfilePageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 

--- a/app/[locale]/profile/page.tsx
+++ b/app/[locale]/profile/page.tsx
@@ -9,8 +9,10 @@ import {
   UserRound,
 } from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Suspense } from "react";
 
 import { AvatarToken, Badge, MetricCard, PageShell, Surface } from "@/components/gomoku-ui";
+import { PageLoadingShell } from "@/components/page-loading-shell";
 import { Link, redirect } from "@/i18n/navigation";
 import { getCurrentSession } from "@/lib/auth";
 
@@ -41,7 +43,15 @@ const recentMatches = [
   },
 ] as const;
 
-export default async function ProfilePage({ params }: ProfilePageProps) {
+export default function ProfilePage({ params }: ProfilePageProps) {
+  return (
+    <Suspense fallback={<PageLoadingShell />}>
+      <ProfilePageContent params={params} />
+    </Suspense>
+  );
+}
+
+async function ProfilePageContent({ params }: ProfilePageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 

--- a/app/[locale]/signup/page.tsx
+++ b/app/[locale]/signup/page.tsx
@@ -1,7 +1,9 @@
 import { Crown, Swords } from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Suspense } from "react";
 
 import { BoardShowpiece, PageShell } from "@/components/gomoku-ui";
+import { PageLoadingShell } from "@/components/page-loading-shell";
 import { SignupForm } from "@/components/signup-form";
 import { redirect } from "@/i18n/navigation";
 import { getCurrentSession } from "@/lib/auth";
@@ -12,7 +14,15 @@ type SignupPageProps = {
   }>;
 };
 
-export default async function SignupPage({ params }: SignupPageProps) {
+export default function SignupPage({ params }: SignupPageProps) {
+  return (
+    <Suspense fallback={<PageLoadingShell wide={false} />}>
+      <SignupPageContent params={params} />
+    </Suspense>
+  );
+}
+
+async function SignupPageContent({ params }: SignupPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -7,8 +7,6 @@ import { resolveApiLocale } from "../../../lib/i18n/api";
 import { prisma } from "../../../lib/prisma";
 import { fieldIssuesToMap, validateLoginInput } from "../../../lib/validation/auth-profile";
 
-export const dynamic = "force-dynamic";
-
 type LoginBody = {
   email?: unknown;
   password?: unknown;

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -2,8 +2,6 @@ import { headers } from "next/headers";
 
 import { auth } from "../../../lib/auth";
 
-export const dynamic = "force-dynamic";
-
 export async function POST() {
   const authResponse = await auth.api
     .signOut({

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -4,8 +4,6 @@ import { apiErrorResponse } from "../../../lib/api-errors";
 import { getCurrentSession, serializeUserForResponse } from "../../../lib/auth";
 import { resolveApiLocale } from "../../../lib/i18n/api";
 
-export const dynamic = "force-dynamic";
-
 export async function GET(request: Request) {
   const context = await getCurrentSession();
   const t = await getTranslations({ locale: resolveApiLocale(request), namespace: "auth.errors" });

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -15,8 +15,6 @@ import { resolveApiLocale } from "../../../lib/i18n/api";
 import { prisma } from "../../../lib/prisma";
 import { fieldIssuesToMap, validateSignupInput } from "../../../lib/validation/auth-profile";
 
-export const dynamic = "force-dynamic";
-
 type SignupBody = {
   displayName?: unknown;
   email?: unknown;

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,7 +1,5 @@
 import { prisma } from "../../lib/prisma";
 
-export const dynamic = "force-dynamic";
-
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }

--- a/app/api/matches/[id]/ai-turn/route.ts
+++ b/app/api/matches/[id]/ai-turn/route.ts
@@ -15,8 +15,6 @@ import { publishGameUpdate } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 import { syncUserGameStatsForUser } from "@/lib/stats/result-sync";
 
-export const dynamic = "force-dynamic";
-
 type AiTurnRequestBody = {
   baseVersion?: unknown;
   participantId?: unknown;

--- a/app/api/matches/[id]/cancel/route.ts
+++ b/app/api/matches/[id]/cancel/route.ts
@@ -7,8 +7,6 @@ import { isActiveParticipantForUser } from "@/lib/matches/participant-access";
 import { publishGameUpdate } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 
-export const dynamic = "force-dynamic";
-
 const endReasonHostCancelled = "host_cancelled";
 
 function getErrorMessage(error: unknown): string {

--- a/app/api/matches/[id]/challenge/decline/route.ts
+++ b/app/api/matches/[id]/challenge/decline/route.ts
@@ -6,8 +6,6 @@ import { getChallengeMatchMetadata } from "@/lib/matches/challenge-metadata";
 import { publishChallengeDeclined } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 
-export const dynamic = "force-dynamic";
-
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }

--- a/app/api/matches/[id]/join/route.ts
+++ b/app/api/matches/[id]/join/route.ts
@@ -9,8 +9,6 @@ import { buildGameUpdatePayload } from "@/lib/matches/game-update";
 import { publishGameUpdate, publishQueueMatched } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 
-export const dynamic = "force-dynamic";
-
 const joinMatchRequestSchema = z.preprocess(
   (value) => (typeof value === "object" && value !== null && !Array.isArray(value) ? value : {}),
   z.object({

--- a/app/api/matches/[id]/moves/route.ts
+++ b/app/api/matches/[id]/moves/route.ts
@@ -9,8 +9,6 @@ import { publishGameUpdate } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 import { syncUserGameStatsForUser } from "@/lib/stats/result-sync";
 
-export const dynamic = "force-dynamic";
-
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }

--- a/app/api/matches/[id]/resign/route.ts
+++ b/app/api/matches/[id]/resign/route.ts
@@ -9,8 +9,6 @@ import { publishGameUpdate } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 import { syncUserGameStatsForUser } from "@/lib/stats/result-sync";
 
-export const dynamic = "force-dynamic";
-
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }

--- a/app/api/matches/[id]/state/route.ts
+++ b/app/api/matches/[id]/state/route.ts
@@ -4,8 +4,6 @@ import { getSoloMatchMetadata } from "@/lib/matches/ai-solo";
 import { isActiveParticipantForUser } from "@/lib/matches/participant-access";
 import { prisma } from "@/lib/prisma";
 
-export const dynamic = "force-dynamic";
-
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }

--- a/app/api/matches/challenge/route.ts
+++ b/app/api/matches/challenge/route.ts
@@ -17,8 +17,6 @@ import { standardGomokuBoardSize } from "@/lib/matches/move-rules";
 import { publishChallengeReceived, publishGameUpdate } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 
-export const dynamic = "force-dynamic";
-
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }

--- a/app/api/matches/history/route.ts
+++ b/app/api/matches/history/route.ts
@@ -5,8 +5,6 @@ import {
   normalizeMatchHistoryLimit,
 } from "@/lib/matches/match-history";
 
-export const dynamic = "force-dynamic";
-
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }

--- a/app/api/matches/queue/route.ts
+++ b/app/api/matches/queue/route.ts
@@ -5,8 +5,6 @@ import {
   joinMatchmakingQueue,
 } from "@/lib/matches/matchmaking";
 
-export const dynamic = "force-dynamic";
-
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }

--- a/app/api/matches/route.ts
+++ b/app/api/matches/route.ts
@@ -8,8 +8,6 @@ import { standardGomokuBoardSize } from "@/lib/matches/move-rules";
 import { publishGameUpdate } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 
-export const dynamic = "force-dynamic";
-
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }

--- a/app/api/matches/solo/route.ts
+++ b/app/api/matches/solo/route.ts
@@ -8,8 +8,6 @@ import { evaluateMoveOutcome, standardGomokuBoardSize } from "@/lib/matches/move
 import { publishGameUpdate } from "@/lib/matches/realtime-publisher";
 import { prisma } from "@/lib/prisma";
 
-export const dynamic = "force-dynamic";
-
 type SoloMatchRequestBody = {
   difficulty?: unknown;
   playerSeat?: unknown;

--- a/app/components/page-loading-shell.tsx
+++ b/app/components/page-loading-shell.tsx
@@ -1,0 +1,27 @@
+import { PageShell } from "@/components/gomoku-ui";
+
+export function PageLoadingShell({ wide = true }: { wide?: boolean }) {
+  return (
+    <PageShell wide={wide} className="grid gap-5">
+      <div className="command-panel min-h-44 animate-pulse">
+        <div className="h-4 w-28 rounded-sm bg-white/[0.08]" />
+        <div className="mt-6 h-12 w-full max-w-md rounded-sm bg-white/[0.08]" />
+        <div className="mt-5 h-5 w-full max-w-2xl rounded-sm bg-white/[0.06]" />
+      </div>
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_340px]">
+        <div className="surface-panel min-h-80 animate-pulse">
+          <div className="h-6 w-40 rounded-sm bg-white/[0.08]" />
+          <div className="mt-6 grid gap-3">
+            <div className="h-14 rounded-md bg-white/[0.05]" />
+            <div className="h-14 rounded-md bg-white/[0.05]" />
+            <div className="h-14 rounded-md bg-white/[0.05]" />
+          </div>
+        </div>
+        <div className="surface-panel min-h-60 animate-pulse">
+          <div className="h-6 w-32 rounded-sm bg-white/[0.08]" />
+          <div className="mt-6 h-28 rounded-md bg-white/[0.05]" />
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/app/components/presence-provider.tsx
+++ b/app/components/presence-provider.tsx
@@ -9,11 +9,13 @@ import { ChallengeListener } from "./challenge-listener";
 
 type PresenceContextType = {
   onlineUsers: string[];
+  setCurrentUsername: (username?: string) => void;
   socket: Socket | null;
 };
 
 const PresenceContext = createContext<PresenceContextType>({
   onlineUsers: [],
+  setCurrentUsername: () => undefined,
   socket: null,
 });
 
@@ -27,10 +29,15 @@ export function PresenceProvider({
   socketUrl?: string;
 }) {
   const [onlineUsers, setOnlineUsers] = useState<string[]>([]);
+  const [activeUsername, setCurrentUsername] = useState(currentUsername);
   const [socket, setSocket] = useState<Socket | null>(null);
 
   useEffect(() => {
-    if (!currentUsername) {
+    setCurrentUsername(currentUsername);
+  }, [currentUsername]);
+
+  useEffect(() => {
+    if (!activeUsername) {
       setOnlineUsers([]);
       setSocket(null);
       return;
@@ -42,8 +49,7 @@ export function PresenceProvider({
 
     const handleConnect = () => {
       nextSocket.emit("presence:subscribe");
-      // IMPORTANT
-      nextSocket.emit("register", currentUsername);
+      nextSocket.emit("register", activeUsername);
     };
 
     const handlePresenceUpdate = (users: string[]) => {
@@ -69,12 +75,13 @@ export function PresenceProvider({
       nextSocket.disconnect();
       setSocket(null);
     };
-  }, [currentUsername, socketUrl]);
+  }, [activeUsername, socketUrl]);
 
   return (
     <PresenceContext.Provider
       value={{
         onlineUsers,
+        setCurrentUsername,
         socket,
       }}
     >
@@ -86,4 +93,14 @@ export function PresenceProvider({
 
 export function usePresence() {
   return useContext(PresenceContext);
+}
+
+export function PresenceSessionSync({ username }: { username?: string }) {
+  const { setCurrentUsername } = usePresence();
+
+  useEffect(() => {
+    setCurrentUsername(username);
+  }, [setCurrentUsername, username]);
+
+  return null;
 }

--- a/app/lib/leaderboard.ts
+++ b/app/lib/leaderboard.ts
@@ -1,3 +1,5 @@
+import { cacheLife } from "next/cache";
+
 import type { Prisma } from "../../generated/prisma/client";
 import { prisma } from "./prisma";
 
@@ -67,6 +69,9 @@ export function toLeaderboardEntries(stats: LeaderboardStat[]): LeaderboardEntry
 }
 
 export async function getLeaderboardEntries(): Promise<LeaderboardEntry[]> {
+  "use cache";
+  cacheLife("minutes");
+
   const stats = await prisma.userGameStats.findMany(leaderboardQueryArgs);
 
   return toLeaderboardEntries(stats);

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,10 @@ const currentDirectory = dirname(fileURLToPath(import.meta.url));
 const withNextIntl = createNextIntlPlugin("./app/i18n/request.ts");
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    instantNavigationDevToolsToggle: true,
+  },
   turbopack: {
     root: currentDirectory,
   },

--- a/tests/e2e/smoke.e2e.ts
+++ b/tests/e2e/smoke.e2e.ts
@@ -126,7 +126,9 @@ test("authenticated redesigned pages render at desktop and mobile widths", async
   try {
     await gotoAppRoute(page, "/account");
     await expect(page.getByRole("heading", { level: 1, name: "Account Settings" })).toBeVisible();
-    await expect(page.getByText(user.email, { exact: true })).toBeVisible();
+    await expect(
+      page.getByText(user.email, { exact: true }).filter({ visible: true }),
+    ).toBeVisible();
     await expectNoDocumentOverflow(page, "/account");
 
     await gotoAppRoute(page, "/profile");
@@ -140,13 +142,15 @@ test("authenticated redesigned pages render at desktop and mobile widths", async
 
     await gotoAppRoute(page, "/friends");
     await expect(page.getByRole("heading", { level: 1, name: "Friends" })).toBeVisible();
-    await expect(page.getByText(friend.displayName, { exact: true })).toBeVisible();
-    await expect(page.getByTestId("friends-table")).toBeVisible();
+    await expect(
+      page.getByText(friend.displayName, { exact: true }).filter({ visible: true }),
+    ).toBeVisible();
+    await expect(page.getByTestId("friends-table").filter({ visible: true })).toBeVisible();
     await expectNoDocumentOverflow(page, "/friends");
 
     await gotoAppRoute(page, "/messages");
     await expect(page.getByRole("heading", { level: 1, name: "Messages" })).toBeVisible();
-    await expect(page.getByPlaceholder("Message MJ...")).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Message MJ..." })).toBeVisible();
     await expectNoDocumentOverflow(page, "/messages");
   } finally {
     await cleanupTestUsers([user.username, friend.username]);


### PR DESCRIPTION
## Summary

- Enable Next.js Cache Components and Instant Navs devtools support.
- Remove incompatible `dynamic = "force-dynamic"` route segment exports now that routes are dynamic by default under Cache Components.
- Add Suspense boundaries and loading shells for session/runtime-backed pages so the app can partially prerender and stream dynamic content.
- Keep presence/session wiring dynamic without blocking the root layout, and cache leaderboard reads with a short cache lifetime while deferring the page to request time.

## Impact

App routes now build as Partial Prerendered (`◐`) routes with dynamic content streamed behind fallbacks. API routes remain dynamic. Developers can use the Next DevTools Instant Navs panel to inspect the initial shell during local development.

## Validation

- `bun run build`
- `bun run lint`
- `bun test`
- `bun run format:check`
- Browser smoke test for `/en` and `/en/login` through the repo webapp-testing server helper

Note: `gh` is not installed in this environment, so this PR was created through the GitHub connector after pushing the branch with git.