### PR TITLE
Expand test coverage for auth and matches

### DIFF
--- a/app/[locale]/friends/actions.test.ts
+++ b/app/[locale]/friends/actions.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
+
+const getLocale = mock();
+const getTranslations = mock();
+const revalidatePath = mock();
+const getCurrentSession = mock();
+const findUser = mock();
+const findFriendship = mock();
+const createFriendship = mock();
+const updateFriendship = mock();
+const deleteFriendshipAndNotify = mock();
+
+await mock.module("next-intl/server", () => ({
+  getLocale,
+  getTranslations,
+}));
+
+await mock.module("next/cache", () => ({
+  revalidatePath,
+}));
+
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
+
+await mock.module("@/lib/prisma", () => ({
+  prisma: {
+    friendship: {
+      create: createFriendship,
+      findUnique: findFriendship,
+      update: updateFriendship,
+    },
+    user: {
+      findUnique: findUser,
+    },
+  },
+}));
+
+await mock.module("@/lib/friendships/friendship-mutations", () => ({
+  deleteFriendshipAndNotify,
+  getLowHighIds: (left: string, right: string) =>
+    left < right ? { userLowId: left, userHighId: right } : { userLowId: right, userHighId: left },
+}));
+
+const { removeFriend, respondToRequest, sendFriendRequest } = await import("./actions");
+
+const session = {
+  user: {
+    id: "user-ada",
+  },
+};
+const targetUser = {
+  id: "user-grace",
+  username: "grace",
+};
+const pendingFriendship = {
+  id: 42,
+  requestedById: "user-grace",
+  status: "PENDING",
+  userHighId: "user-grace",
+  userLowId: "user-ada",
+};
+
+beforeEach(() => {
+  getLocale.mockReset();
+  getTranslations.mockReset();
+  revalidatePath.mockReset();
+  getCurrentSession.mockReset();
+  findUser.mockReset();
+  findFriendship.mockReset();
+  createFriendship.mockReset();
+  updateFriendship.mockReset();
+  deleteFriendshipAndNotify.mockReset();
+
+  getLocale.mockResolvedValue("en");
+  getTranslations.mockImplementation(
+    async ({ namespace }: { namespace: string }) =>
+      (key: string) =>
+        `${namespace}:${key}`,
+  );
+  getCurrentSession.mockResolvedValue(session);
+  findUser.mockResolvedValue(targetUser);
+  findFriendship.mockResolvedValue(null);
+  createFriendship.mockResolvedValue({});
+  updateFriendship.mockResolvedValue({});
+  deleteFriendshipAndNotify.mockResolvedValue(undefined);
+});
+
+describe("sendFriendRequest", () => {
+  test("requires authentication before looking up the target player", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const result = await sendFriendRequest("grace");
+
+    expect(result).toEqual({ error: "friends:actions.signInToAddFriends" });
+    expect(findUser).not.toHaveBeenCalled();
+    expect(createFriendship).not.toHaveBeenCalled();
+  });
+
+  test("rejects self-friend requests and existing friendships", async () => {
+    findUser.mockResolvedValueOnce({ id: "user-ada", username: "ada" });
+
+    expect(await sendFriendRequest("ada")).toEqual({
+      error: "friends:actions.cannotAddYourself",
+    });
+    expect(createFriendship).not.toHaveBeenCalled();
+
+    findUser.mockResolvedValueOnce(targetUser);
+    findFriendship.mockResolvedValueOnce(pendingFriendship);
+
+    expect(await sendFriendRequest("grace")).toEqual({
+      error: "friends:actions.alreadyFriendsOrPending",
+    });
+  });
+
+  test("creates a pending friendship and revalidates shared navigation", async () => {
+    const result = await sendFriendRequest("grace");
+
+    expect(result).toEqual({ success: true });
+    expect(createFriendship).toHaveBeenCalledWith({
+      data: {
+        requestedById: "user-ada",
+        status: "PENDING",
+        userHighId: "user-grace",
+        userLowId: "user-ada",
+      },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
+  });
+});
+
+describe("respondToRequest", () => {
+  test("rejects missing, unauthorized, and self-request transitions", async () => {
+    findFriendship.mockResolvedValueOnce(null);
+
+    expect(await respondToRequest(42, true)).toEqual({
+      error: "friends:actions.requestNotFound",
+    });
+
+    findFriendship.mockResolvedValueOnce({
+      ...pendingFriendship,
+      userHighId: "user-grace",
+      userLowId: "user-marie",
+    });
+
+    expect(await respondToRequest(42, true)).toEqual({
+      error: "friends:actions.unauthorized",
+    });
+
+    findFriendship.mockResolvedValueOnce({
+      ...pendingFriendship,
+      requestedById: "user-ada",
+    });
+
+    expect(await respondToRequest(42, true)).toEqual({
+      error: "friends:actions.invalidTransition",
+    });
+  });
+
+  test("accepts pending requests not created by the signed-in user", async () => {
+    findFriendship.mockResolvedValueOnce(pendingFriendship);
+
+    const result = await respondToRequest(42, true);
+
+    expect(result).toEqual({ success: true });
+    expect(updateFriendship).toHaveBeenCalledWith({
+      data: {
+        acceptedAt: expect.any(Date),
+        respondedAt: expect.any(Date),
+        status: "ACCEPTED",
+      },
+      where: { id: 42 },
+    });
+    expect(deleteFriendshipAndNotify).not.toHaveBeenCalled();
+    expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
+  });
+
+  test("declines requests through the shared delete-and-notify path", async () => {
+    findFriendship.mockResolvedValueOnce(pendingFriendship);
+
+    const result = await respondToRequest(42, false);
+
+    expect(result).toEqual({ success: true });
+    expect(deleteFriendshipAndNotify).toHaveBeenCalledWith(pendingFriendship);
+    expect(updateFriendship).not.toHaveBeenCalled();
+  });
+});
+
+describe("removeFriend", () => {
+  test("requires ownership before removing a friendship", async () => {
+    findFriendship.mockResolvedValueOnce({
+      ...pendingFriendship,
+      userHighId: "user-grace",
+      userLowId: "user-marie",
+    });
+
+    const result = await removeFriend(42);
+
+    expect(result).toEqual({ error: "friends:actions.unauthorized" });
+    expect(deleteFriendshipAndNotify).not.toHaveBeenCalled();
+  });
+
+  test("removes owned friendships through the shared delete-and-notify path", async () => {
+    findFriendship.mockResolvedValueOnce(pendingFriendship);
+
+    const result = await removeFriend(42);
+
+    expect(result).toEqual({ success: true });
+    expect(deleteFriendshipAndNotify).toHaveBeenCalledWith(pendingFriendship);
+    expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
+  });
+});

--- a/app/[locale]/friends/actions.test.ts
+++ b/app/[locale]/friends/actions.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
 
@@ -7,10 +7,15 @@ const getTranslations = mock();
 const revalidatePath = mock();
 const getCurrentSession = mock();
 const findUser = mock();
+const findManyUsers = mock();
 const findFriendship = mock();
 const createFriendship = mock();
+const deleteFriendship = mock();
 const updateFriendship = mock();
-const deleteFriendshipAndNotify = mock();
+const fetchMock = mock(async () => new Response(null, { status: 200 }));
+const originalFetch = globalThis.fetch;
+const originalRealtimeInternalSecret = process.env["REALTIME_INTERNAL_SECRET"];
+const originalRealtimeFriendshipInternalUrl = process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"];
 
 await mock.module("next-intl/server", () => ({
   getLocale,
@@ -31,19 +36,15 @@ await mock.module("@/lib/prisma", () => ({
   prisma: {
     friendship: {
       create: createFriendship,
+      delete: deleteFriendship,
       findUnique: findFriendship,
       update: updateFriendship,
     },
     user: {
+      findMany: findManyUsers,
       findUnique: findUser,
     },
   },
-}));
-
-await mock.module("@/lib/friendships/friendship-mutations", () => ({
-  deleteFriendshipAndNotify,
-  getLowHighIds: (left: string, right: string) =>
-    left < right ? { userLowId: left, userHighId: right } : { userLowId: right, userHighId: left },
 }));
 
 const { removeFriend, respondToRequest, sendFriendRequest } = await import("./actions");
@@ -71,11 +72,17 @@ beforeEach(() => {
   revalidatePath.mockReset();
   getCurrentSession.mockReset();
   findUser.mockReset();
+  findManyUsers.mockReset();
   findFriendship.mockReset();
   createFriendship.mockReset();
+  deleteFriendship.mockReset();
   updateFriendship.mockReset();
-  deleteFriendshipAndNotify.mockReset();
+  fetchMock.mockReset();
 
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  process.env["REALTIME_INTERNAL_SECRET"] = "friend-secret";
+  process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"] =
+    "http://localhost:3001/internal/friendship-update";
   getLocale.mockResolvedValue("en");
   getTranslations.mockImplementation(
     async ({ namespace }: { namespace: string }) =>
@@ -84,10 +91,31 @@ beforeEach(() => {
   );
   getCurrentSession.mockResolvedValue(session);
   findUser.mockResolvedValue(targetUser);
+  findManyUsers.mockResolvedValue([
+    { id: "user-ada", username: "ada" },
+    { id: "user-grace", username: "grace" },
+  ]);
   findFriendship.mockResolvedValue(null);
   createFriendship.mockResolvedValue({});
+  deleteFriendship.mockResolvedValue({});
   updateFriendship.mockResolvedValue({});
-  deleteFriendshipAndNotify.mockResolvedValue(undefined);
+  fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+
+  if (originalRealtimeInternalSecret === undefined) {
+    delete process.env["REALTIME_INTERNAL_SECRET"];
+  } else {
+    process.env["REALTIME_INTERNAL_SECRET"] = originalRealtimeInternalSecret;
+  }
+
+  if (originalRealtimeFriendshipInternalUrl === undefined) {
+    delete process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"];
+  } else {
+    process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"] = originalRealtimeFriendshipInternalUrl;
+  }
 });
 
 describe("sendFriendRequest", () => {
@@ -175,7 +203,7 @@ describe("respondToRequest", () => {
       },
       where: { id: 42 },
     });
-    expect(deleteFriendshipAndNotify).not.toHaveBeenCalled();
+    expect(deleteFriendship).not.toHaveBeenCalled();
     expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
   });
 
@@ -185,7 +213,14 @@ describe("respondToRequest", () => {
     const result = await respondToRequest(42, false);
 
     expect(result).toEqual({ success: true });
-    expect(deleteFriendshipAndNotify).toHaveBeenCalledWith(pendingFriendship);
+    expect(deleteFriendship).toHaveBeenCalledWith({ where: { id: 42 } });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/internal/friendship-update",
+      expect.objectContaining({
+        body: JSON.stringify({ usernames: ["ada", "grace"] }),
+        method: "POST",
+      }),
+    );
     expect(updateFriendship).not.toHaveBeenCalled();
   });
 });
@@ -201,7 +236,7 @@ describe("removeFriend", () => {
     const result = await removeFriend(42);
 
     expect(result).toEqual({ error: "friends:actions.unauthorized" });
-    expect(deleteFriendshipAndNotify).not.toHaveBeenCalled();
+    expect(deleteFriendship).not.toHaveBeenCalled();
   });
 
   test("removes owned friendships through the shared delete-and-notify path", async () => {
@@ -210,7 +245,8 @@ describe("removeFriend", () => {
     const result = await removeFriend(42);
 
     expect(result).toEqual({ success: true });
-    expect(deleteFriendshipAndNotify).toHaveBeenCalledWith(pendingFriendship);
+    expect(deleteFriendship).toHaveBeenCalledWith({ where: { id: 42 } });
+    expect(fetchMock).toHaveBeenCalled();
     expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
   });
 });

--- a/app/[locale]/profile/[username]/actions.test.ts
+++ b/app/[locale]/profile/[username]/actions.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
+
 const getCurrentSession = mock();
 const findFriendship = mock();
 const createFriendship = mock();
@@ -11,9 +13,11 @@ await mock.module("next/cache", () => ({
   revalidatePath,
 }));
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 await mock.module("@/lib/prisma", () => ({
   prisma: {

--- a/app/[locale]/profile/[username]/actions.test.ts
+++ b/app/[locale]/profile/[username]/actions.test.ts
@@ -1,13 +1,18 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
 
 const getCurrentSession = mock();
+const findManyUsers = mock();
 const findFriendship = mock();
 const createFriendship = mock();
+const deleteFriendship = mock();
 const updateFriendship = mock();
-const deleteFriendshipAndNotify = mock();
 const revalidatePath = mock();
+const fetchMock = mock(async () => new Response(null, { status: 200 }));
+const originalFetch = globalThis.fetch;
+const originalRealtimeInternalSecret = process.env["REALTIME_INTERNAL_SECRET"];
+const originalRealtimeFriendshipInternalUrl = process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"];
 
 await mock.module("next/cache", () => ({
   revalidatePath,
@@ -23,16 +28,14 @@ await mock.module("@/lib/prisma", () => ({
   prisma: {
     friendship: {
       create: createFriendship,
+      delete: deleteFriendship,
       findUnique: findFriendship,
       update: updateFriendship,
     },
+    user: {
+      findMany: findManyUsers,
+    },
   },
-}));
-
-await mock.module("@/lib/friendships/friendship-mutations", () => ({
-  deleteFriendshipAndNotify,
-  getLowHighIds: (id1: string, id2: string) =>
-    id1 < id2 ? { userLowId: id1, userHighId: id2 } : { userLowId: id2, userHighId: id1 },
 }));
 
 const { processFriendAction } = await import("./actions");
@@ -47,17 +50,44 @@ const friendship = {
 
 beforeEach(() => {
   getCurrentSession.mockReset();
+  findManyUsers.mockReset();
   findFriendship.mockReset();
   createFriendship.mockReset();
+  deleteFriendship.mockReset();
   updateFriendship.mockReset();
-  deleteFriendshipAndNotify.mockReset();
   revalidatePath.mockReset();
+  fetchMock.mockReset();
 
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  process.env["REALTIME_INTERNAL_SECRET"] = "friend-secret";
+  process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"] =
+    "http://localhost:3001/internal/friendship-update";
   getCurrentSession.mockResolvedValue({
     user: { id: "user-a" },
   });
+  findManyUsers.mockResolvedValue([
+    { id: "user-a", username: "ada" },
+    { id: "user-b", username: "bob" },
+  ]);
   findFriendship.mockResolvedValue(friendship);
-  deleteFriendshipAndNotify.mockResolvedValue(undefined);
+  deleteFriendship.mockResolvedValue({});
+  fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+
+  if (originalRealtimeInternalSecret === undefined) {
+    delete process.env["REALTIME_INTERNAL_SECRET"];
+  } else {
+    process.env["REALTIME_INTERNAL_SECRET"] = originalRealtimeInternalSecret;
+  }
+
+  if (originalRealtimeFriendshipInternalUrl === undefined) {
+    delete process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"];
+  } else {
+    process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"] = originalRealtimeFriendshipInternalUrl;
+  }
 });
 
 describe("processFriendAction", () => {
@@ -65,7 +95,14 @@ describe("processFriendAction", () => {
     const result = await processFriendAction("user-b", "REMOVE");
 
     expect(result).toEqual({ success: true });
-    expect(deleteFriendshipAndNotify).toHaveBeenCalledWith(friendship);
+    expect(deleteFriendship).toHaveBeenCalledWith({ where: { id: 42 } });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/internal/friendship-update",
+      expect.objectContaining({
+        body: JSON.stringify({ usernames: ["ada", "bob"] }),
+        method: "POST",
+      }),
+    );
     expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
   });
 
@@ -81,6 +118,6 @@ describe("processFriendAction", () => {
     const result = await processFriendAction("user-b", "DECLINE");
 
     expect(result).toEqual({ success: true });
-    expect(deleteFriendshipAndNotify).toHaveBeenCalledWith(pendingFriendship);
+    expect(deleteFriendship).toHaveBeenCalledWith({ where: { id: 42 } });
   });
 });

--- a/app/[locale]/profile/actions.test.ts
+++ b/app/[locale]/profile/actions.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
+
+const mkdir = mock();
+const writeFile = mock();
+const getLocale = mock();
+const getTranslations = mock();
+const revalidatePath = mock();
+const getCurrentSession = mock();
+const updateUser = mock();
+
+await mock.module("fs/promises", () => ({
+  mkdir,
+  writeFile,
+}));
+
+await mock.module("next-intl/server", () => ({
+  getLocale,
+  getTranslations,
+}));
+
+await mock.module("next/cache", () => ({
+  revalidatePath,
+}));
+
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
+
+await mock.module("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      update: updateUser,
+    },
+  },
+}));
+
+const { uploadProfilePicture } = await import("./actions");
+
+beforeEach(() => {
+  mkdir.mockReset();
+  writeFile.mockReset();
+  getLocale.mockReset();
+  getTranslations.mockReset();
+  revalidatePath.mockReset();
+  getCurrentSession.mockReset();
+  updateUser.mockReset();
+
+  mkdir.mockResolvedValue(undefined);
+  writeFile.mockResolvedValue(undefined);
+  getLocale.mockResolvedValue("en");
+  getTranslations.mockImplementation(
+    async ({ namespace }: { namespace: string }) =>
+      (key: string) =>
+        `${namespace}:${key}`,
+  );
+  getCurrentSession.mockResolvedValue({
+    user: {
+      id: "user-ada",
+    },
+  });
+  updateUser.mockResolvedValue({});
+});
+
+describe("uploadProfilePicture", () => {
+  test("requires authentication before reading uploaded files", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const result = await uploadProfilePicture(formDataWithFile(pngFile()));
+
+    expect(result).toEqual({ error: "profile.errors:loginRequired" });
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  test("rejects missing, empty, oversized, and unsupported files", async () => {
+    expect(await uploadProfilePicture(new FormData())).toEqual({
+      error: "profile.errors:noFile",
+    });
+
+    expect(await uploadProfilePicture(formDataWithFile(new File([], "empty.png")))).toEqual({
+      error: "profile.errors:noFile",
+    });
+
+    expect(
+      await uploadProfilePicture(
+        formDataWithFile(new File([new Uint8Array(5 * 1024 * 1024 + 1)], "big.png")),
+      ),
+    ).toEqual({
+      error: "profile.errors:imageTooLarge",
+    });
+
+    expect(
+      await uploadProfilePicture(formDataWithFile(new File(["not an image"], "avatar.txt"))),
+    ).toEqual({
+      error: "profile.errors:invalidImage",
+    });
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  test("stores supported image uploads and updates the user's avatar URL", async () => {
+    const result = await uploadProfilePicture(formDataWithFile(pngFile()));
+
+    expect(result).toEqual({ success: true });
+    expect(mkdir).toHaveBeenCalledWith(expect.stringContaining("public/uploads"), {
+      recursive: true,
+    });
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("user-ada-"),
+      expect.any(Buffer),
+    );
+    expect(updateUser).toHaveBeenCalledWith({
+      data: {
+        avatarUrl: expect.stringMatching(/^\/uploads\/user-ada-\d+\.png$/),
+      },
+      where: { id: "user-ada" },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith("/");
+  });
+
+  test("returns a translated save failure when storage or persistence throws", async () => {
+    writeFile.mockRejectedValueOnce(new Error("disk full"));
+
+    const result = await uploadProfilePicture(formDataWithFile(pngFile()));
+
+    expect(result).toEqual({ error: "profile.errors:pictureSaveFailed" });
+  });
+});
+
+function formDataWithFile(file: File) {
+  const data = new FormData();
+  data.set("file", file);
+  return data;
+}
+
+function pngFile() {
+  return new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0, 0, 0, 0, 0])], "avatar.png", {
+    type: "image/png",
+  });
+}

--- a/app/api/auth/auth-routes.test.ts
+++ b/app/api/auth/auth-routes.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { APIError } from "better-auth/api";
 
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
+
 await mock.module("server-only", () => ({}));
 await mock.module("next-intl/server", () => ({
   getLocale: async () => "en",
@@ -38,24 +40,19 @@ const user = {
   emailVerifiedAt: null,
 };
 
-await mock.module("../../lib/auth", () => ({
-  auth: {
-    api: {
-      changePassword,
-      signInEmail,
-      signUpEmail,
+await mock.module("../../lib/auth", () =>
+  createAuthModuleMock({
+    auth: {
+      api: {
+        changePassword,
+        signInEmail,
+        signUpEmail,
+      },
     },
-  },
-  getCurrentSession,
-  getDuplicateSignupFields,
-  serializeUserForResponse: (value: typeof user) => ({
-    id: value.id,
-    username: value.username,
-    displayName: value.displayName,
-    email: value.email,
-    emailVerified: value.emailVerified || Boolean(value.emailVerifiedAt),
+    getCurrentSession,
+    getDuplicateSignupFields,
   }),
-}));
+);
 
 await mock.module("../../lib/prisma", () => ({
   prisma: {
@@ -65,24 +62,19 @@ await mock.module("../../lib/prisma", () => ({
     },
   },
 }));
-await mock.module("@/lib/auth", () => ({
-  auth: {
-    api: {
-      changePassword,
-      signInEmail,
-      signUpEmail,
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    auth: {
+      api: {
+        changePassword,
+        signInEmail,
+        signUpEmail,
+      },
     },
-  },
-  getCurrentSession,
-  getDuplicateSignupFields,
-  serializeUserForResponse: (value: typeof user) => ({
-    id: value.id,
-    username: value.username,
-    displayName: value.displayName,
-    email: value.email,
-    emailVerified: value.emailVerified || Boolean(value.emailVerifiedAt),
+    getCurrentSession,
+    getDuplicateSignupFields,
   }),
-}));
+);
 await mock.module("@/lib/prisma", () => ({
   prisma: {
     user: {
@@ -110,6 +102,16 @@ function jsonRequest(path: string, body: unknown) {
       "content-type": "application/json",
     },
     body: JSON.stringify(body),
+  });
+}
+
+function malformedJsonRequest(path: string) {
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: "{",
   });
 }
 
@@ -154,6 +156,40 @@ beforeEach(() => {
 });
 
 describe("auth API routes", () => {
+  test("login rejects malformed request bodies before credential lookup", async () => {
+    const response = await loginRoute.POST(malformedJsonRequest("/api/auth/login"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toMatchObject({
+      error: "invalid_request",
+      message: "invalidRequestBody",
+    });
+    expect(signInEmail).not.toHaveBeenCalled();
+    expect(findUnique).not.toHaveBeenCalled();
+  });
+
+  test("login returns field errors for invalid credentials shape", async () => {
+    const response = await loginRoute.POST(
+      jsonRequest("/api/auth/login", {
+        email: "not-an-email",
+        password: "",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toMatchObject({
+      error: "validation_failed",
+      message: "fixHighlightedFields",
+      fields: {
+        email: ["invalidEmail"],
+        password: ["shortPassword"],
+      },
+    });
+    expect(signInEmail).not.toHaveBeenCalled();
+  });
+
   test("login signs in with normalized credentials and returns session headers", async () => {
     const response = await loginRoute.POST(
       jsonRequest("/api/auth/login", {
@@ -196,6 +232,81 @@ describe("auth API routes", () => {
       message: "invalidCredentials",
     });
     expect(findUnique).not.toHaveBeenCalled();
+  });
+
+  test("login fails closed when Better Auth returns a user id that no longer exists", async () => {
+    findUnique.mockResolvedValueOnce(null);
+
+    const response = await loginRoute.POST(
+      jsonRequest("/api/auth/login", {
+        email: "max@example.com",
+        password: "password123",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload).toMatchObject({
+      error: "login_failed",
+      message: "loginUnavailable",
+    });
+  });
+
+  test("login maps unexpected failures to the public unavailable shape with detail", async () => {
+    signInEmail.mockRejectedValueOnce(new Error("network split"));
+
+    const response = await loginRoute.POST(
+      jsonRequest("/api/auth/login", {
+        email: "max@example.com",
+        password: "password123",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload).toMatchObject({
+      detail: "network split",
+      error: "login_failed",
+      message: "loginUnavailable",
+    });
+  });
+
+  test("signup rejects malformed request bodies before duplicate lookup", async () => {
+    const response = await signupRoute.POST(malformedJsonRequest("/api/auth/signup"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toMatchObject({
+      error: "invalid_request",
+      message: "invalidRequestBody",
+    });
+    expect(getDuplicateSignupFields).not.toHaveBeenCalled();
+    expect(signUpEmail).not.toHaveBeenCalled();
+  });
+
+  test("signup returns field errors for invalid profile input", async () => {
+    const response = await signupRoute.POST(
+      jsonRequest("/api/auth/signup", {
+        displayName: "",
+        email: "not-an-email",
+        password: "short",
+        username: "no spaces",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toMatchObject({
+      error: "validation_failed",
+      message: "fixHighlightedFields",
+    });
+    expect(payload.fields).toMatchObject({
+      email: ["invalidEmail"],
+      password: ["shortPassword"],
+      username: ["invalidUsername"],
+    });
+    expect(getDuplicateSignupFields).not.toHaveBeenCalled();
+    expect(signUpEmail).not.toHaveBeenCalled();
   });
 
   test("signup maps duplicate email and username errors before calling Better Auth", async () => {
@@ -248,6 +359,95 @@ describe("auth API routes", () => {
         id: user.id,
         username: user.username,
       },
+    });
+  });
+
+  test("signup fails closed when Better Auth returns a user id that no longer exists", async () => {
+    findUnique.mockResolvedValueOnce(null);
+
+    const response = await signupRoute.POST(
+      jsonRequest("/api/auth/signup", {
+        displayName: "Max",
+        email: "max@example.com",
+        password: "password123",
+        username: "max_player",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload).toMatchObject({
+      error: "signup_failed",
+      message: "signupUnavailable",
+    });
+  });
+
+  test("signup maps Better Auth API duplicate failures through a fresh duplicate check", async () => {
+    signUpEmail.mockRejectedValueOnce(new APIError("BAD_REQUEST", { message: "duplicate" }));
+    getDuplicateSignupFields.mockResolvedValueOnce({}).mockResolvedValueOnce({ email: true });
+
+    const response = await signupRoute.POST(
+      jsonRequest("/api/auth/signup", {
+        displayName: "Max",
+        email: "max@example.com",
+        password: "password123",
+        username: "max_player",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(payload).toMatchObject({
+      error: "duplicate_account",
+      fields: {
+        email: ["duplicateEmail"],
+      },
+      message: "duplicateAccount",
+    });
+  });
+
+  test("signup maps database unique constraint failures to duplicate-account errors", async () => {
+    signUpEmail.mockRejectedValueOnce(new Error("Unique constraint failed on the fields"));
+    getDuplicateSignupFields.mockResolvedValueOnce({}).mockResolvedValueOnce({ username: true });
+
+    const response = await signupRoute.POST(
+      jsonRequest("/api/auth/signup", {
+        displayName: "Max",
+        email: "max@example.com",
+        password: "password123",
+        username: "max_player",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(payload).toMatchObject({
+      error: "duplicate_account",
+      fields: {
+        username: ["duplicateUsername"],
+      },
+      message: "duplicateAccount",
+    });
+  });
+
+  test("signup maps unexpected failures to the public unavailable shape with detail", async () => {
+    signUpEmail.mockRejectedValueOnce(new Error("mail service down"));
+
+    const response = await signupRoute.POST(
+      jsonRequest("/api/auth/signup", {
+        displayName: "Max",
+        email: "max@example.com",
+        password: "password123",
+        username: "max_player",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload).toMatchObject({
+      detail: "mail service down",
+      error: "signup_failed",
+      message: "signupUnavailable",
     });
   });
 
@@ -311,6 +511,59 @@ describe("auth API routes", () => {
     });
   });
 
+  test("saveDisplayName requires a signed-in user", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const state = await profileActions.saveDisplayName(
+      previousState,
+      formData({
+        displayName: "Max J",
+      }),
+    );
+
+    expect(updateUser).not.toHaveBeenCalled();
+    expect(state).toMatchObject({
+      fields: {},
+      message: "loginRequired",
+      successMessage: null,
+    });
+  });
+
+  test("saveDisplayName validates display name before updating", async () => {
+    const state = await profileActions.saveDisplayName(
+      previousState,
+      formData({
+        displayName: "",
+      }),
+    );
+
+    expect(updateUser).not.toHaveBeenCalled();
+    expect(state).toMatchObject({
+      fields: {
+        displayName: ["displayNameRequired"],
+      },
+      message: "fixHighlightedFields",
+      successMessage: null,
+    });
+  });
+
+  test("saveDisplayName returns a profile-save error when persistence fails", async () => {
+    updateUser.mockRejectedValueOnce(new Error("write failed"));
+
+    const state = await profileActions.saveDisplayName(
+      previousState,
+      formData({
+        displayName: "Max J",
+      }),
+    );
+
+    expect(state).toMatchObject({
+      fields: {},
+      message: "profileSaveFailed",
+      successMessage: null,
+    });
+  });
+
   test("changeAccountPassword validates password fields before calling Better Auth", async () => {
     const state = await profileActions.changeAccountPassword(
       previousState,
@@ -329,6 +582,26 @@ describe("auth API routes", () => {
     });
     expect(changePassword).not.toHaveBeenCalled();
     expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  test("changeAccountPassword requires a signed-in user", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const state = await profileActions.changeAccountPassword(
+      previousState,
+      formData({
+        currentPassword: "password123",
+        newPassword: "password999",
+        confirmPassword: "password999",
+      }),
+    );
+
+    expect(changePassword).not.toHaveBeenCalled();
+    expect(state).toMatchObject({
+      fields: {},
+      message: "loginRequired",
+      successMessage: null,
+    });
   });
 
   test("changeAccountPassword maps Better Auth password failures to the current-password field", async () => {
@@ -376,6 +649,25 @@ describe("auth API routes", () => {
       fields: {},
       message: null,
       successMessage: "saveSuccess",
+    });
+  });
+
+  test("changeAccountPassword returns a profile-save error for unexpected auth failures", async () => {
+    changePassword.mockRejectedValueOnce(new Error("auth store unavailable"));
+
+    const state = await profileActions.changeAccountPassword(
+      previousState,
+      formData({
+        currentPassword: "password123",
+        newPassword: "password999",
+        confirmPassword: "password999",
+      }),
+    );
+
+    expect(state).toMatchObject({
+      fields: {},
+      message: "profileSaveFailed",
+      successMessage: null,
     });
   });
 });

--- a/app/api/auth/logout/route.test.ts
+++ b/app/api/auth/logout/route.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
+
+const headers = mock();
+const signOut = mock();
+
+await mock.module("next/headers", () => ({
+  headers,
+}));
+
+await mock.module("../../../lib/auth", () =>
+  createAuthModuleMock({
+    auth: {
+      api: {
+        signOut,
+      },
+    },
+  }),
+);
+
+const route = await import("./route");
+
+beforeEach(() => {
+  headers.mockReset();
+  signOut.mockReset();
+
+  headers.mockResolvedValue(new Headers({ cookie: "session=1" }));
+  signOut.mockResolvedValue({
+    headers: new Headers({ "set-cookie": "session=; Max-Age=0" }),
+  });
+});
+
+describe("POST /api/auth/logout", () => {
+  test("returns success and forwards Better Auth response headers", async () => {
+    const response = await route.POST();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(response.headers.get("set-cookie")).toBe("session=; Max-Age=0");
+    expect(signOut).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+      returnHeaders: true,
+    });
+  });
+
+  test("still returns success when Better Auth sign-out fails", async () => {
+    signOut.mockRejectedValueOnce(new Error("session store down"));
+
+    const response = await route.POST();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+});

--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const queryRaw = mock();
+
+await mock.module("../../lib/prisma", () => ({
+  prisma: {
+    $queryRaw: queryRaw,
+  },
+}));
+
+const route = await import("./route");
+
+beforeEach(() => {
+  queryRaw.mockReset();
+  queryRaw.mockResolvedValue([{ "?column?": 1 }]);
+});
+
+describe("GET /api/health", () => {
+  test("reports app and database health when the probe succeeds", async () => {
+    const response = await route.GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      database: "ok",
+      service: "app",
+      status: "ok",
+    });
+    expect(payload.checkedAt).toEqual(expect.any(String));
+  });
+
+  test("reports degraded health when the database probe fails", async () => {
+    queryRaw.mockRejectedValueOnce(new Error("connection refused"));
+
+    const response = await route.GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(payload).toMatchObject({
+      database: "unreachable",
+      error: "connection refused",
+      service: "app",
+      status: "degraded",
+    });
+  });
+});

--- a/app/api/matches/[id]/ai-turn/route.test.ts
+++ b/app/api/matches/[id]/ai-turn/route.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { Prisma } from "@/../generated/prisma/client";
 import {
   MatchResult,
   MatchStatus,
@@ -10,6 +11,7 @@ import {
 } from "@/../generated/prisma/enums";
 import { soloAiDisplayName } from "@/lib/matches/ai-solo";
 import { endReasonFiveInARow } from "@/lib/matches/move-rules";
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
 
 const getCurrentSession = mock();
 const previewFindMatch = mock();
@@ -37,9 +39,11 @@ const tx = {
   },
 };
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 await mock.module("@/lib/prisma", () => ({
   prisma: {
@@ -205,6 +209,55 @@ afterAll(() => {
 });
 
 describe("POST /api/matches/:id/ai-turn", () => {
+  test("requires authentication and a participant id before previewing the match", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const unauthorizedResponse = await route.POST(
+      request({
+        participantId: "human-player",
+      }),
+      context(),
+    );
+
+    expect(unauthorizedResponse.status).toBe(401);
+    expect(await unauthorizedResponse.json()).toEqual({ error: "unauthorized" });
+
+    const missingParticipantResponse = await route.POST(request({}), context());
+
+    expect(missingParticipantResponse.status).toBe(400);
+    expect(await missingParticipantResponse.json()).toEqual({ error: "missing_participant_id" });
+    expect(previewFindMatch).not.toHaveBeenCalled();
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  test("rejects missing preview matches and non-participants before waiting on the AI", async () => {
+    previewFindMatch.mockResolvedValueOnce(null);
+
+    const missingResponse = await route.POST(
+      request({
+        participantId: "human-player",
+      }),
+      context(),
+    );
+
+    expect(missingResponse.status).toBe(404);
+    expect(await missingResponse.json()).toEqual({ error: "match_not_found" });
+
+    previewFindMatch.mockResolvedValueOnce(matchRecord());
+
+    const forbiddenResponse = await route.POST(
+      request({
+        participantId: "ai-player",
+      }),
+      context(),
+    );
+
+    expect(forbiddenResponse.status).toBe(403);
+    expect(await forbiddenResponse.json()).toEqual({ error: "participant_not_found" });
+    expect(transaction).not.toHaveBeenCalled();
+    expect(chooseAiMove).not.toHaveBeenCalled();
+  });
+
   test("plays a structured-metadata AI turn and records finished results", async () => {
     const storedMatch = matchRecord();
     const createdMove = move("ai-player", 10, 5, 7, 10);
@@ -286,6 +339,95 @@ describe("POST /api/matches/:id/ai-turn", () => {
     expect(updateMatchMany).not.toHaveBeenCalled();
     expect(createMove).not.toHaveBeenCalled();
     expect(publishGameUpdate).not.toHaveBeenCalled();
+  });
+
+  test("rejects AI turns when the match is not in progress or not on the AI seat", async () => {
+    const finishedMatch = matchRecord({ status: MatchStatus.FINISHED });
+    previewFindMatch.mockResolvedValueOnce(finishedMatch);
+    findMatch.mockResolvedValueOnce(finishedMatch);
+
+    const finishedResponse = await route.POST(
+      request({
+        baseVersion: 9,
+        participantId: "human-player",
+      }),
+      context(),
+    );
+
+    expect(finishedResponse.status).toBe(409);
+    expect(await finishedResponse.json()).toEqual({ error: "game_not_in_progress" });
+
+    const humanTurnMatch = matchRecord({ nextTurnSeat: Seat.BLACK });
+    previewFindMatch.mockResolvedValueOnce(humanTurnMatch);
+    findMatch.mockResolvedValueOnce(humanTurnMatch);
+
+    const notAiTurnResponse = await route.POST(
+      request({
+        baseVersion: 9,
+        participantId: "human-player",
+      }),
+      context(),
+    );
+
+    expect(notAiTurnResponse.status).toBe(409);
+    expect(await notAiTurnResponse.json()).toEqual({ error: "not_ai_turn" });
+    expect(chooseAiMove).not.toHaveBeenCalled();
+    expect(createMove).not.toHaveBeenCalled();
+  });
+
+  test("keeps an accepted AI move successful when realtime publishing fails", async () => {
+    const storedMatch = matchRecord({
+      moves: [],
+      nextTurnSeat: Seat.WHITE,
+      stateVersion: 0,
+    });
+    const createdMove = move("ai-player", 1, 5, 7, 1);
+
+    previewFindMatch.mockResolvedValueOnce(storedMatch);
+    findMatch.mockResolvedValueOnce(storedMatch);
+    updateMatchMany.mockResolvedValueOnce({ count: 1 });
+    createMove.mockResolvedValueOnce(createdMove);
+    publishGameUpdate.mockRejectedValueOnce(new Error("realtime down"));
+
+    const response = await route.POST(
+      request({
+        baseVersion: 0,
+        participantId: "human-player",
+      }),
+      context(),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      accepted: true,
+      ok: true,
+      stateVersion: 1,
+    });
+  });
+
+  test("maps Prisma move conflicts to a public AI-turn conflict response", async () => {
+    previewFindMatch.mockResolvedValueOnce(matchRecord());
+    transaction.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError("Prisma conflict", {
+        clientVersion: "test",
+        code: "P2002",
+        meta: { target: ["requestId"] },
+      }),
+    );
+
+    const response = await route.POST(
+      request({
+        baseVersion: 9,
+        participantId: "human-player",
+      }),
+      context(),
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: "move_conflict",
+    });
   });
 
   test("requires solo match metadata instead of inferring from display names", async () => {

--- a/app/api/matches/[id]/challenge/decline/route.test.ts
+++ b/app/api/matches/[id]/challenge/decline/route.test.ts
@@ -8,6 +8,7 @@ import {
   RuleType,
   Seat,
 } from "@/../generated/prisma/enums";
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
 
 const getCurrentSession = mock();
 const findMatch = mock();
@@ -35,9 +36,11 @@ const tx = {
   },
 };
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 await mock.module("@/lib/prisma", () => ({
   prisma: {

--- a/app/api/matches/[id]/join/route.test.ts
+++ b/app/api/matches/[id]/join/route.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { Prisma } from "@/../generated/prisma/client";
 import { MatchStatus, MatchVisibility, Role, RuleType, Seat } from "@/../generated/prisma/enums";
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
 
 const getCurrentSession = mock();
 const findMatch = mock();
@@ -30,9 +32,11 @@ const tx = {
   },
 };
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 await mock.module("@/lib/prisma", () => ({
   prisma: {
@@ -292,6 +296,67 @@ describe("POST /api/matches/:id/join", () => {
     expect(verifyPassword).not.toHaveBeenCalled();
   });
 
+  test("rejects invalid payloads and unavailable matches before the transition", async () => {
+    const invalidResponse = await route.POST(request({ displayName: "x".repeat(81) }), context());
+
+    expect(invalidResponse.status).toBe(400);
+    expect(await invalidResponse.json()).toEqual({ error: "invalid_payload" });
+    expect(findMatch).not.toHaveBeenCalled();
+
+    findMatch.mockResolvedValueOnce(null);
+
+    const missingResponse = await route.POST(request(), context());
+
+    expect(missingResponse.status).toBe(404);
+    expect(await missingResponse.json()).toEqual({ error: "match_not_found" });
+
+    findMatch.mockResolvedValueOnce({
+      ...waitingMatch(),
+      status: MatchStatus.IN_PROGRESS,
+    });
+
+    const unavailableResponse = await route.POST(request(), context());
+
+    expect(unavailableResponse.status).toBe(409);
+    expect(await unavailableResponse.json()).toEqual({ error: "match_not_available" });
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  test("rejects users who are already in the match or when white is already occupied", async () => {
+    findMatch.mockResolvedValueOnce({
+      ...waitingMatch(),
+      participants: [
+        hostParticipant(),
+        {
+          ...joinerParticipant(),
+          userId: "user-white",
+        },
+      ],
+    });
+
+    const alreadyJoinedResponse = await route.POST(request(), context());
+
+    expect(alreadyJoinedResponse.status).toBe(409);
+    expect(await alreadyJoinedResponse.json()).toEqual({ error: "already_in_match" });
+
+    findMatch.mockResolvedValueOnce({
+      ...waitingMatch(),
+      participants: [
+        hostParticipant(),
+        {
+          ...joinerParticipant(),
+          userId: "user-red",
+        },
+      ],
+    });
+
+    const fullResponse = await route.POST(request(), context());
+
+    expect(fullResponse.status).toBe(409);
+    expect(await fullResponse.json()).toEqual({ error: "match_full" });
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
   test("rejects the join when cancellation wins the waiting-room transition race", async () => {
     findMatch.mockResolvedValueOnce(waitingMatch());
     updateMatchMany.mockResolvedValueOnce({ count: 0 });
@@ -375,5 +440,37 @@ describe("POST /api/matches/:id/join", () => {
     expect(verifyPassword).not.toHaveBeenCalled();
     expect(transaction).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("keeps a joined match successful when realtime publication fails", async () => {
+    findMatch.mockResolvedValueOnce(waitingMatch());
+    publishGameUpdate.mockRejectedValueOnce(new Error("realtime down"));
+
+    const response = await route.POST(request(), context());
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      matchId: "match-1",
+      participantId: "white-player",
+      seat: Seat.WHITE,
+    });
+    expect(publishQueueMatched).not.toHaveBeenCalled();
+  });
+
+  test("maps participant uniqueness races to match_full", async () => {
+    findMatch.mockResolvedValueOnce(waitingMatch());
+    transaction.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError("Prisma conflict", {
+        clientVersion: "test",
+        code: "P2002",
+        meta: { target: ["matchId", "seat"] },
+      }),
+    );
+
+    const response = await route.POST(request(), context());
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: "match_full" });
   });
 });

--- a/app/api/matches/[id]/rules-routes.test.ts
+++ b/app/api/matches/[id]/rules-routes.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { Prisma } from "@/../generated/prisma/client";
 import {
   MatchResult,
   MatchStatus,
@@ -9,6 +10,7 @@ import {
   Seat,
 } from "@/../generated/prisma/enums";
 import { endReasonFiveInARow, endReasonResign } from "@/lib/matches/move-rules";
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
 
 const transaction = mock();
 const findMatch = mock();
@@ -51,9 +53,11 @@ await mock.module("@/lib/matches/realtime-publisher", () => ({
   publishQueueMatched,
 }));
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 const movesRoute = await import("./moves/route");
 const resignRoute = await import("./resign/route");
@@ -180,6 +184,87 @@ beforeEach(() => {
 });
 
 describe("POST /api/matches/:id/moves", () => {
+  test("requires authentication before validating move payloads", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const response = await movesRoute.POST(
+      jsonRequest("/api/matches/match-1/moves", {
+        participantId: "black-player",
+        position: { x: 4, y: 7 },
+      }),
+      context(),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "unauthorized" });
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  test("rejects malformed move payloads before opening a transaction", async () => {
+    const response = await movesRoute.POST(
+      jsonRequest("/api/matches/match-1/moves", {
+        participantId: "black-player",
+        position: { x: -1, y: 7 },
+      }),
+      context(),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_payload" });
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  test("reports missing matches and unauthorized participants without writing moves", async () => {
+    findMatch.mockResolvedValueOnce(null);
+
+    const missingResponse = await movesRoute.POST(
+      jsonRequest("/api/matches/match-1/moves", {
+        participantId: "black-player",
+        position: { x: 4, y: 7 },
+        baseVersion: 8,
+      }),
+      context(),
+    );
+
+    expect(missingResponse.status).toBe(404);
+    expect(await missingResponse.json()).toEqual({ error: "match_not_found" });
+
+    findMatch.mockResolvedValueOnce(matchRecord());
+
+    const forbiddenResponse = await movesRoute.POST(
+      jsonRequest("/api/matches/match-1/moves", {
+        participantId: "white-player",
+        position: { x: 4, y: 7 },
+        baseVersion: 8,
+      }),
+      context(),
+    );
+
+    expect(forbiddenResponse.status).toBe(403);
+    expect(await forbiddenResponse.json()).toEqual({ error: "participant_not_found" });
+    expect(createMove).not.toHaveBeenCalled();
+    expect(publishGameUpdate).not.toHaveBeenCalled();
+  });
+
+  test("rejects occupied intersections before creating another move", async () => {
+    findMatch.mockResolvedValueOnce(matchRecord());
+    findMove.mockResolvedValueOnce({ id: "occupied-cell" });
+
+    const response = await movesRoute.POST(
+      jsonRequest("/api/matches/match-1/moves", {
+        participantId: "black-player",
+        position: { x: 4, y: 7 },
+        baseVersion: 8,
+      }),
+      context(),
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: "occupied" });
+    expect(createMove).not.toHaveBeenCalled();
+    expect(updateParticipant).not.toHaveBeenCalled();
+  });
+
   test("finishes the match when the submitted move completes five in a row", async () => {
     const storedMatch = matchRecord();
     const createdMove = move("black-player", 9, 4, 7, 9);
@@ -257,9 +342,113 @@ describe("POST /api/matches/:id/moves", () => {
     expect(updateParticipant).not.toHaveBeenCalled();
     expect(publishGameUpdate).not.toHaveBeenCalled();
   });
+
+  test("keeps an accepted move successful when realtime publishing fails", async () => {
+    const storedMatch = matchRecord({
+      moves: [],
+      stateVersion: 0,
+    });
+    const createdMove = { ...move("black-player", 1, 7, 7, 1), requestId: "move-1" };
+
+    findMatch.mockResolvedValueOnce(storedMatch);
+    findMove.mockResolvedValueOnce(null);
+    updateMatchMany.mockResolvedValueOnce({ count: 1 });
+    createMove.mockResolvedValueOnce(createdMove);
+    publishGameUpdate.mockRejectedValueOnce(new Error("realtime down"));
+
+    const response = await movesRoute.POST(
+      jsonRequest("/api/matches/match-1/moves", {
+        participantId: "black-player",
+        position: { x: 7, y: 7 },
+        baseVersion: 0,
+        requestId: "move-1",
+      }),
+      context(),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      accepted: true,
+      ok: true,
+      requestId: "move-1",
+    });
+    expect(createMove).toHaveBeenCalled();
+  });
+
+  test("maps Prisma unique constraint conflicts to public move errors", async () => {
+    transaction.mockRejectedValueOnce(prismaKnownRequestError("P2002", { target: ["requestId"] }));
+
+    const response = await movesRoute.POST(
+      jsonRequest("/api/matches/match-1/moves", {
+        participantId: "black-player",
+        position: { x: 4, y: 7 },
+        baseVersion: 8,
+        requestId: "duplicate-request",
+      }),
+      context(),
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: "duplicate_request",
+    });
+  });
 });
 
 describe("POST /api/matches/:id/resign", () => {
+  test("requires authentication and valid payloads before resigning", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const unauthorizedResponse = await resignRoute.POST(
+      jsonRequest("/api/matches/match-1/resign", {
+        participantId: "black-player",
+      }),
+      context(),
+    );
+
+    expect(unauthorizedResponse.status).toBe(401);
+    expect(await unauthorizedResponse.json()).toEqual({ error: "unauthorized" });
+
+    const invalidResponse = await resignRoute.POST(
+      jsonRequest("/api/matches/match-1/resign", {
+        participantId: "",
+      }),
+      context(),
+    );
+
+    expect(invalidResponse.status).toBe(400);
+    expect(await invalidResponse.json()).toEqual({ error: "invalid_payload" });
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  test("reports missing matches and unauthorized participants before resigning", async () => {
+    findMatch.mockResolvedValueOnce(null);
+
+    const missingResponse = await resignRoute.POST(
+      jsonRequest("/api/matches/match-1/resign", {
+        participantId: "black-player",
+      }),
+      context(),
+    );
+
+    expect(missingResponse.status).toBe(404);
+    expect(await missingResponse.json()).toEqual({ error: "match_not_found" });
+
+    findMatch.mockResolvedValueOnce(matchRecord());
+
+    const forbiddenResponse = await resignRoute.POST(
+      jsonRequest("/api/matches/match-1/resign", {
+        participantId: "white-player",
+      }),
+      context(),
+    );
+
+    expect(forbiddenResponse.status).toBe(403);
+    expect(await forbiddenResponse.json()).toEqual({ error: "participant_not_found" });
+    expect(updateParticipant).not.toHaveBeenCalled();
+  });
+
   test("finishes the match in favor of the opponent", async () => {
     const storedMatch = matchRecord();
 
@@ -334,6 +523,57 @@ describe("POST /api/matches/:id/resign", () => {
 });
 
 describe("POST /api/matches/:id/cancel", () => {
+  test("requires authentication and valid payloads before cancelling", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const unauthorizedResponse = await cancelRoute.POST(
+      jsonRequest("/api/matches/match-1/cancel", {
+        participantId: "black-player",
+      }),
+      context(),
+    );
+
+    expect(unauthorizedResponse.status).toBe(401);
+    expect(await unauthorizedResponse.json()).toEqual({ error: "unauthorized" });
+
+    const invalidResponse = await cancelRoute.POST(
+      jsonRequest("/api/matches/match-1/cancel", {
+        participantId: "",
+      }),
+      context(),
+    );
+
+    expect(invalidResponse.status).toBe(400);
+    expect(await invalidResponse.json()).toEqual({ error: "invalid_payload" });
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  test("allows only the waiting-room host to cancel", async () => {
+    findMatch.mockResolvedValueOnce(
+      matchRecord({
+        createdByUserId: "user-white",
+        moves: [],
+        nextTurnSeat: null,
+        participants: [participants()[0]],
+        stateVersion: 0,
+        status: MatchStatus.WAITING,
+      }),
+    );
+
+    const response = await cancelRoute.POST(
+      jsonRequest("/api/matches/match-1/cancel", {
+        participantId: "black-player",
+        baseVersion: 0,
+      }),
+      context(),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "only_host_can_cancel" });
+    expect(updateMatchMany).not.toHaveBeenCalled();
+    expect(updateManyParticipants).not.toHaveBeenCalled();
+  });
+
   test("cancels a waiting room for the host before returning to the lobby", async () => {
     const storedMatch = matchRecord({
       createdByUserId: "user-black",
@@ -424,3 +664,11 @@ describe("POST /api/matches/:id/cancel", () => {
     expect(publishGameUpdate).not.toHaveBeenCalled();
   });
 });
+
+function prismaKnownRequestError(code: string, meta: Record<string, unknown>) {
+  return new Prisma.PrismaClientKnownRequestError("Prisma known request error", {
+    clientVersion: "test",
+    code,
+    meta,
+  });
+}

--- a/app/api/matches/[id]/state/route.test.ts
+++ b/app/api/matches/[id]/state/route.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
+
 const findUnique = mock();
 const buildBoard = mock();
 const getCurrentSession = mock();
@@ -16,9 +18,11 @@ await mock.module("@/lib/game/state-builder", () => ({
   buildBoard,
 }));
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 const route = await import("./route");
 

--- a/app/api/matches/challenge/route.test.ts
+++ b/app/api/matches/challenge/route.test.ts
@@ -9,6 +9,7 @@ import {
   RuleType,
   Seat,
 } from "@/../generated/prisma/enums";
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
 
 const getCurrentSession = mock();
 const findUser = mock();
@@ -33,9 +34,11 @@ const tx = {
   },
 };
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 await mock.module("@/lib/prisma", () => ({
   prisma: {
@@ -173,6 +176,43 @@ beforeEach(() => {
 });
 
 describe("POST /api/matches/challenge", () => {
+  test("requires authentication and a valid target username", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const unauthorizedResponse = await route.POST(request({ targetUsername: "white" }));
+
+    expect(unauthorizedResponse.status).toBe(401);
+    expect(await unauthorizedResponse.json()).toMatchObject({ error: "unauthorized" });
+    expect(findUser).not.toHaveBeenCalled();
+
+    const invalidResponse = await route.POST(request({ targetUsername: "" }));
+
+    expect(invalidResponse.status).toBe(400);
+    expect(await invalidResponse.json()).toMatchObject({ error: "invalid_payload" });
+    expect(findUser).not.toHaveBeenCalled();
+  });
+
+  test("rejects missing targets and self-challenges before creating a room", async () => {
+    findUser.mockResolvedValueOnce(null);
+
+    const missingResponse = await route.POST(request({ targetUsername: "missing" }));
+
+    expect(missingResponse.status).toBe(404);
+    expect(await missingResponse.json()).toMatchObject({ error: "target_not_found" });
+
+    findUser.mockResolvedValueOnce({
+      id: "user-black",
+      username: "black",
+    });
+
+    const selfResponse = await route.POST(request({ targetUsername: "black" }));
+
+    expect(selfResponse.status).toBe(400);
+    expect(await selfResponse.json()).toMatchObject({ error: "cannot_challenge_self" });
+    expect(createMatch).not.toHaveBeenCalled();
+    expect(publishChallengeReceived).not.toHaveBeenCalled();
+  });
+
   test("requires an accepted friendship with the target user", async () => {
     findFriendship.mockResolvedValueOnce({
       status: FriendshipStatus.PENDING,

--- a/app/api/matches/history/route.test.ts
+++ b/app/api/matches/history/route.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
+
 const getCurrentSession = mock();
 const getMatchHistoryForUser = mock();
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 await mock.module("@/lib/matches/match-history", () => ({
   MATCH_HISTORY_MAX_LIMIT: 100,

--- a/app/api/matches/queue/route.test.ts
+++ b/app/api/matches/queue/route.test.ts
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
+
 const getCurrentSession = mock();
 const cancelMatchmakingQueue = mock();
 const getMatchmakingQueueStatus = mock();
 const joinMatchmakingQueue = mock();
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 await mock.module("@/lib/matches/matchmaking", () => ({
   cancelMatchmakingQueue,
@@ -35,6 +39,20 @@ beforeEach(() => {
 });
 
 describe("/api/matches/queue", () => {
+  test("requires authentication before reading or cancelling queue state", async () => {
+    getCurrentSession.mockResolvedValue(null);
+
+    const statusResponse = await route.GET();
+    const cancelResponse = await route.DELETE();
+
+    expect(statusResponse.status).toBe(401);
+    expect(await statusResponse.json()).toMatchObject({ error: "unauthorized" });
+    expect(cancelResponse.status).toBe(401);
+    expect(await cancelResponse.json()).toMatchObject({ error: "unauthorized" });
+    expect(getMatchmakingQueueStatus).not.toHaveBeenCalled();
+    expect(cancelMatchmakingQueue).not.toHaveBeenCalled();
+  });
+
   test("requires authentication before queueing", async () => {
     getCurrentSession.mockResolvedValueOnce(null);
 
@@ -78,5 +96,31 @@ describe("/api/matches/queue", () => {
     expect(await cancelResponse.json()).toEqual({ kind: "not_queued" });
     expect(getMatchmakingQueueStatus).toHaveBeenCalledWith(user);
     expect(cancelMatchmakingQueue).toHaveBeenCalledWith(user);
+  });
+
+  test("returns method-specific server errors when queue operations fail", async () => {
+    getMatchmakingQueueStatus.mockRejectedValueOnce(new Error("read failed"));
+    joinMatchmakingQueue.mockRejectedValueOnce(new Error("join failed"));
+    cancelMatchmakingQueue.mockRejectedValueOnce("cancel failed");
+
+    const statusResponse = await route.GET();
+    const joinResponse = await route.POST();
+    const cancelResponse = await route.DELETE();
+
+    expect(statusResponse.status).toBe(500);
+    expect(await statusResponse.json()).toEqual({
+      detail: "read failed",
+      error: "failed_to_load_queue_status",
+    });
+    expect(joinResponse.status).toBe(500);
+    expect(await joinResponse.json()).toEqual({
+      detail: "join failed",
+      error: "failed_to_join_queue",
+    });
+    expect(cancelResponse.status).toBe(500);
+    expect(await cancelResponse.json()).toEqual({
+      detail: "Unknown error",
+      error: "failed_to_cancel_queue",
+    });
   });
 });

--- a/app/api/matches/route.test.ts
+++ b/app/api/matches/route.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { MatchStatus, MatchVisibility, Role, RuleType, Seat } from "@/../generated/prisma/enums";
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
 
 const getCurrentSession = mock();
 const createMatch = mock();
@@ -17,9 +18,11 @@ const originalFetch = globalThis.fetch;
 const originalRealtimeInternalUrl = process.env["REALTIME_INTERNAL_URL"];
 const originalRealtimeSecret = process.env["REALTIME_INTERNAL_SECRET"];
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 await mock.module("@/lib/prisma", () => ({
   prisma: {
@@ -244,6 +247,58 @@ describe("GET /api/matches", () => {
       "listed-1",
       "listed-2",
     ]);
+  });
+
+  test("returns later filtered lobby pages without database-level skip or take", async () => {
+    findManyMatches.mockResolvedValueOnce([
+      createdMatch({ id: "listed-1", visibility: MatchVisibility.PUBLIC }),
+      createdMatch({ id: "listed-2", visibility: MatchVisibility.PUBLIC }),
+      createdMatch({
+        id: "hidden-challenge",
+        metadata: {
+          declineTokenHash: "hashed-decline-token",
+          kind: "human-challenge",
+          targetUserId: "user-bob",
+          targetUsername: "bob",
+        },
+        visibility: MatchVisibility.PRIVATE,
+      }),
+      createdMatch({ id: "listed-3", visibility: MatchVisibility.PUBLIC }),
+      createdMatch({ id: "listed-4", visibility: MatchVisibility.PUBLIC }),
+    ]);
+
+    const response = await route.GET(new Request("http://localhost/api/matches?page=2&limit=2"));
+    const payload = await response.json();
+    const findManyArgs = findManyMatches.mock.calls[0]?.[0] as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect("skip" in findManyArgs).toBe(false);
+    expect("take" in findManyArgs).toBe(false);
+    expect(payload).toMatchObject({
+      page: 2,
+      limit: 2,
+      totalMatches: 4,
+      totalPages: 2,
+    });
+    expect(payload.data.map((match: { matchId: string }) => match.matchId)).toEqual([
+      "listed-3",
+      "listed-4",
+    ]);
+  });
+
+  test("normalizes invalid lobby pagination params", async () => {
+    findManyMatches.mockResolvedValueOnce([createdMatch({ id: "listed-1" })]);
+
+    const response = await route.GET(new Request("http://localhost/api/matches?page=-2&limit=0"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      page: 1,
+      limit: 10,
+      totalMatches: 1,
+      totalPages: 1,
+    });
   });
 });
 

--- a/app/api/matches/route.test.ts
+++ b/app/api/matches/route.test.ts
@@ -232,11 +232,8 @@ describe("GET /api/matches", () => {
 
     const response = await route.GET(new Request("http://localhost/api/matches?page=1&limit=2"));
     const payload = await response.json();
-    const findManyArgs = findManyMatches.mock.calls[0]?.[0] as Record<string, unknown>;
 
     expect(response.status).toBe(200);
-    expect("skip" in findManyArgs).toBe(false);
-    expect("take" in findManyArgs).toBe(false);
     expect(payload).toMatchObject({
       page: 1,
       limit: 2,
@@ -249,7 +246,7 @@ describe("GET /api/matches", () => {
     ]);
   });
 
-  test("returns later filtered lobby pages without database-level skip or take", async () => {
+  test("returns later filtered lobby pages after excluding hidden challenge rooms", async () => {
     findManyMatches.mockResolvedValueOnce([
       createdMatch({ id: "listed-1", visibility: MatchVisibility.PUBLIC }),
       createdMatch({ id: "listed-2", visibility: MatchVisibility.PUBLIC }),
@@ -269,11 +266,8 @@ describe("GET /api/matches", () => {
 
     const response = await route.GET(new Request("http://localhost/api/matches?page=2&limit=2"));
     const payload = await response.json();
-    const findManyArgs = findManyMatches.mock.calls[0]?.[0] as Record<string, unknown>;
 
     expect(response.status).toBe(200);
-    expect("skip" in findManyArgs).toBe(false);
-    expect("take" in findManyArgs).toBe(false);
     expect(payload).toMatchObject({
       page: 2,
       limit: 2,

--- a/app/api/matches/solo/route.test.ts
+++ b/app/api/matches/solo/route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { MatchStatus, MatchVisibility, Role, RuleType, Seat } from "@/../generated/prisma/enums";
 import { soloAiDisplayName } from "@/lib/matches/ai-solo";
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
 
 const getCurrentSession = mock();
 const transaction = mock();
@@ -24,9 +25,11 @@ const tx = {
   },
 };
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 await mock.module("@/lib/prisma", () => ({
   prisma: {

--- a/app/api/profile/stats/route.test.ts
+++ b/app/api/profile/stats/route.test.ts
@@ -1,13 +1,17 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
+
 const getCurrentSession = mock();
 const getProfileStatsForUser = mock();
 const consoleError = mock(() => {});
 const originalConsoleError = console.error;
 
-await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
-}));
+await mock.module("@/lib/auth", () =>
+  createAuthModuleMock({
+    getCurrentSession,
+  }),
+);
 
 await mock.module("@/lib/stats/profile-stats", () => ({
   getProfileStatsForUser,
@@ -123,6 +127,18 @@ describe("GET /api/profile/stats", () => {
     expect(getProfileStatsForUser).toHaveBeenCalledWith("user-ada", {
       recentMatchesLimit: 50,
       recentMatchesPage: 3,
+    });
+  });
+
+  test("falls back for invalid pagination params", async () => {
+    const response = await route.GET(
+      new Request("http://localhost/api/profile/stats?page=-2&limit=0"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getProfileStatsForUser).toHaveBeenCalledWith("user-ada", {
+      recentMatchesLimit: 10,
+      recentMatchesPage: 1,
     });
   });
 

--- a/app/auth-actions.test.ts
+++ b/app/auth-actions.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { APIError } from "better-auth/api";
+
+import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
+
+const getLocale = mock();
+const getTranslations = mock();
+const headers = mock();
+const redirect = mock();
+const signInEmail = mock();
+const signUpEmail = mock();
+const getDuplicateSignupFields = mock();
+
+await mock.module("server-only", () => ({}));
+
+await mock.module("next-intl/server", () => ({
+  getLocale,
+  getTranslations,
+}));
+
+await mock.module("next/headers", () => ({
+  headers,
+}));
+
+await mock.module("./i18n/navigation", () => ({
+  redirect,
+}));
+
+await mock.module("./lib/auth", () =>
+  createAuthModuleMock({
+    auth: {
+      api: {
+        signInEmail,
+        signUpEmail,
+      },
+    },
+    getDuplicateSignupFields,
+  }),
+);
+
+const { loginAction, signupAction } = await import("./auth-actions");
+const { initialLoginActionState, initialSignupActionState } = await import("./auth-action-state");
+
+function formData(values: Record<string, string>) {
+  const data = new FormData();
+
+  for (const [key, value] of Object.entries(values)) {
+    data.set(key, value);
+  }
+
+  return data;
+}
+
+beforeEach(() => {
+  getLocale.mockReset();
+  getTranslations.mockReset();
+  headers.mockReset();
+  redirect.mockReset();
+  signInEmail.mockReset();
+  signUpEmail.mockReset();
+  getDuplicateSignupFields.mockReset();
+
+  getLocale.mockResolvedValue("en");
+  getTranslations.mockImplementation(
+    async ({ locale, namespace }: { locale: string; namespace: string }) =>
+      (key: string) =>
+        `${locale}:${namespace}:${key}`,
+  );
+  headers.mockResolvedValue(new Headers({ cookie: "session=1" }));
+  redirect.mockImplementation((args: unknown) => ({ redirected: args }));
+  signInEmail.mockResolvedValue({});
+  signUpEmail.mockResolvedValue({});
+  getDuplicateSignupFields.mockResolvedValue({});
+});
+
+describe("loginAction", () => {
+  test("returns localized field errors and preserves the raw email on validation failure", async () => {
+    const state = await loginAction(
+      initialLoginActionState,
+      formData({
+        email: "not-an-email",
+        locale: "ja",
+        password: "short",
+      }),
+    );
+
+    expect(state).toEqual({
+      email: "not-an-email",
+      fields: {
+        email: ["ja:auth.errors:invalidEmail"],
+        password: ["ja:auth.errors:shortPassword"],
+      },
+      message: "ja:auth.errors:fixHighlightedFields",
+    });
+    expect(signInEmail).not.toHaveBeenCalled();
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  test("maps Better Auth credential failures to a public invalid-credentials message", async () => {
+    signInEmail.mockRejectedValueOnce(new APIError("UNAUTHORIZED", { message: "bad login" }));
+
+    const state = await loginAction(
+      initialLoginActionState,
+      formData({
+        email: "MAX@example.COM",
+        password: "password123",
+      }),
+    );
+
+    expect(signInEmail).toHaveBeenCalledWith({
+      body: {
+        email: "max@example.com",
+        password: "password123",
+      },
+      headers: expect.any(Headers),
+    });
+    expect(state).toEqual({
+      email: "MAX@example.COM",
+      fields: {},
+      message: "en:auth.errors:invalidCredentials",
+    });
+  });
+
+  test("redirects to the localized profile route after a successful sign-in", async () => {
+    const state = await loginAction(
+      initialLoginActionState,
+      formData({
+        email: "max@example.com",
+        locale: "zh",
+        password: "password123",
+      }),
+    );
+
+    expect(state).toEqual({
+      redirected: {
+        href: "/profile",
+        locale: "zh",
+      },
+    });
+  });
+});
+
+describe("signupAction", () => {
+  test("returns localized field errors and preserves submitted values on validation failure", async () => {
+    const state = await signupAction(
+      initialSignupActionState,
+      formData({
+        displayName: "Max",
+        email: "not-an-email",
+        locale: "ja",
+        password: "short",
+        username: "bad user",
+      }),
+    );
+
+    expect(state).toMatchObject({
+      displayName: "Max",
+      email: "not-an-email",
+      fields: {
+        email: ["ja:auth.errors:invalidEmail"],
+        password: ["ja:auth.errors:shortPassword"],
+        username: ["ja:auth.errors:invalidUsername"],
+      },
+      message: "ja:auth.errors:fixHighlightedFields",
+      username: "bad user",
+    });
+    expect(getDuplicateSignupFields).not.toHaveBeenCalled();
+    expect(signUpEmail).not.toHaveBeenCalled();
+  });
+
+  test("returns duplicate field errors before calling Better Auth", async () => {
+    getDuplicateSignupFields.mockResolvedValueOnce({ email: true, username: true });
+
+    const state = await signupAction(
+      initialSignupActionState,
+      formData({
+        displayName: "Max",
+        email: "max@example.com",
+        password: "password123",
+        username: "max_player",
+      }),
+    );
+
+    expect(state).toMatchObject({
+      fields: {
+        email: ["en:auth.errors:duplicateEmail"],
+        username: ["en:auth.errors:duplicateUsername"],
+      },
+      message: "en:auth.errors:duplicateAccount",
+    });
+    expect(signUpEmail).not.toHaveBeenCalled();
+  });
+
+  test("maps late unique constraint failures to duplicate account errors", async () => {
+    signUpEmail.mockRejectedValueOnce(new Error("Unique constraint failed on the fields"));
+    getDuplicateSignupFields.mockResolvedValueOnce({}).mockResolvedValueOnce({ username: true });
+
+    const state = await signupAction(
+      initialSignupActionState,
+      formData({
+        displayName: "Max",
+        email: "max@example.com",
+        password: "password123",
+        username: "max_player",
+      }),
+    );
+
+    expect(state).toMatchObject({
+      fields: {
+        username: ["en:auth.errors:duplicateUsername"],
+      },
+      message: "en:auth.errors:duplicateAccount",
+    });
+  });
+
+  test("redirects to the localized profile route after successful signup", async () => {
+    const state = await signupAction(
+      initialSignupActionState,
+      formData({
+        displayName: "Max",
+        email: "max@example.com",
+        locale: "ja",
+        password: "password123",
+        username: "max_player",
+      }),
+    );
+
+    expect(signUpEmail).toHaveBeenCalledWith({
+      body: {
+        email: "max@example.com",
+        name: "Max",
+        password: "password123",
+        username: "max_player",
+      },
+      headers: expect.any(Headers),
+    });
+    expect(state).toEqual({
+      redirected: {
+        href: "/profile",
+        locale: "ja",
+      },
+    });
+  });
+});

--- a/app/lib/api-errors.test.ts
+++ b/app/lib/api-errors.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { Prisma } from "../../generated/prisma/client";
+
+await mock.module("server-only", () => ({}));
+
+const {
+  apiErrorResponse,
+  getErrorMessage,
+  getPrismaUniqueConstraintFields,
+  isPrismaUniqueConstraintError,
+} = await import("./api-errors");
+
+describe("api error helpers", () => {
+  test("maps unknown errors to a stable public message", () => {
+    expect(getErrorMessage(new Error("database unavailable"))).toBe("database unavailable");
+    expect(getErrorMessage("boom")).toBe("Unknown error");
+    expect(getErrorMessage(null)).toBe("Unknown error");
+  });
+
+  test("returns structured JSON error responses with the requested status", async () => {
+    const response = apiErrorResponse(
+      {
+        detail: "email is malformed",
+        error: "validation_failed",
+        fields: { email: ["Email is invalid"] },
+        message: "Please fix the highlighted fields.",
+      },
+      400,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      detail: "email is malformed",
+      error: "validation_failed",
+      fields: { email: ["Email is invalid"] },
+      message: "Please fix the highlighted fields.",
+    });
+  });
+
+  test("extracts Prisma unique constraint fields from string and array metadata", () => {
+    expect(getPrismaUniqueConstraintFields(prismaError({ target: "email" }))).toEqual(["email"]);
+    expect(
+      getPrismaUniqueConstraintFields(prismaError({ target: ["email", 42, "username"] })),
+    ).toEqual(["email", "username"]);
+    expect(getPrismaUniqueConstraintFields(prismaError({ target: null }))).toEqual([]);
+  });
+
+  test("detects Prisma unique constraint errors by code without trusting the prototype", () => {
+    expect(isPrismaUniqueConstraintError(prismaError({ target: "email" }))).toBe(true);
+    expect(isPrismaUniqueConstraintError({ code: "P2003" })).toBe(false);
+    expect(isPrismaUniqueConstraintError(null)).toBe(false);
+  });
+});
+
+function prismaError(meta: Record<string, unknown>): Prisma.PrismaClientKnownRequestError {
+  return {
+    code: "P2002",
+    meta,
+  } as Prisma.PrismaClientKnownRequestError;
+}

--- a/app/lib/i18n/api.test.ts
+++ b/app/lib/i18n/api.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { localeCookieName } from "@/i18n/config";
+
+await mock.module("server-only", () => ({}));
+
+const { resolveApiLocale } = await import("./api");
+
+describe("resolveApiLocale", () => {
+  test("prefers an explicit valid x-locale header over cookie and accept-language", () => {
+    const request = requestWithHeaders({
+      "accept-language": "ja-JP,zh;q=0.9,en;q=0.8",
+      cookie: `${localeCookieName}=zh`,
+      "x-locale": "ja",
+    });
+
+    expect(resolveApiLocale(request)).toBe("ja");
+  });
+
+  test("falls back to a decoded locale cookie when the explicit header is unsupported", () => {
+    const request = requestWithHeaders({
+      "accept-language": "ja-JP,zh;q=0.9,en;q=0.8",
+      cookie: `theme=dark; ${localeCookieName}=${encodeURIComponent("zh")}`,
+      "x-locale": "fr",
+    });
+
+    expect(resolveApiLocale(request)).toBe("zh");
+  });
+
+  test("uses the accepted base language when no explicit or cookie locale is valid", () => {
+    const request = requestWithHeaders({
+      "accept-language": "fr-CA;q=0.9, ja-JP;q=0.8, en-US;q=0.7",
+      cookie: `${localeCookieName}=not-a-locale`,
+    });
+
+    expect(resolveApiLocale(request)).toBe("ja");
+  });
+
+  test("returns the default locale for malformed cookies and unsupported languages", () => {
+    const request = requestWithHeaders({
+      "accept-language": "fr-CA,es-MX;q=0.8",
+      cookie: `${localeCookieName}=%E0%A4%A`,
+    });
+
+    expect(resolveApiLocale(request)).toBe("en");
+  });
+});
+
+function requestWithHeaders(headers: HeadersInit) {
+  return new Request("http://localhost/api/auth/login", { headers });
+}

--- a/app/lib/matches/match-history.test.ts
+++ b/app/lib/matches/match-history.test.ts
@@ -28,6 +28,7 @@ const {
   buildMatchHistoryQuery,
   getMatchHistoryPageForUser,
   normalizeMatchHistoryLimit,
+  normalizeMatchHistoryPage,
   toMatchHistoryEntry,
 } = await import("./match-history");
 
@@ -194,6 +195,25 @@ describe("match history read model", () => {
     expect(normalizeMatchHistoryLimit(2.5)).toBe(MATCH_HISTORY_DEFAULT_LIMIT);
   });
 
+  test("normalizes history pages for callers", () => {
+    expect(normalizeMatchHistoryPage(null)).toBe(1);
+    expect(normalizeMatchHistoryPage(0)).toBe(1);
+    expect(normalizeMatchHistoryPage(-3)).toBe(1);
+    expect(normalizeMatchHistoryPage(2.5)).toBe(1);
+    expect(normalizeMatchHistoryPage(4)).toBe(4);
+  });
+
+  test("builds paged history queries with the normalized skip offset", () => {
+    expect(buildMatchHistoryQuery("user-ada", 10, 3)).toMatchObject({
+      skip: 20,
+      take: 10,
+    });
+    expect(buildMatchHistoryQuery("user-ada", 10, -1)).toMatchObject({
+      skip: 0,
+      take: 10,
+    });
+  });
+
   test("clamps paged history reads to the last available page", async () => {
     countMatches.mockResolvedValueOnce(12);
     findManyMatches.mockResolvedValueOnce([]);
@@ -211,6 +231,27 @@ describe("match history read model", () => {
       expect.objectContaining({
         skip: 10,
         take: 5,
+      }),
+    );
+  });
+
+  test("keeps empty history pages on page one with default pagination metadata", async () => {
+    countMatches.mockResolvedValueOnce(0);
+    findManyMatches.mockResolvedValueOnce([]);
+
+    const page = await getMatchHistoryPageForUser("user-ada", 3, 10);
+
+    expect(page).toMatchObject({
+      entries: [],
+      page: 1,
+      limit: 10,
+      totalMatches: 0,
+      totalPages: 1,
+    });
+    expect(findManyMatches).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 0,
+        take: 10,
       }),
     );
   });

--- a/app/lib/matches/realtime-publisher.test.ts
+++ b/app/lib/matches/realtime-publisher.test.ts
@@ -3,19 +3,25 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { GameUpdatePayload } from "../../../shared/match-events";
 import { internalRealtimeSecretHeader } from "../../../shared/realtime-internal";
 import {
+  publishChallengeDeclined,
   publishChallengeReceived,
   publishGameUpdate,
+  publishQueueMatched,
+  resolveChallengeDeclinedUrl,
   resolveChallengeReceivedUrl,
   resolveGameUpdateUrl,
+  resolveQueueMatchedUrl,
 } from "./realtime-publisher";
 
 const fetchMock = mock(async () => new Response(null, { status: 200 }));
 const originalFetch = globalThis.fetch;
 const envKeys = [
   "BETTER_AUTH_SECRET",
+  "REALTIME_CHALLENGE_DECLINED_URL",
   "REALTIME_CHALLENGE_RECEIVED_URL",
   "REALTIME_INTERNAL_SECRET",
   "REALTIME_INTERNAL_URL",
+  "REALTIME_QUEUE_MATCHED_URL",
   "REALTIME_PUBLISH_TIMEOUT_MS",
 ] as const;
 const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]])) as Record<
@@ -101,6 +107,25 @@ describe("resolveChallengeReceivedUrl", () => {
       "http://localhost:3001/custom/challenge-received";
 
     expect(resolveChallengeReceivedUrl()).toBe("http://localhost:3001/custom/challenge-received");
+  });
+});
+
+describe("queue and challenge endpoint resolution", () => {
+  test("uses explicit queue and challenge-declined endpoints when configured", () => {
+    process.env["REALTIME_QUEUE_MATCHED_URL"] = "http://realtime/internal/custom-queue";
+    process.env["REALTIME_CHALLENGE_DECLINED_URL"] =
+      "http://realtime/internal/custom-challenge-declined";
+
+    expect(resolveQueueMatchedUrl()).toBe("http://realtime/internal/custom-queue");
+    expect(resolveChallengeDeclinedUrl()).toBe(
+      "http://realtime/internal/custom-challenge-declined",
+    );
+  });
+
+  test("derives the challenge-declined endpoint from the game endpoint", () => {
+    process.env["REALTIME_INTERNAL_URL"] = "http://localhost:3001/internal/game-update";
+
+    expect(resolveChallengeDeclinedUrl()).toBe("http://localhost:3001/internal/challenge-declined");
   });
 });
 
@@ -197,5 +222,105 @@ describe("publishChallengeReceived", () => {
       "Content-Type": "application/json",
       [internalRealtimeSecretHeader]: "game-secret",
     });
+  });
+});
+
+describe("publishQueueMatched", () => {
+  test("posts the matched session to a localhost-derived queue endpoint", async () => {
+    process.env["REALTIME_INTERNAL_URL"] = "http://localhost:3001/internal/game-update";
+    process.env["REALTIME_QUEUE_MATCHED_URL"] = "http://realtime:3001/internal/queue-matched";
+    process.env["REALTIME_INTERNAL_SECRET"] = "queue-secret";
+
+    await publishQueueMatched(
+      "black",
+      {
+        matchId: "match-1",
+        participantId: "black-player",
+      },
+      5000,
+    );
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+
+    expect(call?.[0]).toBe("http://localhost:3001/internal/queue-matched");
+    expect(call?.[1]).toMatchObject({
+      body: JSON.stringify({
+        username: "black",
+        session: {
+          matchId: "match-1",
+          participantId: "black-player",
+        },
+      }),
+      cache: "no-store",
+      method: "POST",
+    });
+    expect(call?.[1].headers).toEqual({
+      "Content-Type": "application/json",
+      [internalRealtimeSecretHeader]: "queue-secret",
+    });
+  });
+
+  test("throws on missing secrets and failed queue responses", async () => {
+    await expectRejectsWithMessage(
+      () => publishQueueMatched("black", { matchId: "match-1" }),
+      "Missing REALTIME_INTERNAL_SECRET",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    process.env["REALTIME_INTERNAL_SECRET"] = "queue-secret";
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 502 }));
+
+    await expectRejectsWithMessage(
+      () => publishQueueMatched("black", { matchId: "match-1" }),
+      "Failed to publish queue:matched (502)",
+    );
+  });
+});
+
+describe("publishChallengeDeclined", () => {
+  test("posts a decline notification with the username envelope", async () => {
+    process.env["REALTIME_CHALLENGE_DECLINED_URL"] =
+      "http://localhost:3001/internal/challenge-declined";
+    process.env["REALTIME_INTERNAL_SECRET"] = "decline-secret";
+
+    await publishChallengeDeclined(
+      "black",
+      {
+        matchId: "match-1",
+        senderUsername: "white",
+      },
+      5000,
+    );
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+
+    expect(call?.[0]).toBe("http://localhost:3001/internal/challenge-declined");
+    expect(call?.[1]).toMatchObject({
+      body: JSON.stringify({
+        matchId: "match-1",
+        senderUsername: "white",
+        username: "black",
+      }),
+      cache: "no-store",
+      method: "POST",
+    });
+    expect(call?.[1].headers).toEqual({
+      "Content-Type": "application/json",
+      [internalRealtimeSecretHeader]: "decline-secret",
+    });
+  });
+
+  test("throws on failed challenge-declined responses", async () => {
+    process.env["REALTIME_INTERNAL_SECRET"] = "decline-secret";
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    await expectRejectsWithMessage(
+      () =>
+        publishChallengeDeclined("black", {
+          matchId: "match-1",
+          senderUsername: "white",
+        }),
+      "Failed to publish challenge:declined (503)",
+    );
   });
 });

--- a/app/lib/stats/profile-stats.test.ts
+++ b/app/lib/stats/profile-stats.test.ts
@@ -197,4 +197,22 @@ describe("profile stats", () => {
       },
     });
   });
+
+  test("normalizes recent-match pagination options before querying history", async () => {
+    await getProfileStatsForUser("user-ada", {
+      recentMatchesLimit: 0,
+      recentMatchesPage: -2,
+    });
+
+    expect(getMatchHistoryPageForUser).toHaveBeenCalledWith("user-ada", 1, 1);
+
+    getMatchHistoryPageForUser.mockClear();
+
+    await getProfileStatsForUser("user-ada", {
+      recentMatchesLimit: 999,
+      recentMatchesPage: 4,
+    });
+
+    expect(getMatchHistoryPageForUser).toHaveBeenCalledWith("user-ada", 4, 50);
+  });
 });

--- a/app/test-utils/auth-module-mock.ts
+++ b/app/test-utils/auth-module-mock.ts
@@ -1,0 +1,48 @@
+type DuplicateSignupFields = {
+  email?: boolean;
+  username?: boolean;
+};
+
+type UserForResponse = {
+  displayName: string;
+  email: string;
+  emailVerified?: boolean | null;
+  emailVerifiedAt?: Date | string | null;
+  id: string;
+  username: string;
+};
+
+type AuthModuleMock = {
+  auth: {
+    api: Record<string, unknown>;
+  };
+  getConfiguredOAuthProviders: () => string[];
+  getCurrentSession: () => Promise<unknown>;
+  getDuplicateSignupFields: (email: string, username: string) => Promise<DuplicateSignupFields>;
+  serializeUserForResponse: (user: UserForResponse) => {
+    displayName: string;
+    email: string;
+    emailVerified: boolean;
+    id: string;
+    username: string;
+  };
+};
+
+export function createAuthModuleMock(overrides: Partial<AuthModuleMock> = {}): AuthModuleMock {
+  return {
+    auth: {
+      api: {},
+    },
+    getConfiguredOAuthProviders: () => [],
+    getCurrentSession: async () => null,
+    getDuplicateSignupFields: async () => ({}),
+    serializeUserForResponse: (user) => ({
+      displayName: user.displayName,
+      email: user.email,
+      emailVerified: Boolean(user.emailVerified || user.emailVerifiedAt),
+      id: user.id,
+      username: user.username,
+    }),
+    ...overrides,
+  };
+}

--- a/realtime/lib/internal-queue-matched.test.ts
+++ b/realtime/lib/internal-queue-matched.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { internalRealtimeSecretHeader } from "../../shared/realtime-internal";
+import { handleInternalQueueMatched } from "./internal-queue-matched";
+
+describe("handleInternalQueueMatched", () => {
+  test("rejects requests without a configured or matching internal secret", async () => {
+    const unconfigured = await handleInternalQueueMatched(request({}, "wrong-secret"), io(), "");
+    const unauthorized = await handleInternalQueueMatched(
+      request({}, "wrong-secret"),
+      io(),
+      "secret",
+    );
+
+    expect(unconfigured.status).toBe(503);
+    expect(await unconfigured.json()).toEqual({ error: "internal_secret_unconfigured" });
+    expect(unauthorized.status).toBe(401);
+    expect(await unauthorized.json()).toEqual({ error: "unauthorized" });
+  });
+
+  test("rejects malformed JSON payloads", async () => {
+    const response = await handleInternalQueueMatched(
+      new Request("http://realtime/internal/queue-matched", {
+        body: "{",
+        headers: {
+          [internalRealtimeSecretHeader]: "secret",
+        },
+        method: "POST",
+      }),
+      io(),
+      "secret",
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_payload" });
+  });
+
+  test("broadcasts matched sessions to the target user room", async () => {
+    const emit = mock();
+    const to = mock((_room: string) => ({
+      emit,
+    }));
+    const server = { to };
+
+    const response = await handleInternalQueueMatched(
+      request(
+        {
+          username: "black",
+          session: {
+            matchId: "match-1",
+            participantId: "black-player",
+          },
+        },
+        "secret",
+      ),
+      server,
+      "secret",
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(to).toHaveBeenCalledWith("user:black");
+    expect(emit).toHaveBeenCalledWith("queue:matched", {
+      matchId: "match-1",
+      participantId: "black-player",
+    });
+    expect(emit).toHaveBeenCalledWith("queue:status", {
+      kind: "matched",
+      session: {
+        matchId: "match-1",
+        participantId: "black-player",
+      },
+    });
+  });
+});
+
+function request(payload: unknown, secret: string) {
+  return new Request("http://realtime/internal/queue-matched", {
+    body: JSON.stringify(payload),
+    headers: {
+      [internalRealtimeSecretHeader]: secret,
+    },
+    method: "POST",
+  });
+}
+
+function io() {
+  return {
+    to: mock(() => ({
+      emit: mock(),
+    })),
+  };
+}

--- a/tests/e2e/human-lobby.e2e.ts
+++ b/tests/e2e/human-lobby.e2e.ts
@@ -246,6 +246,74 @@ test("human lobby joins a waiting room and stores the returned session", async (
   await expect(page.getByTestId("human-match-board")).toBeVisible();
 });
 
+test("human lobby paginates waiting rooms through the lobby API", async ({ page }) => {
+  const requestedPages: string[] = [];
+
+  await page.route(
+    (url) => url.pathname === "/api/matches",
+    async (route) => {
+      const url = new URL(route.request().url());
+      const pageNumber = Number(url.searchParams.get("page") ?? "1");
+      requestedPages.push(String(pageNumber));
+
+      await route.fulfill({
+        body: JSON.stringify(
+          lobbyMatchesResponse(
+            [
+              {
+                boardSize: 15,
+                matchId: `page-${pageNumber}-match`,
+                participants: [
+                  {
+                    displayName: pageNumber === 1 ? "Ada" : "Grace",
+                    seat: "BLACK",
+                  },
+                ],
+                status: "WAITING",
+              },
+            ],
+            pageNumber,
+            2,
+          ),
+        ),
+        contentType: "application/json",
+        status: 200,
+      });
+    },
+  );
+
+  await page.goto("/en/human", { waitUntil: "domcontentloaded" });
+
+  await expect.poll(() => requestedPages.at(-1), { timeout: 30_000 }).toBe("1");
+  await expect(page.getByText("Ada's room")).toBeVisible();
+  await expect(page.getByText("Page 1 of 2")).toBeVisible();
+
+  const previousButton = page
+    .getByRole("button", { exact: true, name: "Previous" })
+    .filter({ visible: true });
+  const nextButton = page
+    .getByRole("button", { exact: true, name: "Next" })
+    .filter({ visible: true });
+
+  await expect(previousButton).toBeDisabled();
+  await expect(nextButton).toBeEnabled();
+
+  await nextButton.click();
+
+  await expect.poll(() => requestedPages.at(-1)).toBe("2");
+  await expect(page.getByText("Grace's room")).toBeVisible();
+  await expect(page.getByText("Ada's room")).toHaveCount(0);
+  await expect(page.getByText("Page 2 of 2")).toBeVisible();
+  await expect(nextButton).toBeDisabled();
+  await expect(previousButton).toBeEnabled();
+
+  await previousButton.click();
+
+  await expect.poll(() => requestedPages.at(-1)).toBe("1");
+  await expect(page.getByText("Ada's room")).toBeVisible();
+  await expect(page.getByText("Page 1 of 2")).toBeVisible();
+});
+
 async function readStoredSession(page: Page) {
   return page.evaluate((activeKey) => {
     const activeMatchId = sessionStorage.getItem(activeKey);
@@ -259,13 +327,13 @@ async function readStoredSession(page: Page) {
   }, activeSessionKey);
 }
 
-function lobbyMatchesResponse(data: unknown[]) {
+function lobbyMatchesResponse(data: unknown[], page = 1, totalPages?: number) {
   return {
     data,
     limit: 10,
-    page: 1,
+    page,
     totalMatches: data.length,
-    totalPages: Math.max(1, Math.ceil(data.length / 10)),
+    totalPages: totalPages ?? Math.max(1, Math.ceil(data.length / 10)),
   };
 }
 

--- a/tests/e2e/pagination.e2e.ts
+++ b/tests/e2e/pagination.e2e.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from "node:crypto";
+
+import { createId } from "@paralleldrive/cuid2";
+import { expect, type Page, type TestInfo, test } from "@playwright/test";
+import { hashPassword } from "better-auth/crypto";
+
+import { prisma } from "../../app/lib/prisma";
+import {
+  MatchResult,
+  MatchStatus,
+  MatchVisibility,
+  Role,
+  RuleType,
+  Seat,
+} from "../../generated/prisma/enums";
+
+test.setTimeout(90_000);
+
+test("friends roster pagination shows one page of friends at a time", async ({
+  page,
+}, testInfo) => {
+  const user = await createAndSignInTestUser(page, testInfo);
+  const friends = await createAcceptedFriends(user.id, user.token, 11);
+  const friendNames = friends.map((friend) => friend.displayName);
+
+  try {
+    await gotoAppRoute(page, "/friends");
+
+    await expect(page.getByText("Page 1 of 2")).toBeVisible();
+    const firstPageNames = await visibleFriendNames(page, friendNames);
+    expect(firstPageNames).toHaveLength(10);
+
+    const nextButton = page
+      .getByRole("button", { exact: true, name: "Next" })
+      .filter({ visible: true });
+    const previousButton = page
+      .getByRole("button", { exact: true, name: "Previous" })
+      .filter({ visible: true });
+
+    await expect(previousButton).toBeDisabled();
+    await nextButton.click();
+
+    await expect(page.getByText("Page 2 of 2")).toBeVisible();
+    const secondPageNames = await visibleFriendNames(page, friendNames);
+    expect(secondPageNames).toHaveLength(1);
+    expect(firstPageNames).not.toContain(secondPageNames[0]);
+    await expect(nextButton).toBeDisabled();
+
+    await previousButton.click();
+
+    await expect(page.getByText("Page 1 of 2")).toBeVisible();
+    expect(await visibleFriendNames(page, friendNames)).toEqual(firstPageNames);
+  } finally {
+    await cleanupUsers([user.username, ...friends.map((friend) => friend.username)]);
+  }
+});
+
+test("public profile match history pagination updates the historyPage query", async ({ page }) => {
+  const created = await createProfileWithMatchHistory(11);
+  const newestOpponent = created.opponents[0];
+  const oldestOpponent = created.opponents.at(-1);
+
+  if (!newestOpponent || !oldestOpponent) {
+    throw new Error("Expected profile history fixture to create opponents");
+  }
+
+  try {
+    await gotoAppRoute(page, `/profile/${created.profile.username}`);
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: created.profile.displayName }),
+    ).toBeVisible();
+    await expect(page.getByText("Page 1 of 2")).toBeVisible();
+    await expect(page.getByText(newestOpponent.displayName, { exact: true })).toBeVisible();
+    await expect(page.getByText(oldestOpponent.displayName, { exact: true })).toHaveCount(0);
+
+    await page.getByRole("button", { exact: true, name: "Next" }).filter({ visible: true }).click();
+
+    await expect(page).toHaveURL(/historyPage=2/);
+    await expect(page.getByText("Page 2 of 2")).toBeVisible();
+    await expect(page.getByText(oldestOpponent.displayName, { exact: true })).toBeVisible();
+    await expect(page.getByText(newestOpponent.displayName, { exact: true })).toHaveCount(0);
+
+    await page
+      .getByRole("button", { exact: true, name: "Previous" })
+      .filter({ visible: true })
+      .click();
+
+    await expect(page).not.toHaveURL(/historyPage=/);
+    await expect(page.getByText("Page 1 of 2")).toBeVisible();
+  } finally {
+    await cleanupMatches(created.matchIds);
+    await cleanupUsers([
+      created.profile.username,
+      ...created.opponents.map((opponent) => opponent.username),
+    ]);
+  }
+});
+
+async function gotoAppRoute(page: Page, route: string) {
+  await page.goto(route, { waitUntil: "domcontentloaded" });
+}
+
+type TestUser = {
+  displayName: string;
+  email: string;
+  id: string;
+  token: string;
+  username: string;
+};
+
+async function createAndSignInTestUser(page: Page, testInfo: TestInfo): Promise<TestUser> {
+  const project = testInfo.project.name
+    .replace(/[^a-z0-9]/gi, "")
+    .toLowerCase()
+    .slice(0, 6);
+  const token = `${project}${testInfo.workerIndex}${randomUUID().slice(0, 8)}`;
+  const username = `e2e_page_${token}`;
+  const email = `gomoku.page.${token}@example.com`;
+  const displayName = `Page Player ${token.slice(-4)}`;
+  const userId = createId();
+  const hashedPassword = await hashPassword("password123");
+
+  const dbUser = await prisma.user.create({
+    data: {
+      accounts: {
+        create: {
+          accountId: userId,
+          id: createId(),
+          password: hashedPassword,
+          providerId: "credential",
+        },
+      },
+      displayName,
+      email,
+      emailVerified: true,
+      emailVerifiedAt: new Date(),
+      id: userId,
+      username,
+    },
+    select: { id: true },
+  });
+
+  try {
+    await gotoAppRoute(page, "/login");
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill("password123");
+    await page.getByRole("button", { exact: true, name: "Sign in" }).click();
+    await expect(page).toHaveURL(/\/en\/profile$/);
+  } catch (error) {
+    await cleanupUsers([username]);
+    throw error;
+  }
+
+  return {
+    displayName,
+    email,
+    id: dbUser.id,
+    token,
+    username,
+  };
+}
+
+async function createAcceptedFriends(userId: string, token: string, count: number) {
+  const friends: Array<{ displayName: string; username: string }> = [];
+
+  for (let index = 0; index < count; index += 1) {
+    const suffix = `${token}_${index.toString().padStart(2, "0")}`;
+    const friend = await prisma.user.create({
+      data: {
+        displayName: `Roster Friend ${index.toString().padStart(2, "0")} ${token.slice(-4)}`,
+        email: `gomoku.roster.${suffix}@example.com`,
+        emailVerified: true,
+        username: `e2e_roster_${suffix}`,
+      },
+    });
+    const friendshipIds = orderedFriendshipIds(userId, friend.id);
+
+    await prisma.friendship.create({
+      data: {
+        acceptedAt: new Date(),
+        requestedById: userId,
+        respondedAt: new Date(),
+        status: "ACCEPTED",
+        userHighId: friendshipIds.userHighId,
+        userLowId: friendshipIds.userLowId,
+      },
+    });
+
+    friends.push({
+      displayName: friend.displayName,
+      username: friend.username,
+    });
+  }
+
+  return friends;
+}
+
+async function visibleFriendNames(page: Page, friendNames: string[]) {
+  const tableText = await page.getByTestId("friends-table").filter({ visible: true }).innerText();
+
+  return friendNames.filter((name) => tableText.includes(name));
+}
+
+async function createProfileWithMatchHistory(count: number) {
+  const token = `hist_${randomUUID().slice(0, 8)}`;
+  const profile = await prisma.user.create({
+    data: {
+      displayName: `History Player ${token.slice(-4)}`,
+      email: `gomoku.history.${token}@example.com`,
+      emailVerified: true,
+      username: `e2e_${token}`,
+    },
+  });
+  const opponents: Array<{ displayName: string; username: string }> = [];
+  const matchIds: string[] = [];
+
+  for (let index = 0; index < count; index += 1) {
+    const suffix = `${token}_${index.toString().padStart(2, "0")}`;
+    const opponent = await prisma.user.create({
+      data: {
+        displayName: `History Rival ${index.toString().padStart(2, "0")} ${token.slice(-4)}`,
+        email: `gomoku.history.rival.${suffix}@example.com`,
+        emailVerified: true,
+        username: `e2e_rival_${suffix}`,
+      },
+    });
+    const matchId = createId();
+    const finishedAt = new Date(Date.UTC(2026, 4, 20 - index, 12, 0, 0));
+
+    await prisma.match.create({
+      data: {
+        boardSize: 15,
+        createdAt: new Date(finishedAt.getTime() - 15 * 60_000),
+        endReason: "five_in_a_row",
+        finishedAt,
+        id: matchId,
+        participants: {
+          create: [
+            {
+              displayNameSnapshot: profile.displayName,
+              result: MatchResult.WIN,
+              role: Role.PLAYER,
+              seat: Seat.BLACK,
+              userId: profile.id,
+            },
+            {
+              displayNameSnapshot: opponent.displayName,
+              result: MatchResult.LOSS,
+              role: Role.PLAYER,
+              seat: Seat.WHITE,
+              userId: opponent.id,
+            },
+          ],
+        },
+        ruleType: RuleType.GOMOKU,
+        startedAt: new Date(finishedAt.getTime() - 10 * 60_000),
+        status: MatchStatus.FINISHED,
+        visibility: MatchVisibility.PUBLIC,
+        winningSeat: Seat.BLACK,
+      },
+    });
+
+    opponents.push({
+      displayName: opponent.displayName,
+      username: opponent.username,
+    });
+    matchIds.push(matchId);
+  }
+
+  return { matchIds, opponents, profile };
+}
+
+function orderedFriendshipIds(left: string, right: string) {
+  return left < right
+    ? { userHighId: right, userLowId: left }
+    : { userHighId: left, userLowId: right };
+}
+
+async function cleanupMatches(matchIds: string[]) {
+  await prisma.match.deleteMany({
+    where: {
+      id: {
+        in: matchIds,
+      },
+    },
+  });
+}
+
+async function cleanupUsers(usernames: string[]) {
+  await prisma.user.deleteMany({
+    where: {
+      username: {
+        in: usernames,
+      },
+    },
+  });
+}

--- a/tests/e2e/pagination.e2e.ts
+++ b/tests/e2e/pagination.e2e.ts
@@ -26,7 +26,7 @@ test("friends roster pagination shows one page of friends at a time", async ({
   try {
     await gotoAppRoute(page, "/friends");
 
-    await expect(page.getByText("Page 1 of 2")).toBeVisible();
+    await expect(visibleText(page, "Page 1 of 2")).toBeVisible();
     const firstPageNames = await visibleFriendNames(page, friendNames);
     expect(firstPageNames).toHaveLength(10);
 
@@ -40,7 +40,7 @@ test("friends roster pagination shows one page of friends at a time", async ({
     await expect(previousButton).toBeDisabled();
     await nextButton.click();
 
-    await expect(page.getByText("Page 2 of 2")).toBeVisible();
+    await expect(visibleText(page, "Page 2 of 2")).toBeVisible();
     const secondPageNames = await visibleFriendNames(page, friendNames);
     expect(secondPageNames).toHaveLength(1);
     expect(firstPageNames).not.toContain(secondPageNames[0]);
@@ -48,7 +48,7 @@ test("friends roster pagination shows one page of friends at a time", async ({
 
     await previousButton.click();
 
-    await expect(page.getByText("Page 1 of 2")).toBeVisible();
+    await expect(visibleText(page, "Page 1 of 2")).toBeVisible();
     expect(await visibleFriendNames(page, friendNames)).toEqual(firstPageNames);
   } finally {
     await cleanupUsers([user.username, ...friends.map((friend) => friend.username)]);
@@ -70,16 +70,16 @@ test("public profile match history pagination updates the historyPage query", as
     await expect(
       page.getByRole("heading", { level: 1, name: created.profile.displayName }),
     ).toBeVisible();
-    await expect(page.getByText("Page 1 of 2")).toBeVisible();
-    await expect(page.getByText(newestOpponent.displayName, { exact: true })).toBeVisible();
-    await expect(page.getByText(oldestOpponent.displayName, { exact: true })).toHaveCount(0);
+    await expect(visibleText(page, "Page 1 of 2")).toBeVisible();
+    await expect(visibleText(page, newestOpponent.displayName)).toBeVisible();
+    await expect(visibleText(page, oldestOpponent.displayName)).toHaveCount(0);
 
     await page.getByRole("button", { exact: true, name: "Next" }).filter({ visible: true }).click();
 
     await expect(page).toHaveURL(/historyPage=2/);
-    await expect(page.getByText("Page 2 of 2")).toBeVisible();
-    await expect(page.getByText(oldestOpponent.displayName, { exact: true })).toBeVisible();
-    await expect(page.getByText(newestOpponent.displayName, { exact: true })).toHaveCount(0);
+    await expect(visibleText(page, "Page 2 of 2")).toBeVisible();
+    await expect(visibleText(page, oldestOpponent.displayName)).toBeVisible();
+    await expect(visibleText(page, newestOpponent.displayName)).toHaveCount(0);
 
     await page
       .getByRole("button", { exact: true, name: "Previous" })
@@ -87,7 +87,7 @@ test("public profile match history pagination updates the historyPage query", as
       .click();
 
     await expect(page).not.toHaveURL(/historyPage=/);
-    await expect(page.getByText("Page 1 of 2")).toBeVisible();
+    await expect(visibleText(page, "Page 1 of 2")).toBeVisible();
   } finally {
     await cleanupMatches(created.matchIds);
     await cleanupUsers([
@@ -99,6 +99,10 @@ test("public profile match history pagination updates the historyPage query", as
 
 async function gotoAppRoute(page: Page, route: string) {
   await page.goto(route, { waitUntil: "domcontentloaded" });
+}
+
+function visibleText(page: Page, text: string) {
+  return page.getByText(text, { exact: true }).filter({ visible: true });
 }
 
 type TestUser = {


### PR DESCRIPTION
## Summary
- Add focused Bun tests for auth actions/routes, API helpers, i18n locale resolution, health/logout, profile/friends actions, realtime queue events, and match route edge cases.
- Expand pagination coverage for lobby, match history, profile stats, human lobby browser flow, friends roster browser flow, and public profile history browser flow.
- Add a shared auth module mock helper and remove friendship-mutation module mocks from action tests so route/action tests keep the real delete-and-notify path wired.
- Replace brittle lobby pagination assertions over Prisma `skip`/`take` internals with response-contract assertions.

## Verification
- `bun test --coverage` — 274 pass, 0 fail, 91.14% functions / 93.67% lines
- `bun test`
- `bun run format:check`
- `bun run lint:js`
- `bun run lint:css`
- CI `Quality And Build` — passed on `1aed86f`

## Local E2E note
- `bun run test:e2e tests/e2e/human-lobby.e2e.ts` — previously passed across desktop and mobile
- `bun run test:e2e tests/e2e/pagination.e2e.ts --project=chromium` — blocked locally because Postgres is not running on `127.0.0.1:5432`; passed through CI's Postgres-backed E2E run