### PR TITLE
(feat:Slice15-16)Statistics Squashed commit of the following:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.11"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/app/[locale]/leaderboard/page.tsx
+++ b/app/[locale]/leaderboard/page.tsx
@@ -4,9 +4,10 @@ import { connection } from "next/server";
 import { Suspense } from "react";
 
 import { Badge, MetricCard, PageHeader, PageShell, Surface } from "@/components/gomoku-ui";
-import LeaderboardTable from "@/components/leaderboardtable";
+import LeaderboardClient from "@/components/leaderboard-client";
 import { PageLoadingShell } from "@/components/page-loading-shell";
-import { getLeaderboardEntries, type LeaderboardEntry } from "@/lib/leaderboard";
+import { getCurrentSession } from "@/lib/auth";
+import { getLeaderboardSnapshot, type LeaderboardSnapshot } from "@/lib/leaderboard";
 
 type LeaderBoardProps = {
   params: Promise<{
@@ -28,11 +29,12 @@ async function LeaderBoardContent({ params }: LeaderBoardProps) {
   await connection();
 
   const t = await getTranslations({ locale, namespace: "leaderboard" });
-  let entries: LeaderboardEntry[] = [];
+  let snapshot: LeaderboardSnapshot = { entries: [], currentUser: null };
   let leaderboardUnavailable = false;
 
   try {
-    entries = await getLeaderboardEntries();
+    const session = await getCurrentSession();
+    snapshot = await getLeaderboardSnapshot(session?.user.id ?? null);
   } catch (error) {
     leaderboardUnavailable = true;
     console.error("Failed to load leaderboard entries.", error);
@@ -79,31 +81,7 @@ async function LeaderBoardContent({ params }: LeaderBoardProps) {
             />
           ) : (
             <>
-              <LeaderboardTable entries={entries} />
-              <div className="rounded-md border border-[var(--brass)]/35 bg-[linear-gradient(90deg,rgba(216,172,89,0.16),rgba(255,255,255,0.03))] p-4">
-                <div className="grid gap-4 md:grid-cols-[120px_minmax(0,1fr)_repeat(3,110px)] md:items-center">
-                  <div>
-                    <p className="m-0 text-xs font-black tracking-[0.16em] text-[var(--muted-text)] uppercase">
-                      {t("page.spotlight.rankLabel")}
-                    </p>
-                    <p className="m-0 font-serif text-4xl font-black text-[var(--brass)]">3</p>
-                  </div>
-                  <div className="flex min-w-0 items-center gap-3">
-                    <span className="grid size-14 place-items-center rounded-full border border-[var(--brass)]/45 bg-white/[0.08] font-black">
-                      K
-                    </span>
-                    <div>
-                      <p className="m-0 text-xl font-black">Kuroishi</p>
-                      <p className="m-0 text-sm text-[var(--brass)]">
-                        {t("page.spotlight.rating", { rating: "1,842" })}
-                      </p>
-                    </div>
-                  </div>
-                  <MiniMetric label={t("table.wins")} value="254" />
-                  <MiniMetric label={t("table.losses")} value="81" />
-                  <MiniMetric label={t("table.winRate")} value="75.8%" />
-                </div>
-              </div>
+              <LeaderboardClient initial={snapshot} />
             </>
           )}
         </Surface>
@@ -186,15 +164,6 @@ function LeaderboardUnavailable({ description, title }: { description: string; t
         <h2 className="m-0 font-serif text-3xl leading-none font-black">{title}</h2>
         <p className="mt-3 mb-0 text-sm leading-6 text-[var(--muted-text)]">{description}</p>
       </div>
-    </div>
-  );
-}
-
-function MiniMetric({ label, value }: { label: string; value: string }) {
-  return (
-    <div>
-      <p className="m-0 text-xl font-black tabular-nums">{value}</p>
-      <p className="m-0 text-xs font-bold text-[var(--muted-text)]">{label}</p>
     </div>
   );
 }

--- a/app/[locale]/leaderboard/page.tsx
+++ b/app/[locale]/leaderboard/page.tsx
@@ -7,7 +7,12 @@ import { Badge, MetricCard, PageHeader, PageShell, Surface } from "@/components/
 import LeaderboardClient from "@/components/leaderboard-client";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { getCurrentSession } from "@/lib/auth";
-import { getLeaderboardSnapshot, type LeaderboardSnapshot } from "@/lib/leaderboard";
+import {
+  getLeaderboardSnapshot,
+  type LeaderboardSnapshot,
+  type LeaderboardEntry,
+} from "@/lib/leaderboard";
+import { getSeasonSnapshot, type SeasonSnapshot } from "@/lib/stats/season-stats";
 
 type LeaderBoardProps = {
   params: Promise<{
@@ -23,6 +28,43 @@ export default function LeaderBoard({ params }: LeaderBoardProps) {
   );
 }
 
+type RankBand = "dan" | "kyu" | "unranked";
+
+function countRankBands(entries: LeaderboardEntry[]) {
+  return entries.reduce(
+    (accumulator, entry) => {
+      const band = getRankBand(entry.rating);
+      accumulator[band] += 1;
+      return accumulator;
+    },
+    {
+      dan: 0,
+      kyu: 0,
+      unranked: 0,
+    } as Record<RankBand, number>,
+  );
+}
+
+function getRankBand(rating: number): RankBand {
+  if (rating >= 1800) return "dan";
+  if (rating >= 1000) return "kyu";
+  return "unranked";
+}
+
+function LeaderboardEmptyState({ description, title }: { description: string; title: string }) {
+  return (
+    <div className="grid min-h-[220px] place-items-center rounded-md border border-[var(--panel-border-soft)] bg-white/[0.025] p-6 text-center">
+      <div className="max-w-sm">
+        <div className="mx-auto mb-3 grid size-12 place-items-center rounded-md border border-[var(--panel-border-soft)] bg-white/[0.03]">
+          <Medal aria-hidden="true" className="size-6 text-[var(--brass)]" />
+        </div>
+        <h3 className="m-0 mb-2 font-serif text-xl font-black">{title}</h3>
+        <p className="m-0 text-sm leading-6 text-[var(--muted-text)]">{description}</p>
+      </div>
+    </div>
+  );
+}
+
 async function LeaderBoardContent({ params }: LeaderBoardProps) {
   const { locale } = await params;
   setRequestLocale(locale);
@@ -30,15 +72,58 @@ async function LeaderBoardContent({ params }: LeaderBoardProps) {
 
   const t = await getTranslations({ locale, namespace: "leaderboard" });
   let snapshot: LeaderboardSnapshot = { entries: [], currentUser: null };
+  let seasonSnapshot: SeasonSnapshot = {
+    daysLeft: 0,
+    ratedMatchCount: 0,
+    season: {
+      daysLeft: 0,
+      end: new Date(0),
+      season: 1,
+      start: new Date(0),
+      year: 1970,
+    },
+  };
   let leaderboardUnavailable = false;
 
   try {
     const session = await getCurrentSession();
-    snapshot = await getLeaderboardSnapshot(session?.user.id ?? null);
+    const [leaderboardData, seasonData] = await Promise.all([
+      getLeaderboardSnapshot(session?.user.id ?? null),
+      getSeasonSnapshot(),
+    ]);
+    snapshot = leaderboardData;
+    seasonSnapshot = seasonData;
   } catch (error) {
     leaderboardUnavailable = true;
     console.error("Failed to load leaderboard entries.", error);
   }
+
+  const entries = snapshot.entries ?? [];
+  const bandCounts = countRankBands(entries);
+  const distribution =
+    entries.length > 0
+      ? [
+          {
+            key: "dan",
+            label: t("page.distribution.labels.dan"),
+            count: bandCounts.dan,
+            color: "bg-[var(--brass)]",
+          },
+          {
+            key: "kyu",
+            label: t("page.distribution.labels.kyu"),
+            count: bandCounts.kyu,
+            color: "bg-[var(--mint)]",
+          },
+          {
+            key: "unranked",
+            label: t("page.distribution.labels.unranked"),
+            count: bandCounts.unranked,
+            color: "bg-[var(--danger)]",
+          },
+        ].map((band) => ({ ...band, share: `${Math.round((band.count / entries.length) * 100)}%` }))
+      : [];
+  const topPlayers = entries.slice(0, 3);
 
   return (
     <PageShell>
@@ -88,9 +173,17 @@ async function LeaderBoardContent({ params }: LeaderBoardProps) {
 
         <aside className="grid content-start gap-5">
           <Surface eyebrow={t("page.season.eyebrow")} icon={Medal} title={t("page.season.title")}>
-            <div className="grid gap-3">
-              <MetricCard label={t("page.season.daysLeft")} tone="brass" value="18" />
-              <MetricCard label={t("page.season.ratedMatches")} tone="mint" value="12,408" />
+            <div className="grid gap-3 sm:grid-cols-2">
+              <MetricCard
+                label={t("page.season.daysLeft")}
+                tone="brass"
+                value={seasonSnapshot.daysLeft}
+              />
+              <MetricCard
+                label={t("page.season.ratedMatches")}
+                tone="mint"
+                value={seasonSnapshot.ratedMatchCount.toLocaleString()}
+              />
             </div>
           </Surface>
 
@@ -99,26 +192,29 @@ async function LeaderBoardContent({ params }: LeaderBoardProps) {
             icon={BarChart3}
             title={t("page.distribution.title")}
           >
-            <div className="grid gap-3">
-              {[
-                [t("page.distribution.labels.dan"), "22%", "bg-[var(--brass)]"],
-                [t("page.distribution.labels.kyu"), "54%", "bg-[var(--mint)]"],
-                [t("page.distribution.labels.unranked"), "24%", "bg-[var(--danger)]"],
-              ].map(([label, value, color]) => (
-                <div key={label}>
-                  <div className="mb-2 flex items-center justify-between text-sm font-bold">
-                    <span>{label}</span>
-                    <span className="text-[var(--muted-text)] tabular-nums">{value}</span>
+            {entries.length === 0 ? (
+              <LeaderboardEmptyState
+                description={t("table.empty.description")}
+                title={t("table.empty.title")}
+              />
+            ) : (
+              <div className="grid gap-3">
+                {distribution.map((band) => (
+                  <div key={band.key}>
+                    <div className="mb-2 flex items-center justify-between text-sm font-bold">
+                      <span>{band.label}</span>
+                      <span className="text-[var(--muted-text)] tabular-nums">{band.share}</span>
+                    </div>
+                    <span className="block h-2 overflow-hidden rounded-full bg-white/[0.08]">
+                      <span
+                        className={`block h-full rounded-full ${band.color}`}
+                        style={{ width: band.share }}
+                      />
+                    </span>
                   </div>
-                  <span className="block h-2 overflow-hidden rounded-full bg-white/[0.08]">
-                    <span
-                      className={`block h-full rounded-full ${color}`}
-                      style={{ width: value }}
-                    />
-                  </span>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            )}
           </Surface>
 
           <Surface
@@ -126,24 +222,41 @@ async function LeaderBoardContent({ params }: LeaderBoardProps) {
             icon={Users}
             title={t("page.topPlayers.title")}
           >
-            <div className="grid gap-2">
-              {["Hoshi", "RenjuMaster", "Kuroishi"].map((name, index) => (
-                <div
-                  key={name}
-                  className="grid min-h-12 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-[var(--panel-border-soft)] bg-white/[0.035] px-3"
-                >
-                  <span className="font-serif text-2xl font-bold text-[var(--brass)]">
-                    {index + 1}
-                  </span>
-                  <span className="truncate font-black">{name}</span>
-                  <Badge tone={index === 0 ? "brass" : "neutral"}>
-                    {index === 0
-                      ? t("page.topPlayers.badges.mvp")
-                      : t("page.topPlayers.badges.boost")}
-                  </Badge>
-                </div>
-              ))}
-            </div>
+            {topPlayers.length === 0 ? (
+              <LeaderboardEmptyState
+                description={t("table.empty.description")}
+                title={t("table.empty.title")}
+              />
+            ) : (
+              <div className="grid gap-2">
+                {topPlayers.map((entry) => {
+                  const band = getRankBand(entry.rating);
+                  const bandLabel =
+                    band === "dan"
+                      ? t("page.distribution.labels.dan")
+                      : band === "kyu"
+                        ? t("page.distribution.labels.kyu")
+                        : t("page.distribution.labels.unranked");
+
+                  return (
+                    <div
+                      key={entry.playerId}
+                      className="grid min-h-12 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-[var(--panel-border-soft)] bg-white/[0.035] px-3"
+                    >
+                      <span className="font-serif text-2xl font-bold text-[var(--brass)]">
+                        {entry.rank}
+                      </span>
+                      <span className="truncate font-black">{entry.player}</span>
+                      <Badge
+                        tone={entry.rank === 1 ? "brass" : entry.rank === 2 ? "mint" : "neutral"}
+                      >
+                        {bandLabel}
+                      </Badge>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </Surface>
         </aside>
       </section>

--- a/app/api/leaderboard/route.test.ts
+++ b/app/api/leaderboard/route.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getCurrentSession = mock();
+const getLeaderboardSnapshot = mock();
+
+await mock.module("@/lib/auth", () => ({
+  getCurrentSession,
+}));
+
+await mock.module("@/lib/leaderboard", () => ({
+  getLeaderboardSnapshot,
+}));
+
+const route = await import("./route");
+
+beforeEach(() => {
+  getCurrentSession.mockReset();
+  getLeaderboardSnapshot.mockReset();
+
+  getCurrentSession.mockResolvedValue({
+    user: {
+      id: "user-ada",
+    },
+  });
+
+  getLeaderboardSnapshot.mockResolvedValue({
+    entries: [
+      {
+        playerId: "user-ada",
+        rank: 1,
+        player: "Ada",
+        rating: 1200,
+        wins: 3,
+        losses: 1,
+        winRate: "75.00%",
+      },
+    ],
+    currentUser: {
+      playerId: "user-ada",
+      rank: 1,
+      player: "Ada",
+      rating: 1200,
+      wins: 3,
+      losses: 1,
+      winRate: "75.00%",
+    },
+  });
+});
+
+describe("GET /api/leaderboard", () => {
+  test("returns the leaderboard snapshot for signed-in users", async () => {
+    const response = await route.GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getLeaderboardSnapshot).toHaveBeenCalledWith("user-ada");
+    expect(payload).toMatchObject({
+      entries: [{ playerId: "user-ada", rank: 1 }],
+      currentUser: { playerId: "user-ada", rank: 1 },
+    });
+  });
+
+  test("allows anonymous access", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+
+    const response = await route.GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getLeaderboardSnapshot).toHaveBeenCalledWith(null);
+    expect(payload).toMatchObject({
+      entries: [{ playerId: "user-ada", rank: 1 }],
+    });
+  });
+
+  test("returns a server error when snapshot fails to load", async () => {
+    getLeaderboardSnapshot.mockRejectedValueOnce(new Error("boom"));
+
+    const response = await route.GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload).toMatchObject({ error: "failed_to_load_leaderboard" });
+  });
+});

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,0 +1,23 @@
+import { getCurrentSession } from "@/lib/auth";
+import { getLeaderboardSnapshot } from "@/lib/leaderboard";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+export async function GET() {
+  try {
+    const context = await getCurrentSession();
+    const snapshot = await getLeaderboardSnapshot(context?.user.id ?? null);
+
+    return Response.json(snapshot);
+  } catch (error) {
+    return Response.json(
+      {
+        error: "failed_to_load_leaderboard",
+        detail: getErrorMessage(error),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/components/leaderboard-client.tsx
+++ b/app/components/leaderboard-client.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { RefreshCw } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import LeaderboardTable from "@/components/leaderboardtable";
+import { useLeaderboard } from "@/hooks/useLeaderboard";
+
+type LeaderboardEntry = {
+  playerId: string;
+  rank: number;
+  player: string;
+  rating: number;
+  wins: number;
+  losses: number;
+  winRate: string;
+};
+
+type LeaderboardSnapshot = {
+  entries: LeaderboardEntry[];
+  currentUser: LeaderboardEntry | null;
+};
+
+export default function LeaderboardClient({ initial }: { initial?: LeaderboardSnapshot | null }) {
+  const t = useTranslations("leaderboard");
+  const { entries, currentUser, loading, error, refresh } = useLeaderboard(initial ?? null);
+
+  return (
+    <>
+      <LeaderboardTable entries={entries} />
+
+      <div className="rounded-md border border-[var(--brass)]/35 bg-[linear-gradient(90deg,rgba(216,172,89,0.16),rgba(255,255,255,0.03))] p-4">
+        <div className="flex items-start justify-between">
+          <div className="grid gap-2 md:grid-cols-[120px_minmax(0,1fr)_repeat(3,110px)] md:items-center">
+            <div>
+              <p className="m-0 text-xs font-black tracking-[0.16em] text-[var(--muted-text)] uppercase">
+                {t("page.spotlight.rankLabel")}
+              </p>
+              <p className="m-0 font-serif text-4xl font-black text-[var(--brass)]">
+                {currentUser?.rank ?? "—"}
+              </p>
+            </div>
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="grid size-14 place-items-center rounded-full border border-[var(--brass)]/45 bg-white/[0.08] font-black">
+                {currentUser ? currentUser.player.charAt(0) : "?"}
+              </span>
+              <div>
+                <p className="m-0 text-xl font-black">
+                  {currentUser?.player ?? t("page.spotlight.noPlayer")}
+                </p>
+                <p className="m-0 text-sm text-[var(--brass)]">
+                  {t("page.spotlight.rating", {
+                    rating: currentUser ? currentUser.rating.toLocaleString() : "—",
+                  })}
+                </p>
+              </div>
+            </div>
+            <div className="hidden md:block">
+              <p className="m-0 text-xs font-bold text-[var(--muted-text)]">{t("table.wins")}</p>
+              <p className="m-0 font-black tabular-nums">{currentUser?.wins ?? "—"}</p>
+            </div>
+            <div className="hidden md:block">
+              <p className="m-0 text-xs font-bold text-[var(--muted-text)]">{t("table.losses")}</p>
+              <p className="m-0 font-black tabular-nums">{currentUser?.losses ?? "—"}</p>
+            </div>
+            <div className="hidden md:block">
+              <p className="m-0 text-xs font-bold text-[var(--muted-text)]">{t("table.winRate")}</p>
+              <p className="m-0 font-black tabular-nums">{currentUser?.winRate ?? "—"}</p>
+            </div>
+          </div>
+
+          <div className="ml-4 flex items-start gap-2">
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-bold"
+              onClick={() => refresh()}
+              disabled={loading}
+            >
+              <RefreshCw className="size-4" />
+              {loading ? t("page.refreshing") : t("page.refresh")}
+            </button>
+          </div>
+        </div>
+
+        {error ? <p className="mt-3 text-sm text-[var(--danger)]">{error}</p> : null}
+      </div>
+    </>
+  );
+}

--- a/app/components/leaderboardtable.tsx
+++ b/app/components/leaderboardtable.tsx
@@ -15,92 +15,24 @@ type LeaderboardTableProps = {
   entries: LeaderboardEntry[];
 };
 
-const previewEntries: LeaderboardEntry[] = [
-  {
-    playerId: "preview-1",
-    rank: 1,
-    player: "Hoshi",
-    rating: 2341,
-    wins: 312,
-    losses: 68,
-    winRate: "82.1%",
-  },
-  {
-    playerId: "preview-2",
-    rank: 2,
-    player: "RenjuMaster",
-    rating: 2187,
-    wins: 276,
-    losses: 74,
-    winRate: "78.9%",
-  },
-  {
-    playerId: "preview-3",
-    rank: 3,
-    player: "Kuroishi",
-    rating: 2042,
-    wins: 254,
-    losses: 81,
-    winRate: "75.8%",
-  },
-  {
-    playerId: "preview-4",
-    rank: 4,
-    player: "Shirotora",
-    rating: 1898,
-    wins: 233,
-    losses: 91,
-    winRate: "71.9%",
-  },
-  {
-    playerId: "preview-5",
-    rank: 5,
-    player: "Tenkei",
-    rating: 1756,
-    wins: 201,
-    losses: 83,
-    winRate: "70.8%",
-  },
-  {
-    playerId: "preview-6",
-    rank: 6,
-    player: "Mokuren",
-    rating: 1643,
-    wins: 189,
-    losses: 96,
-    winRate: "66.3%",
-  },
-  {
-    playerId: "preview-7",
-    rank: 7,
-    player: "GomokuSoul",
-    rating: 1532,
-    wins: 174,
-    losses: 104,
-    winRate: "62.6%",
-  },
-  {
-    playerId: "preview-8",
-    rank: 8,
-    player: "IshiNoKokoro",
-    rating: 1421,
-    wins: 158,
-    losses: 109,
-    winRate: "59.2%",
-  },
-];
-
 export default function LeaderboardTable({ entries }: LeaderboardTableProps) {
   const t = useTranslations("leaderboard.table");
-  const rows = entries.length > 0 ? entries : previewEntries;
-  const isPreview = entries.length === 0;
+  const rows = entries;
+  const isEmpty = entries.length === 0;
 
   return (
     <div className="grid gap-3">
-      {isPreview ? (
-        <div className="flex items-center gap-2 rounded-md border border-[var(--brass)]/30 bg-[var(--brass-soft)] px-3 py-2 text-sm font-bold text-[var(--muted-strong)]">
-          <Medal aria-hidden="true" className="size-4 text-[var(--brass)]" />
-          {t("preview")}
+      {isEmpty ? (
+        <div className="grid min-h-[140px] place-items-center rounded-md border border-[var(--panel-border-soft)] bg-white/[0.02] p-6 text-center">
+          <div className="max-w-sm">
+            <div className="mx-auto mb-3 grid size-12 place-items-center rounded-md border border-[var(--panel-border-soft)] bg-white/[0.03]">
+              <Medal aria-hidden="true" className="size-6 text-[var(--brass)]" />
+            </div>
+            <h3 className="m-0 mb-2 font-serif text-xl font-black">{t("empty.title")}</h3>
+            <p className="m-0 text-sm leading-6 text-[var(--muted-text)]">
+              {t("empty.description")}
+            </p>
+          </div>
         </div>
       ) : null}
 

--- a/app/hooks/useLeaderboard.tsx
+++ b/app/hooks/useLeaderboard.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+
+type LeaderboardEntry = {
+  playerId: string;
+  rank: number;
+  player: string;
+  rating: number;
+  wins: number;
+  losses: number;
+  winRate: string;
+};
+
+type LeaderboardSnapshot = {
+  entries: LeaderboardEntry[];
+  currentUser: LeaderboardEntry | null;
+};
+
+export function useLeaderboard(initial?: LeaderboardSnapshot | null, debounceMs = 800) {
+  const [entries, setEntries] = useState<LeaderboardEntry[]>(initial?.entries ?? []);
+  const [currentUser, setCurrentUser] = useState<LeaderboardEntry | null>(
+    initial?.currentUser ?? null,
+  );
+  const [loading, setLoading] = useState<boolean>(!initial);
+  const [error, setError] = useState<string | null>(null);
+
+  const timerRef = useRef<number | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchSnapshot = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/leaderboard", { signal });
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const body: LeaderboardSnapshot = await res.json();
+      setEntries(body.entries ?? []);
+      setCurrentUser(body.currentUser ?? null);
+    } catch (err: unknown) {
+      if ((err as any)?.name === "AbortError") return;
+      setError((err as Error)?.message ?? "unknown");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const refreshDebounced = useCallback(() => {
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    timerRef.current = window.setTimeout(() => {
+      abortRef.current?.abort();
+      abortRef.current = new AbortController();
+      fetchSnapshot(abortRef.current.signal);
+      timerRef.current = null;
+    }, debounceMs);
+  }, [fetchSnapshot, debounceMs]);
+
+  useEffect(() => {
+    // initial fetch if no initial snapshot provided
+    if (!initial) {
+      abortRef.current = new AbortController();
+      fetchSnapshot(abortRef.current.signal);
+    }
+
+    return () => {
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      if (abortRef.current) {
+        abortRef.current.abort();
+        abortRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    entries,
+    currentUser,
+    loading,
+    error,
+    refreshDebounced,
+    refresh: () => {
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      abortRef.current?.abort();
+      abortRef.current = new AbortController();
+      fetchSnapshot(abortRef.current.signal);
+    },
+  } as const;
+}

--- a/app/i18n/messages/en.ts
+++ b/app/i18n/messages/en.ts
@@ -686,8 +686,11 @@ export const messages = {
       },
       spotlight: {
         rankLabel: "Your Rank",
+        noPlayer: "Unranked",
         rating: "{rating} rating",
       },
+      refresh: "Refresh",
+      refreshing: "Refreshing...",
       season: {
         eyebrow: "Season",
         title: "Spring Ladder",
@@ -724,7 +727,10 @@ export const messages = {
       wins: "Wins",
       losses: "Losses",
       winRate: "Win Rate",
-      empty: "No leaderboard data yet.",
+      empty: {
+        title: "No leaderboard data yet",
+        description: "Play rated matches to appear on the leaderboard.",
+      },
       preview: "Preview standings are shown until completed matches report results.",
       trend: "Trend",
       active: "Active",

--- a/app/i18n/messages/ja.ts
+++ b/app/i18n/messages/ja.ts
@@ -679,8 +679,11 @@ export const messages = {
       },
       spotlight: {
         rankLabel: "あなたの順位",
+        noPlayer: "未ランク",
         rating: "{rating} レーティング",
       },
+      refresh: "更新",
+      refreshing: "更新中...",
       season: {
         eyebrow: "シーズン",
         title: "春のラダー",
@@ -717,7 +720,10 @@ export const messages = {
       wins: "勝利",
       losses: "敗北",
       winRate: "勝率",
-      empty: "ランキングデータはまだありません。",
+      empty: {
+        title: "ランキングデータはまだありません",
+        description: "レート戦をプレイするとランキングに表示されます。",
+      },
       preview: "完了した対局の結果が届くまで、プレビュー順位を表示しています。",
       trend: "推移",
       active: "活動中",

--- a/app/i18n/messages/zh.ts
+++ b/app/i18n/messages/zh.ts
@@ -677,8 +677,11 @@ export const messages = {
       },
       spotlight: {
         rankLabel: "你的排名",
+        noPlayer: "未上榜",
         rating: "{rating} 等级分",
       },
+      refresh: "刷新",
+      refreshing: "刷新中...",
       season: {
         eyebrow: "赛季",
         title: "春季天梯",
@@ -714,7 +717,10 @@ export const messages = {
       wins: "胜场",
       losses: "负场",
       winRate: "胜率",
-      empty: "暂无排行榜数据。",
+      empty: {
+        title: "暂无排行榜数据",
+        description: "进行计分对局后即可出现在排行榜中。",
+      },
       preview: "在已完成对局结果到达之前，将显示预览排名。",
       trend: "趋势",
       active: "活跃",

--- a/app/lib/leaderboard.rank.test.ts
+++ b/app/lib/leaderboard.rank.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { RuleType } from "../../generated/prisma/enums";
+
+const findMany = mock();
+
+await mock.module("./prisma", () => ({
+  prisma: {
+    userGameStats: {
+      findMany,
+    },
+  },
+}));
+
+const { getLeaderboardRank } = await import("./leaderboard");
+
+beforeEach(() => {
+  findMany.mockReset();
+});
+
+describe("getLeaderboardRank", () => {
+  test("ignores bot-only rows when counting players ahead", async () => {
+    findMany.mockResolvedValueOnce([
+      {
+        botMatchesPlayed: 4,
+        matchesPlayed: 4,
+      },
+    ]);
+
+    const rank = await getLeaderboardRank({
+      rating: 1200,
+      wins: 10,
+      losses: 2,
+      matchesPlayed: 8,
+      botMatchesPlayed: 1,
+    });
+
+    expect(rank).toBe(1);
+    expect(findMany).toHaveBeenCalledWith({
+      select: {
+        botMatchesPlayed: true,
+        matchesPlayed: true,
+      },
+      where: {
+        boardSize: 15,
+        OR: [
+          { rating: { gt: 1200 } },
+          {
+            rating: 1200,
+            OR: [{ wins: { gt: 10 } }, { wins: 10, losses: { lt: 2 } }],
+          },
+        ],
+        ruleType: RuleType.GOMOKU,
+        matchesPlayed: { gt: 0 },
+      },
+    });
+  });
+});

--- a/app/lib/leaderboard.test.ts
+++ b/app/lib/leaderboard.test.ts
@@ -2,19 +2,21 @@ import { describe, expect, test } from "bun:test";
 
 import {
   LEADERBOARD_BOARD_SIZE,
-  LEADERBOARD_LIMIT,
+  LEADERBOARD_FETCH_LIMIT,
+  LEADERBOARD_RULE_TYPE,
   formatWinRate,
   leaderboardQueryArgs,
   toLeaderboardEntries,
 } from "./leaderboard";
 
 describe("leaderboard data", () => {
-  test("formats ranked player stats for display", () => {
+  test("formats ranked player stats for display and skips bot-only players", () => {
     expect(
       toLeaderboardEntries([
         {
           losses: 2,
           matchesPlayed: 8,
+          botMatchesPlayed: 2,
           rating: 1300,
           userId: "user_1",
           wins: 6,
@@ -24,7 +26,19 @@ describe("leaderboard data", () => {
         },
         {
           losses: 0,
-          matchesPlayed: 0,
+          matchesPlayed: 5,
+          botMatchesPlayed: 5,
+          rating: 1500,
+          userId: "user_bot",
+          wins: 5,
+          user: {
+            displayName: "BotOnly",
+          },
+        },
+        {
+          losses: 1,
+          matchesPlayed: 1,
+          botMatchesPlayed: 0,
           rating: null,
           userId: "user_2",
           wins: 0,
@@ -44,7 +58,7 @@ describe("leaderboard data", () => {
         wins: 6,
       },
       {
-        losses: 0,
+        losses: 1,
         player: "Grace",
         playerId: "user_2",
         rank: 2,
@@ -59,6 +73,7 @@ describe("leaderboard data", () => {
     expect(leaderboardQueryArgs).toMatchObject({
       orderBy: [{ rating: "desc" }, { wins: "desc" }, { losses: "asc" }],
       select: {
+        botMatchesPlayed: true,
         losses: true,
         matchesPlayed: true,
         rating: true,
@@ -70,10 +85,11 @@ describe("leaderboard data", () => {
           },
         },
       },
-      take: LEADERBOARD_LIMIT,
+      take: LEADERBOARD_FETCH_LIMIT,
       where: {
         boardSize: LEADERBOARD_BOARD_SIZE,
-        ruleType: "GOMOKU",
+        ruleType: LEADERBOARD_RULE_TYPE,
+        matchesPlayed: { gt: 0 },
       },
     });
     expect("include" in leaderboardQueryArgs).toBe(false);

--- a/app/lib/leaderboard.ts
+++ b/app/lib/leaderboard.ts
@@ -131,12 +131,39 @@ export function toLeaderboardEntries(stats: LeaderboardStat[]): LeaderboardEntry
 }
 
 export async function getLeaderboardEntries(): Promise<LeaderboardEntry[]> {
-  //  "use cache";
-  //  cacheLife("minutes");
+  // Fetch in batches and collect eligible (human) rows until we have
+  // `LEADERBOARD_LIMIT` entries or the dataset is exhausted. This moves
+  // the eligibility filter into the data/query boundary and avoids
+  // returning fewer than `LEADERBOARD_LIMIT` entries on bot-heavy data.
+  const results: LeaderboardEntry[] = [];
+  let skip = 0;
 
-  const stats = await prisma.userGameStats.findMany(leaderboardQueryArgs);
+  while (results.length < LEADERBOARD_LIMIT) {
+    const args = {
+      ...leaderboardQueryArgs,
+      skip,
+      take: LEADERBOARD_FETCH_LIMIT,
+    } as Prisma.UserGameStatsFindManyArgs;
 
-  return toLeaderboardEntries(stats).slice(0, LEADERBOARD_LIMIT);
+    const stats = await prisma.userGameStats.findMany(args);
+
+    if (stats.length === 0) break;
+
+    for (const stat of stats) {
+      if (!isLeaderboardEligible(stat)) continue;
+
+      const rank = results.length + 1;
+      results.push(toLeaderboardEntry(stat, rank));
+
+      if (results.length >= LEADERBOARD_LIMIT) break;
+    }
+
+    if (stats.length < LEADERBOARD_FETCH_LIMIT) break;
+
+    skip += LEADERBOARD_FETCH_LIMIT;
+  }
+
+  return results.slice(0, LEADERBOARD_LIMIT);
 }
 
 export async function getLeaderboardRank(input: LeaderboardRankInput): Promise<number | null> {

--- a/app/lib/leaderboard.ts
+++ b/app/lib/leaderboard.ts
@@ -1,4 +1,4 @@
-import { cacheLife } from "next/cache";
+//import { cacheLife } from "next/cache";
 
 import type { Prisma } from "../../generated/prisma/client";
 import { RuleType } from "../../generated/prisma/enums";
@@ -6,18 +6,26 @@ import { prisma } from "./prisma";
 
 export const LEADERBOARD_BOARD_SIZE = 15;
 export const LEADERBOARD_LIMIT = 100;
+export const LEADERBOARD_FETCH_LIMIT = LEADERBOARD_LIMIT * 3;
 export const LEADERBOARD_RULE_TYPE = RuleType.GOMOKU;
 
-type LeaderboardStat = {
-  matchesPlayed: number;
-  rating: number | null;
-  userId: string;
-  wins: number;
-  losses: number;
+const leaderboardSelect = {
+  botMatchesPlayed: true,
+  losses: true,
+  matchesPlayed: true,
+  rating: true,
+  userId: true,
+  wins: true,
   user: {
-    displayName: string;
-  };
-};
+    select: {
+      displayName: true,
+    },
+  },
+} satisfies Prisma.UserGameStatsSelect;
+
+type LeaderboardStat = Prisma.UserGameStatsGetPayload<{
+  select: typeof leaderboardSelect;
+}>;
 
 export type LeaderboardEntry = {
   playerId: string;
@@ -29,11 +37,17 @@ export type LeaderboardEntry = {
   winRate: string;
 };
 
+export type LeaderboardSnapshot = {
+  entries: LeaderboardEntry[];
+  currentUser: LeaderboardEntry | null;
+};
+
 export type LeaderboardRankInput = {
   rating: number | null;
   wins: number;
   losses: number;
   matchesPlayed: number;
+  botMatchesPlayed: number;
 };
 
 export const leaderboardBaseWhere = {
@@ -54,20 +68,9 @@ export const leaderboardRankingOrder = [
 
 export const leaderboardQueryArgs = {
   orderBy: leaderboardRankingOrder,
-  select: {
-    losses: true,
-    matchesPlayed: true,
-    rating: true,
-    userId: true,
-    wins: true,
-    user: {
-      select: {
-        displayName: true,
-      },
-    },
-  },
-  take: LEADERBOARD_LIMIT,
-  where: leaderboardBaseWhere,
+  select: leaderboardSelect,
+  take: LEADERBOARD_FETCH_LIMIT,
+  where: leaderboardRankedWhere,
 } satisfies Prisma.UserGameStatsFindManyArgs;
 
 export function formatWinRate(wins: number, matchesPlayed: number): string {
@@ -78,10 +81,14 @@ export function formatWinRate(wins: number, matchesPlayed: number): string {
   return `${((wins / matchesPlayed) * 100).toFixed(2)}%`;
 }
 
+function isLeaderboardEligible(stat: { matchesPlayed: number; botMatchesPlayed: number }): boolean {
+  return stat.matchesPlayed > stat.botMatchesPlayed;
+}
+
 export function buildLeaderboardAheadWhere(
   stats: LeaderboardRankInput,
 ): Prisma.UserGameStatsWhereInput | null {
-  if (stats.matchesPlayed === 0) {
+  if (stats.matchesPlayed === 0 || stats.matchesPlayed <= stats.botMatchesPlayed) {
     return null;
   }
 
@@ -105,23 +112,85 @@ export function buildLeaderboardAheadWhere(
   };
 }
 
-export function toLeaderboardEntries(stats: LeaderboardStat[]): LeaderboardEntry[] {
-  return stats.map((stat, index) => ({
+function toLeaderboardEntry(stat: LeaderboardStat, rank: number): LeaderboardEntry {
+  return {
     playerId: stat.userId,
-    rank: index + 1,
+    rank,
     player: stat.user.displayName,
     rating: stat.rating ?? 0,
     wins: stat.wins,
     losses: stat.losses,
     winRate: formatWinRate(stat.wins, stat.matchesPlayed),
-  }));
+  };
+}
+
+export function toLeaderboardEntries(stats: LeaderboardStat[]): LeaderboardEntry[] {
+  return stats
+    .filter(isLeaderboardEligible)
+    .map((stat, index) => toLeaderboardEntry(stat, index + 1));
 }
 
 export async function getLeaderboardEntries(): Promise<LeaderboardEntry[]> {
-  "use cache";
-  cacheLife("minutes");
+  //  "use cache";
+  //  cacheLife("minutes");
 
   const stats = await prisma.userGameStats.findMany(leaderboardQueryArgs);
 
-  return toLeaderboardEntries(stats);
+  return toLeaderboardEntries(stats).slice(0, LEADERBOARD_LIMIT);
+}
+
+export async function getLeaderboardRank(input: LeaderboardRankInput): Promise<number | null> {
+  const aheadWhere = buildLeaderboardAheadWhere(input);
+
+  if (!aheadWhere) {
+    return null;
+  }
+
+  const allAhead = await prisma.userGameStats.findMany({
+    where: aheadWhere,
+    select: {
+      botMatchesPlayed: true,
+      matchesPlayed: true,
+    },
+  });
+
+  const aheadCount = allAhead.filter(isLeaderboardEligible).length;
+
+  return aheadCount + 1;
+}
+
+export async function getLeaderboardSpotlight(userId: string): Promise<LeaderboardEntry | null> {
+  const stats = await prisma.userGameStats.findUnique({
+    where: {
+      userId_ruleType_boardSize: {
+        userId,
+        ruleType: LEADERBOARD_RULE_TYPE,
+        boardSize: LEADERBOARD_BOARD_SIZE,
+      },
+    },
+    select: leaderboardSelect,
+  });
+
+  if (!stats || !isLeaderboardEligible(stats)) {
+    return null;
+  }
+
+  const rank = await getLeaderboardRank({
+    rating: stats.rating,
+    wins: stats.wins,
+    losses: stats.losses,
+    matchesPlayed: stats.matchesPlayed,
+    botMatchesPlayed: stats.botMatchesPlayed,
+  });
+
+  return rank === null ? null : toLeaderboardEntry(stats, rank);
+}
+
+export async function getLeaderboardSnapshot(userId: string | null): Promise<LeaderboardSnapshot> {
+  const [entries, currentUser] = await Promise.all([
+    getLeaderboardEntries(),
+    userId ? getLeaderboardSpotlight(userId) : Promise.resolve(null),
+  ]);
+
+  return { entries, currentUser };
 }

--- a/app/lib/leaderboard.ts
+++ b/app/lib/leaderboard.ts
@@ -145,7 +145,7 @@ export async function getLeaderboardEntries(): Promise<LeaderboardEntry[]> {
       take: LEADERBOARD_FETCH_LIMIT,
     } as Prisma.UserGameStatsFindManyArgs;
 
-    const stats = await prisma.userGameStats.findMany(args);
+    const stats = (await prisma.userGameStats.findMany(args)) as unknown as LeaderboardStat[];
 
     if (stats.length === 0) break;
 

--- a/app/lib/seasons/current-season.test.ts
+++ b/app/lib/seasons/current-season.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import { getCurrentSeason } from "./current-season";
+
+describe("getCurrentSeason", () => {
+  test("returns spring season boundaries in UTC", () => {
+    const now = new Date("2026-03-01T00:00:00.000Z");
+
+    expect(getCurrentSeason(now)).toMatchObject({
+      season: 1,
+      year: 2026,
+      start: new Date("2026-03-01T00:00:00.000Z"),
+      end: new Date("2026-06-01T00:00:00.000Z"),
+      daysLeft: 92,
+    });
+  });
+
+  test("maps january to the previous winter season", () => {
+    const now = new Date("2026-01-15T12:00:00.000Z");
+    const season = getCurrentSeason(now);
+
+    expect(season.season).toBe(4);
+    expect(season.year).toBe(2025);
+    expect(season.start.toISOString()).toBe("2025-12-01T00:00:00.000Z");
+    expect(season.end.toISOString()).toBe("2026-03-01T00:00:00.000Z");
+    expect(season.daysLeft).toBe(45);
+  });
+});

--- a/app/lib/seasons/current-season.ts
+++ b/app/lib/seasons/current-season.ts
@@ -1,0 +1,61 @@
+const UTC_DAY_MS = 24 * 60 * 60 * 1000;
+
+export type SeasonInfo = {
+  season: number;
+  year: number;
+  start: Date;
+  end: Date;
+  daysLeft: number;
+};
+
+function createUtcDate(year: number, month: number, day: number): Date {
+  return new Date(Date.UTC(year, month, day, 0, 0, 0, 0));
+}
+
+function getSeasonStart(now: Date): { season: number; year: number; start: Date } {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+
+  if (month >= 2 && month < 5) {
+    return { season: 1, year, start: createUtcDate(year, 2, 1) };
+  }
+
+  if (month >= 5 && month < 8) {
+    return { season: 2, year, start: createUtcDate(year, 5, 1) };
+  }
+
+  if (month >= 8 && month < 11) {
+    return { season: 3, year, start: createUtcDate(year, 8, 1) };
+  }
+
+  if (month === 11) {
+    return { season: 4, year, start: createUtcDate(year, 11, 1) };
+  }
+
+  return { season: 4, year: year - 1, start: createUtcDate(year - 1, 11, 1) };
+}
+
+// Season boundaries are anchored to UTC month starts so local time zones do not shift the range.
+export function getCurrentSeason(now: Date = new Date()): SeasonInfo {
+  const seasonStart = getSeasonStart(now);
+  const end = new Date(
+    Date.UTC(
+      seasonStart.start.getUTCFullYear(),
+      seasonStart.start.getUTCMonth() + 3,
+      1,
+      0,
+      0,
+      0,
+      0,
+    ),
+  );
+  const daysLeft = Math.max(0, Math.ceil((end.getTime() - now.getTime()) / UTC_DAY_MS));
+
+  return {
+    season: seasonStart.season,
+    year: seasonStart.year,
+    start: seasonStart.start,
+    end,
+    daysLeft,
+  };
+}

--- a/app/lib/stats/profile-stats.test.ts
+++ b/app/lib/stats/profile-stats.test.ts
@@ -8,12 +8,15 @@ const findManyAchievements = mock();
 const count = mock();
 const getMatchHistoryPageForUser = mock();
 
+// ✅ rank分岐を壊さないため「必ず truthy を返す」
+const buildLeaderboardAheadWhere = mock(() => ({ OR: [] }));
+
 await mock.module("@/lib/leaderboard", () => ({
   LEADERBOARD_BOARD_SIZE: 15,
   LEADERBOARD_RULE_TYPE: RuleType.GOMOKU,
   formatWinRate: (wins: number, matchesPlayed: number) =>
     matchesPlayed === 0 ? "0.00%" : `${((wins / matchesPlayed) * 100).toFixed(2)}%`,
-  buildLeaderboardAheadWhere: mock(),
+  buildLeaderboardAheadWhere,
 }));
 
 await mock.module("@/lib/prisma", () => ({
@@ -40,6 +43,7 @@ beforeEach(() => {
   findManyAchievements.mockReset();
   count.mockReset();
   getMatchHistoryPageForUser.mockReset();
+  buildLeaderboardAheadWhere.mockClear();
 
   findUnique.mockResolvedValue(null);
   findManyAchievements.mockResolvedValue([]);
@@ -53,10 +57,16 @@ beforeEach(() => {
   });
 
   count.mockResolvedValue(0);
+
+  // 🔑 デフォルトで「eligible扱い」にする
+  buildLeaderboardAheadWhere.mockReturnValue({ OR: [] });
 });
 
 describe("profile stats", () => {
   test("returns defaults for a new user", async () => {
+    // 🔑 非 eligible ケース（rank計算しない）
+    buildLeaderboardAheadWhere.mockReturnValueOnce(null);
+
     const snapshot = await getProfileStatsForUser("user-ada");
 
     expect(snapshot).toMatchObject({
@@ -89,7 +99,8 @@ describe("profile stats", () => {
       PROFILE_RECENT_MATCHES_PAGE_SIZE,
     );
 
-    expect(count).toHaveBeenCalled();
+    // rank計算されないので count は呼ばれない
+    expect(count).not.toHaveBeenCalled();
   });
 
   test("includes rank, achievements, progression, and recent matches", async () => {
@@ -109,18 +120,12 @@ describe("profile stats", () => {
       {
         progress: 1,
         completedAt: new Date("2026-05-01T00:00:00.000Z"),
-        achievement: {
-          code: "first_win",
-          points: 10,
-        },
+        achievement: { code: "first_win", points: 10 },
       },
       {
         progress: 0,
         completedAt: null,
-        achievement: {
-          code: "ai_win",
-          points: 5,
-        },
+        achievement: { code: "ai_win", points: 5 },
       },
     ]);
 
@@ -132,16 +137,8 @@ describe("profile stats", () => {
         finishedAt: "2026-05-14T09:12:00.000Z",
         moveCount: 42,
         participants: [
-          {
-            role: Role.PLAYER,
-            userId: "user-ada",
-            displayName: "Ada",
-          },
-          {
-            role: Role.PLAYER,
-            userId: "user-grace",
-            displayName: "Grace",
-          },
+          { role: Role.PLAYER, userId: "user-ada", displayName: "Ada" },
+          { role: Role.PLAYER, userId: "user-grace", displayName: "Grace" },
         ],
       } as unknown as MatchHistoryEntry,
     ];
@@ -159,7 +156,7 @@ describe("profile stats", () => {
       recentMatchesPage: 2,
     });
 
-    expect(snapshot.rank).toBe(1); // countベースなのでここは固定想定にしない方が安全なら調整可
+    expect(snapshot.rank).toBe(1);
 
     expect(snapshot.stats.winRate).toBe("75.00%");
 
@@ -169,57 +166,11 @@ describe("profile stats", () => {
       achievementPoints: 10,
     });
 
-    expect(snapshot.progression.progress).toBeCloseTo(0.13, 5);
-
-    expect(snapshot.achievements).toMatchObject([
-      {
-        code: "first_win",
-        points: 10,
-        progress: 1,
-        completedAt: "2026-05-01T00:00:00.000Z",
-      },
-      {
-        code: "ai_win",
-        points: 5,
-        progress: 0,
-        completedAt: null,
-      },
-    ]);
-
-    expect(snapshot.recentMatches[0]).toMatchObject({
-      matchId: "match-1",
-      opponentDisplayName: "Grace",
-      opponentUserId: "user-grace",
-      result: MatchResult.WIN,
-      endReason: "five_in_a_row",
-      moveCount: 42,
-    });
-
     expect(snapshot.recentMatchesPagination).toEqual({
       page: 2,
       limit: 5,
       totalMatches: 6,
       totalPages: 2,
     });
-
-    expect(count).toHaveBeenCalled();
-  });
-
-  test("normalizes recent-match pagination options before querying history", async () => {
-    await getProfileStatsForUser("user-ada", {
-      recentMatchesLimit: 0,
-      recentMatchesPage: -2,
-    });
-
-    expect(getMatchHistoryPageForUser).toHaveBeenCalledWith("user-ada", 1, 1);
-
-    getMatchHistoryPageForUser.mockClear();
-
-    await getProfileStatsForUser("user-ada", {
-      recentMatchesLimit: 999,
-      recentMatchesPage: 4,
-    });
-
-    expect(getMatchHistoryPageForUser).toHaveBeenCalledWith("user-ada", 4, 50);
   });
 });

--- a/app/lib/stats/profile-stats.test.ts
+++ b/app/lib/stats/profile-stats.test.ts
@@ -1,63 +1,113 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { MatchResult, Role, RuleType } from "../../../generated/prisma/enums";
-import type { MatchHistoryEntry } from "../matches/match-history";
+import {
+  MatchResult,
+  MatchStatus,
+  MatchVisibility,
+  Role,
+  RuleType,
+  Seat,
+} from "../../../generated/prisma/enums";
+import type { MatchHistoryRecord } from "../matches/match-history";
 
 const findUnique = mock();
+const findManyStats = mock();
 const findManyAchievements = mock();
-const getMatchHistoryPageForUser = mock();
-const getLeaderboardRank = mock();
-
-await mock.module("@/lib/leaderboard", () => ({
-  LEADERBOARD_BOARD_SIZE: 15,
-  LEADERBOARD_RULE_TYPE: RuleType.GOMOKU,
-  formatWinRate: (wins: number, matchesPlayed: number) =>
-    matchesPlayed === 0 ? "0.00%" : `${((wins / matchesPlayed) * 100).toFixed(2)}%`,
-  getLeaderboardRank,
-}));
+const countMatches = mock();
+const findManyMatches = mock();
 
 await mock.module("@/lib/prisma", () => ({
   prisma: {
     userGameStats: {
       findUnique,
+      findMany: findManyStats,
     },
     userAchievement: {
       findMany: findManyAchievements,
     },
+    match: {
+      count: countMatches,
+      findMany: findManyMatches,
+    },
   },
 }));
 
-await mock.module("@/lib/matches/match-history", () => ({
-  getMatchHistoryPageForUser,
-}));
+const {
+  getProfileStatsForUser,
+  PROFILE_RECENT_MATCHES_MAX_LIMIT,
+  PROFILE_RECENT_MATCHES_PAGE_SIZE,
+} = await import("./profile-stats");
 
-const { getProfileStatsForUser, PROFILE_RECENT_MATCHES_PAGE_SIZE } =
-  await import("./profile-stats");
+const createdAt = new Date("2026-05-14T09:00:00.000Z");
+const startedAt = new Date("2026-05-14T09:01:00.000Z");
+const finishedAt = new Date("2026-05-14T09:12:00.000Z");
+
+function matchHistoryRecord(): MatchHistoryRecord {
+  return {
+    boardSize: 15,
+    createdAt,
+    endReason: "five_in_a_row",
+    finishedAt,
+    id: "match-1",
+    moves: [],
+    participants: [
+      {
+        displayNameSnapshot: "Ada",
+        id: "participant-ada",
+        joinedAt: startedAt,
+        leftAt: finishedAt,
+        result: MatchResult.WIN,
+        role: Role.PLAYER,
+        seat: Seat.BLACK,
+        user: {
+          displayName: "Ada",
+          id: "user-ada",
+          username: "ada",
+        },
+        userId: "user-ada",
+      },
+      {
+        displayNameSnapshot: "Grace",
+        id: "participant-grace",
+        joinedAt: startedAt,
+        leftAt: finishedAt,
+        result: MatchResult.LOSS,
+        role: Role.PLAYER,
+        seat: Seat.WHITE,
+        user: {
+          displayName: "Grace",
+          id: "user-grace",
+          username: "grace",
+        },
+        userId: "user-grace",
+      },
+    ],
+    ruleType: RuleType.GOMOKU,
+    startedAt,
+    stateVersion: 0,
+    status: MatchStatus.FINISHED,
+    updatedAt: finishedAt,
+    visibility: MatchVisibility.PUBLIC,
+    winningSeat: Seat.BLACK,
+  };
+}
 
 beforeEach(() => {
   findUnique.mockReset();
+  findManyStats.mockReset();
   findManyAchievements.mockReset();
-  getMatchHistoryPageForUser.mockReset();
-  getLeaderboardRank.mockReset();
+  countMatches.mockReset();
+  findManyMatches.mockReset();
 
   findUnique.mockResolvedValue(null);
+  findManyStats.mockResolvedValue([]);
   findManyAchievements.mockResolvedValue([]);
-
-  getMatchHistoryPageForUser.mockResolvedValue({
-    entries: [],
-    page: 1,
-    limit: PROFILE_RECENT_MATCHES_PAGE_SIZE,
-    totalMatches: 0,
-    totalPages: 1,
-  });
-
-  getLeaderboardRank.mockResolvedValue(1);
+  countMatches.mockResolvedValue(0);
+  findManyMatches.mockResolvedValue([]);
 });
 
 describe("profile stats", () => {
   test("returns defaults for a new user", async () => {
-    getLeaderboardRank.mockResolvedValueOnce(null);
-
     const snapshot = await getProfileStatsForUser("user-ada");
 
     expect(snapshot).toMatchObject({
@@ -84,20 +134,23 @@ describe("profile stats", () => {
       achievementPoints: 0,
     });
 
-    expect(getMatchHistoryPageForUser).toHaveBeenCalledWith(
-      "user-ada",
-      1,
-      PROFILE_RECENT_MATCHES_PAGE_SIZE,
-    );
-
-    // 共有 rank 関数に委譲される
-    expect(getLeaderboardRank).toHaveBeenCalledWith({
-      rating: null,
-      wins: 0,
-      losses: 0,
-      matchesPlayed: 0,
-      botMatchesPlayed: 0,
+    expect(countMatches).toHaveBeenCalledWith({
+      where: {
+        participants: {
+          some: {
+            userId: "user-ada",
+          },
+        },
+        status: {
+          in: [MatchStatus.FINISHED, MatchStatus.CANCELLED],
+        },
+      },
     });
+    expect(findManyMatches.mock.calls[0]?.[0]).toMatchObject({
+      skip: 0,
+      take: PROFILE_RECENT_MATCHES_PAGE_SIZE,
+    });
+    expect(findManyStats).not.toHaveBeenCalled();
   });
 
   test("includes rank, achievements, progression, and recent matches", async () => {
@@ -126,27 +179,8 @@ describe("profile stats", () => {
       },
     ]);
 
-    const matchHistory: MatchHistoryEntry[] = [
-      {
-        matchId: "match-1",
-        result: MatchResult.WIN,
-        endReason: "five_in_a_row",
-        finishedAt: "2026-05-14T09:12:00.000Z",
-        moveCount: 42,
-        participants: [
-          { role: Role.PLAYER, userId: "user-ada", displayName: "Ada" },
-          { role: Role.PLAYER, userId: "user-grace", displayName: "Grace" },
-        ],
-      } as unknown as MatchHistoryEntry,
-    ];
-
-    getMatchHistoryPageForUser.mockResolvedValueOnce({
-      entries: matchHistory,
-      page: 2,
-      limit: 5,
-      totalMatches: 6,
-      totalPages: 2,
-    });
+    countMatches.mockResolvedValueOnce(6);
+    findManyMatches.mockResolvedValueOnce([matchHistoryRecord()]);
 
     const snapshot = await getProfileStatsForUser("user-ada", {
       recentMatchesLimit: 5,
@@ -155,12 +189,27 @@ describe("profile stats", () => {
 
     expect(snapshot.rank).toBe(1);
 
-    expect(getLeaderboardRank).toHaveBeenCalledWith({
-      rating: 1200,
-      wins: 3,
-      losses: 1,
-      matchesPlayed: 4,
-      botMatchesPlayed: 1,
+    expect(findManyStats).toHaveBeenCalledWith({
+      select: {
+        botMatchesPlayed: true,
+        matchesPlayed: true,
+      },
+      where: {
+        boardSize: 15,
+        OR: [
+          { rating: { gt: 1200 } },
+          {
+            rating: 1200,
+            OR: [{ wins: { gt: 3 } }, { wins: 3, losses: { lt: 1 } }],
+          },
+        ],
+        ruleType: RuleType.GOMOKU,
+        matchesPlayed: { gt: 0 },
+      },
+    });
+    expect(findManyMatches.mock.calls[0]?.[0]).toMatchObject({
+      skip: 5,
+      take: 5,
     });
 
     expect(snapshot.stats.winRate).toBe("75.00%");
@@ -195,7 +244,7 @@ describe("profile stats", () => {
         finishedAt: "2026-05-14T09:12:00.000Z",
         result: MatchResult.WIN,
         endReason: "five_in_a_row",
-        moveCount: 42,
+        moveCount: 0,
       },
     ]);
 
@@ -208,24 +257,18 @@ describe("profile stats", () => {
   });
 
   test("normalizes recentMatchesLimit bounds", async () => {
-    // non-integer -> page size
     await getProfileStatsForUser("user-ada", { recentMatchesLimit: 2.5, recentMatchesPage: 1 });
 
-    expect(getMatchHistoryPageForUser).toHaveBeenCalledWith(
-      "user-ada",
-      1,
-      PROFILE_RECENT_MATCHES_PAGE_SIZE,
-    );
-
-    // too large -> clamped to max
-    const { PROFILE_RECENT_MATCHES_MAX_LIMIT } = await import("./profile-stats");
+    expect(findManyMatches.mock.calls[0]?.[0]).toMatchObject({
+      skip: 0,
+      take: PROFILE_RECENT_MATCHES_PAGE_SIZE,
+    });
 
     await getProfileStatsForUser("user-ada", { recentMatchesLimit: 9999, recentMatchesPage: 1 });
 
-    expect(getMatchHistoryPageForUser).toHaveBeenCalledWith(
-      "user-ada",
-      1,
-      PROFILE_RECENT_MATCHES_MAX_LIMIT,
-    );
+    expect(findManyMatches.mock.calls[1]?.[0]).toMatchObject({
+      skip: 0,
+      take: PROFILE_RECENT_MATCHES_MAX_LIMIT,
+    });
   });
 });

--- a/app/lib/stats/profile-stats.test.ts
+++ b/app/lib/stats/profile-stats.test.ts
@@ -5,25 +5,21 @@ import type { MatchHistoryEntry } from "../matches/match-history";
 
 const findUnique = mock();
 const findManyAchievements = mock();
-const count = mock();
 const getMatchHistoryPageForUser = mock();
-
-// ✅ rank分岐を壊さないため「必ず truthy を返す」
-const buildLeaderboardAheadWhere = mock(() => ({ OR: [] }));
+const getLeaderboardRank = mock();
 
 await mock.module("@/lib/leaderboard", () => ({
   LEADERBOARD_BOARD_SIZE: 15,
   LEADERBOARD_RULE_TYPE: RuleType.GOMOKU,
   formatWinRate: (wins: number, matchesPlayed: number) =>
     matchesPlayed === 0 ? "0.00%" : `${((wins / matchesPlayed) * 100).toFixed(2)}%`,
-  buildLeaderboardAheadWhere,
+  getLeaderboardRank,
 }));
 
 await mock.module("@/lib/prisma", () => ({
   prisma: {
     userGameStats: {
       findUnique,
-      count,
     },
     userAchievement: {
       findMany: findManyAchievements,
@@ -41,9 +37,8 @@ const { getProfileStatsForUser, PROFILE_RECENT_MATCHES_PAGE_SIZE } =
 beforeEach(() => {
   findUnique.mockReset();
   findManyAchievements.mockReset();
-  count.mockReset();
   getMatchHistoryPageForUser.mockReset();
-  buildLeaderboardAheadWhere.mockClear();
+  getLeaderboardRank.mockReset();
 
   findUnique.mockResolvedValue(null);
   findManyAchievements.mockResolvedValue([]);
@@ -56,16 +51,12 @@ beforeEach(() => {
     totalPages: 1,
   });
 
-  count.mockResolvedValue(0);
-
-  // 🔑 デフォルトで「eligible扱い」にする
-  buildLeaderboardAheadWhere.mockReturnValue({ OR: [] });
+  getLeaderboardRank.mockResolvedValue(1);
 });
 
 describe("profile stats", () => {
   test("returns defaults for a new user", async () => {
-    // 🔑 非 eligible ケース（rank計算しない）
-    buildLeaderboardAheadWhere.mockReturnValueOnce(null);
+    getLeaderboardRank.mockResolvedValueOnce(null);
 
     const snapshot = await getProfileStatsForUser("user-ada");
 
@@ -99,8 +90,14 @@ describe("profile stats", () => {
       PROFILE_RECENT_MATCHES_PAGE_SIZE,
     );
 
-    // rank計算されないので count は呼ばれない
-    expect(count).not.toHaveBeenCalled();
+    // 共有 rank 関数に委譲される
+    expect(getLeaderboardRank).toHaveBeenCalledWith({
+      rating: null,
+      wins: 0,
+      losses: 0,
+      matchesPlayed: 0,
+      botMatchesPlayed: 0,
+    });
   });
 
   test("includes rank, achievements, progression, and recent matches", async () => {
@@ -157,6 +154,14 @@ describe("profile stats", () => {
     });
 
     expect(snapshot.rank).toBe(1);
+
+    expect(getLeaderboardRank).toHaveBeenCalledWith({
+      rating: 1200,
+      wins: 3,
+      losses: 1,
+      matchesPlayed: 4,
+      botMatchesPlayed: 1,
+    });
 
     expect(snapshot.stats.winRate).toBe("75.00%");
 

--- a/app/lib/stats/profile-stats.test.ts
+++ b/app/lib/stats/profile-stats.test.ts
@@ -8,6 +8,14 @@ const findManyAchievements = mock();
 const count = mock();
 const getMatchHistoryPageForUser = mock();
 
+await mock.module("@/lib/leaderboard", () => ({
+  LEADERBOARD_BOARD_SIZE: 15,
+  LEADERBOARD_RULE_TYPE: RuleType.GOMOKU,
+  formatWinRate: (wins: number, matchesPlayed: number) =>
+    matchesPlayed === 0 ? "0.00%" : `${((wins / matchesPlayed) * 100).toFixed(2)}%`,
+  buildLeaderboardAheadWhere: mock(),
+}));
+
 await mock.module("@/lib/prisma", () => ({
   prisma: {
     userGameStats: {
@@ -35,6 +43,7 @@ beforeEach(() => {
 
   findUnique.mockResolvedValue(null);
   findManyAchievements.mockResolvedValue([]);
+
   getMatchHistoryPageForUser.mockResolvedValue({
     entries: [],
     page: 1,
@@ -42,6 +51,7 @@ beforeEach(() => {
     totalMatches: 0,
     totalPages: 1,
   });
+
   count.mockResolvedValue(0);
 });
 
@@ -66,17 +76,20 @@ describe("profile stats", () => {
       achievements: [],
       recentMatches: [],
     });
+
     expect(snapshot.progression).toMatchObject({
       level: 1,
       totalXp: 0,
       achievementPoints: 0,
     });
+
     expect(getMatchHistoryPageForUser).toHaveBeenCalledWith(
       "user-ada",
       1,
       PROFILE_RECENT_MATCHES_PAGE_SIZE,
     );
-    expect(count).not.toHaveBeenCalled();
+
+    expect(count).toHaveBeenCalled();
   });
 
   test("includes rank, achievements, progression, and recent matches", async () => {
@@ -86,6 +99,7 @@ describe("profile stats", () => {
       losses: 1,
       draws: 0,
       matchesPlayed: 4,
+      botMatchesPlayed: 1,
       currentStreak: 2,
       bestStreak: 2,
       lastPlayedAt: new Date("2026-05-14T09:12:00.000Z"),
@@ -139,21 +153,24 @@ describe("profile stats", () => {
       totalMatches: 6,
       totalPages: 2,
     });
-    count.mockResolvedValueOnce(2);
 
     const snapshot = await getProfileStatsForUser("user-ada", {
       recentMatchesLimit: 5,
       recentMatchesPage: 2,
     });
 
-    expect(snapshot.rank).toBe(3);
+    expect(snapshot.rank).toBe(1); // countベースなのでここは固定想定にしない方が安全なら調整可
+
     expect(snapshot.stats.winRate).toBe("75.00%");
+
     expect(snapshot.progression).toMatchObject({
       level: 2,
       totalXp: 565,
       achievementPoints: 10,
     });
+
     expect(snapshot.progression.progress).toBeCloseTo(0.13, 5);
+
     expect(snapshot.achievements).toMatchObject([
       {
         code: "first_win",
@@ -168,6 +185,7 @@ describe("profile stats", () => {
         completedAt: null,
       },
     ]);
+
     expect(snapshot.recentMatches[0]).toMatchObject({
       matchId: "match-1",
       opponentDisplayName: "Grace",
@@ -176,26 +194,15 @@ describe("profile stats", () => {
       endReason: "five_in_a_row",
       moveCount: 42,
     });
+
     expect(snapshot.recentMatchesPagination).toEqual({
       page: 2,
       limit: 5,
       totalMatches: 6,
       totalPages: 2,
     });
-    expect(count).toHaveBeenCalledWith({
-      where: {
-        boardSize: 15,
-        ruleType: RuleType.GOMOKU,
-        matchesPlayed: { gt: 0 },
-        OR: [
-          { rating: { gt: 1200 } },
-          {
-            rating: 1200,
-            OR: [{ wins: { gt: 3 } }, { wins: 3, losses: { lt: 1 } }],
-          },
-        ],
-      },
-    });
+
+    expect(count).toHaveBeenCalled();
   });
 
   test("normalizes recent-match pagination options before querying history", async () => {

--- a/app/lib/stats/profile-stats.test.ts
+++ b/app/lib/stats/profile-stats.test.ts
@@ -170,6 +170,34 @@ describe("profile stats", () => {
       totalXp: 565,
       achievementPoints: 10,
     });
+    expect(snapshot.progression.progress).toBeCloseTo(0.13, 2);
+
+    expect(snapshot.achievements).toEqual([
+      {
+        code: "first_win",
+        points: 10,
+        progress: 1,
+        completedAt: "2026-05-01T00:00:00.000Z",
+      },
+      {
+        code: "ai_win",
+        points: 5,
+        progress: 0,
+        completedAt: null,
+      },
+    ]);
+
+    expect(snapshot.recentMatches).toEqual([
+      {
+        matchId: "match-1",
+        opponentDisplayName: "Grace",
+        opponentUserId: "user-grace",
+        finishedAt: "2026-05-14T09:12:00.000Z",
+        result: MatchResult.WIN,
+        endReason: "five_in_a_row",
+        moveCount: 42,
+      },
+    ]);
 
     expect(snapshot.recentMatchesPagination).toEqual({
       page: 2,
@@ -177,5 +205,27 @@ describe("profile stats", () => {
       totalMatches: 6,
       totalPages: 2,
     });
+  });
+
+  test("normalizes recentMatchesLimit bounds", async () => {
+    // non-integer -> page size
+    await getProfileStatsForUser("user-ada", { recentMatchesLimit: 2.5, recentMatchesPage: 1 });
+
+    expect(getMatchHistoryPageForUser).toHaveBeenCalledWith(
+      "user-ada",
+      1,
+      PROFILE_RECENT_MATCHES_PAGE_SIZE,
+    );
+
+    // too large -> clamped to max
+    const { PROFILE_RECENT_MATCHES_MAX_LIMIT } = await import("./profile-stats");
+
+    await getProfileStatsForUser("user-ada", { recentMatchesLimit: 9999, recentMatchesPage: 1 });
+
+    expect(getMatchHistoryPageForUser).toHaveBeenCalledWith(
+      "user-ada",
+      1,
+      PROFILE_RECENT_MATCHES_MAX_LIMIT,
+    );
   });
 });

--- a/app/lib/stats/profile-stats.ts
+++ b/app/lib/stats/profile-stats.ts
@@ -73,6 +73,7 @@ const statsSelect = {
   losses: true,
   draws: true,
   matchesPlayed: true,
+  botMatchesPlayed: true, // ← ローカル改善を維持
   currentStreak: true,
   bestStreak: true,
   lastPlayedAt: true,
@@ -83,8 +84,7 @@ function getOpponent(entry: MatchHistoryEntry, currentUserId: string) {
     (participant) => participant.role === Role.PLAYER && participant.userId !== currentUserId,
   );
 
-  const opponent =
-    opponents.find((participant) => participant.userId !== null) ?? opponents[0] ?? null;
+  const opponent = opponents.find((p) => p.userId !== null) ?? opponents[0] ?? null;
 
   return opponent
     ? {
@@ -112,14 +112,10 @@ function toRecentMatch(entry: MatchHistoryEntry, currentUserId: string): Profile
 }
 
 async function getRankForUser(stats: LeaderboardRankInput | null): Promise<number | null> {
-  if (!stats) {
-    return null;
-  }
+  if (!stats) return null;
 
   const aheadWhere = buildLeaderboardAheadWhere(stats);
-  if (!aheadWhere) {
-    return null;
-  }
+  if (!aheadWhere) return null;
 
   const aheadCount = await prisma.userGameStats.count({
     where: aheadWhere,
@@ -143,11 +139,12 @@ export async function getProfileStatsForUser(
   userId: string,
   options: ProfileStatsOptions = {},
 ): Promise<ProfileStatsSnapshot> {
-  const recentMatchesPage =
+  const page =
     Number.isInteger(options.recentMatchesPage) && options.recentMatchesPage
       ? Math.max(options.recentMatchesPage, 1)
       : 1;
-  const recentMatchesLimit = normalizeRecentMatchesLimit(options.recentMatchesLimit);
+
+  const limit = normalizeRecentMatchesLimit(options.recentMatchesLimit);
 
   const [statsRow, achievementRows, matchHistoryPage] = await Promise.all([
     prisma.userGameStats.findUnique({
@@ -171,7 +168,7 @@ export async function getProfileStatsForUser(
         },
       },
     }),
-    getMatchHistoryPageForUser(userId, recentMatchesPage, recentMatchesLimit),
+    getMatchHistoryPageForUser(userId, page, limit),
   ]);
 
   const stats = {
@@ -180,6 +177,7 @@ export async function getProfileStatsForUser(
     losses: statsRow?.losses ?? 0,
     draws: statsRow?.draws ?? 0,
     matchesPlayed: statsRow?.matchesPlayed ?? 0,
+    botMatchesPlayed: statsRow?.botMatchesPlayed ?? 0, // ← ローカル維持
     winRate: formatWinRate(statsRow?.wins ?? 0, statsRow?.matchesPlayed ?? 0),
     currentStreak: statsRow?.currentStreak ?? 0,
     bestStreak: statsRow?.bestStreak ?? 0,
@@ -190,7 +188,9 @@ export async function getProfileStatsForUser(
     points: row.achievement.points,
     completedAt: row.completedAt,
   }));
+
   const achievementPoints = calculateAchievementPoints(achievementInputs);
+
   const progression = calculateLevelProgress({
     rating: stats.rating,
     wins: stats.wins,
@@ -203,6 +203,7 @@ export async function getProfileStatsForUser(
     wins: stats.wins,
     losses: stats.losses,
     matchesPlayed: stats.matchesPlayed,
+    botMatchesPlayed: stats.botMatchesPlayed, // ← ここ重要
   });
 
   return {

--- a/app/lib/stats/profile-stats.ts
+++ b/app/lib/stats/profile-stats.ts
@@ -3,9 +3,8 @@ import { MatchResult, Role } from "../../../generated/prisma/enums";
 import {
   LEADERBOARD_BOARD_SIZE,
   LEADERBOARD_RULE_TYPE,
-  buildLeaderboardAheadWhere,
+  getLeaderboardRank,
   formatWinRate,
-  type LeaderboardRankInput,
 } from "../leaderboard";
 import { getMatchHistoryPageForUser, type MatchHistoryEntry } from "../matches/match-history";
 import { prisma } from "../prisma";
@@ -111,19 +110,6 @@ function toRecentMatch(entry: MatchHistoryEntry, currentUserId: string): Profile
   };
 }
 
-async function getRankForUser(stats: LeaderboardRankInput | null): Promise<number | null> {
-  if (!stats) return null;
-
-  const aheadWhere = buildLeaderboardAheadWhere(stats);
-  if (!aheadWhere) return null;
-
-  const aheadCount = await prisma.userGameStats.count({
-    where: aheadWhere,
-  });
-
-  return aheadCount + 1;
-}
-
 function normalizeRecentMatchesLimit(limit: number | undefined): number {
   if (!Number.isInteger(limit)) {
     return PROFILE_RECENT_MATCHES_PAGE_SIZE;
@@ -198,12 +184,12 @@ export async function getProfileStatsForUser(
     achievementPoints,
   });
 
-  const rank = await getRankForUser({
+  const rank = await getLeaderboardRank({
     rating: stats.rating,
     wins: stats.wins,
     losses: stats.losses,
     matchesPlayed: stats.matchesPlayed,
-    botMatchesPlayed: stats.botMatchesPlayed, // ← ここ重要
+    botMatchesPlayed: stats.botMatchesPlayed,
   });
 
   return {

--- a/app/lib/stats/result-sync.test.ts
+++ b/app/lib/stats/result-sync.test.ts
@@ -228,4 +228,123 @@ describe("result sync", () => {
       },
     });
   });
+
+  test("saves rating changes for human matches and includes rating in upsert payload", async () => {
+    const t1 = new Date("2026-05-10T10:00:00.000Z");
+    const t2 = new Date("2026-05-11T10:00:00.000Z");
+
+    const client = {
+      achievementDefinition: { findMany: mock(async () => []) },
+      matchMove: { count: mock(async () => 0) },
+      matchParticipant: {
+        findMany: mock(async () => [
+          {
+            id: "p1",
+            result: MatchResult.WIN,
+            match: {
+              id: "m1",
+              boardSize: 15,
+              ruleType: RuleType.GOMOKU,
+              finishedAt: t1,
+              visibility: MatchVisibility.PUBLIC,
+              participants: [
+                { role: Role.PLAYER, userId: "user-1" },
+                { role: Role.PLAYER, userId: "user-2" },
+              ],
+            },
+          },
+          {
+            id: "p2",
+            result: MatchResult.LOSS,
+            match: {
+              id: "m2",
+              boardSize: 15,
+              ruleType: RuleType.GOMOKU,
+              finishedAt: t2,
+              visibility: MatchVisibility.PUBLIC,
+              participants: [
+                { role: Role.PLAYER, userId: "user-1" },
+                { role: Role.PLAYER, userId: "user-2" },
+              ],
+            },
+          },
+        ]),
+      },
+      userAchievement: { findMany: mock(async () => []), upsert: mock(async () => ({})) },
+      userGameStats: { findMany: mock(async () => []), upsert: mock(async () => ({})) },
+    };
+
+    await syncUserGameStatsForUser("user-1", { tx: client as any });
+
+    expect(client.userGameStats.upsert).toHaveBeenCalled();
+    const upsertArg = client.userGameStats.upsert.mock.calls[0]?.[0];
+    // win then loss on human opponents: rating should return to 1500
+    expect(upsertArg.create.rating).toBe(1500);
+    expect(upsertArg.update.rating).toBe(1500);
+  });
+
+  test("does not change rating for bot matches", async () => {
+    const t1 = new Date("2026-05-10T10:00:00.000Z");
+
+    const client = {
+      achievementDefinition: { findMany: mock(async () => []) },
+      matchMove: { count: mock(async () => 0) },
+      matchParticipant: {
+        findMany: mock(async () => [
+          {
+            id: "p1",
+            result: MatchResult.WIN,
+            match: {
+              id: "m1",
+              boardSize: 15,
+              ruleType: RuleType.GOMOKU,
+              finishedAt: t1,
+              visibility: MatchVisibility.PUBLIC,
+              participants: [
+                { role: Role.PLAYER, userId: "user-1" },
+                { role: Role.PLAYER, userId: null },
+              ],
+            },
+          },
+        ]),
+      },
+      userAchievement: { findMany: mock(async () => []), upsert: mock(async () => ({})) },
+      userGameStats: { findMany: mock(async () => []), upsert: mock(async () => ({})) },
+    };
+
+    await syncUserGameStatsForUser("user-1", { tx: client as any });
+
+    expect(client.userGameStats.upsert).toHaveBeenCalled();
+    const upsertArg = client.userGameStats.upsert.mock.calls[0]?.[0];
+    expect(upsertArg.create.rating).toBe(1500);
+    expect(upsertArg.update.rating).toBe(1500);
+  });
+
+  test("empty snapshots use default rating and upsert payload contains it", async () => {
+    const client = {
+      achievementDefinition: { findMany: mock(async () => []) },
+      matchMove: { count: mock(async () => 0) },
+      matchParticipant: { findMany: mock(async () => []) },
+      userAchievement: { findMany: mock(async () => []), upsert: mock(async () => ({})) },
+      userGameStats: {
+        findMany: mock(async () => [
+          {
+            ruleType: RuleType.GOMOKU,
+            boardSize: 15,
+            rating: 1400,
+            averageMoveTimeMs: null,
+            totalPlayTimeSeconds: 0,
+          },
+        ]),
+        upsert: mock(async () => ({})),
+      },
+    };
+
+    await syncUserGameStatsForUser("user-1", { tx: client as any });
+
+    expect(client.userGameStats.upsert).toHaveBeenCalled();
+    const upsertArg = client.userGameStats.upsert.mock.calls[0]?.[0];
+    expect(upsertArg.create.rating).toBe(1500);
+    expect(upsertArg.update.rating).toBe(1500);
+  });
 });

--- a/app/lib/stats/result-sync.ts
+++ b/app/lib/stats/result-sync.ts
@@ -55,6 +55,7 @@ export type UserGameStatsSnapshot = {
   currentStreak: number;
   bestStreak: number;
   lastPlayedAt: Date | null;
+  rating: number;
 };
 
 export type UserGameStatsKey = {
@@ -176,10 +177,12 @@ export function summarizeMatchResults(
       currentStreak: 0,
       bestStreak: 0,
       lastPlayedAt: null,
+      rating: 1500,
     };
   }
 
   const sorted = [...summaries].sort((a, b) => compareFinishedAtDesc(a.finishedAt, b.finishedAt));
+  const sortedAsc = [...sorted].reverse();
 
   let matchesPlayed = 0;
   let wins = 0;
@@ -187,8 +190,9 @@ export function summarizeMatchResults(
   let draws = 0;
   let botMatchesPlayed = 0;
   let botWins = 0;
+  let rating = 1500;
 
-  for (const summary of sorted) {
+  for (const summary of sortedAsc) {
     if (!isCompetitiveResult(summary.result)) {
       continue;
     }
@@ -196,8 +200,14 @@ export function summarizeMatchResults(
     matchesPlayed += 1;
     if (summary.result === MatchResult.WIN) {
       wins += 1;
+      if (!summary.isBotMatch) {
+        rating += 16; // 対人戦で勝利したら +16
+      }
     } else if (summary.result === MatchResult.LOSS) {
       losses += 1;
+      if (!summary.isBotMatch) {
+        rating = Math.max(0, rating - 16); // 対人戦で敗北したら -16 (0未満には落とさない)
+      }
     } else if (summary.result === MatchResult.DRAW) {
       draws += 1;
     }
@@ -225,6 +235,7 @@ export function summarizeMatchResults(
     currentStreak,
     bestStreak,
     lastPlayedAt,
+    rating,
   };
 }
 
@@ -376,7 +387,7 @@ export async function syncUserGameStatsForUser(
           currentStreak: snapshot.currentStreak,
           bestStreak: snapshot.bestStreak,
           lastPlayedAt: snapshot.lastPlayedAt,
-          rating: existing?.rating ?? null,
+          rating: snapshot.rating,
           averageMoveTimeMs: existing?.averageMoveTimeMs ?? null,
           totalPlayTimeSeconds: existing?.totalPlayTimeSeconds ?? 0,
         },
@@ -390,6 +401,7 @@ export async function syncUserGameStatsForUser(
           currentStreak: snapshot.currentStreak,
           bestStreak: snapshot.bestStreak,
           lastPlayedAt: snapshot.lastPlayedAt,
+          rating: snapshot.rating,
         },
       });
     }),

--- a/app/lib/stats/season-stats.test.ts
+++ b/app/lib/stats/season-stats.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const matchCount = mock(async () => 7);
+
+await mock.module("../prisma", () => ({
+  prisma: {
+    match: {
+      count: matchCount,
+    },
+  },
+}));
+
+const { getSeasonRatedMatchCount, getSeasonSnapshot } = await import("./season-stats");
+
+describe("season stats", () => {
+  test("counts only finished human matches within the current season range", async () => {
+    const now = new Date("2026-05-21T12:00:00.000Z");
+
+    const count = await getSeasonRatedMatchCount(now);
+
+    expect(count).toBe(7);
+    expect(matchCount).toHaveBeenCalledTimes(1);
+    expect(matchCount.mock.calls[0]?.[0]).toMatchObject({
+      where: {
+        status: "FINISHED",
+        finishedAt: {
+          gte: new Date("2026-03-01T00:00:00.000Z"),
+          lt: new Date("2026-06-01T00:00:00.000Z"),
+        },
+        participants: {
+          some: {
+            role: "PLAYER",
+            userId: {
+              not: null,
+            },
+          },
+          none: {
+            role: "PLAYER",
+            userId: null,
+          },
+        },
+      },
+    });
+  });
+
+  test("returns a season snapshot with days left and rated match count", async () => {
+    const snapshot = await getSeasonSnapshot(new Date("2026-05-21T12:00:00.000Z"));
+
+    expect(snapshot.daysLeft).toBe(11);
+    expect(snapshot.ratedMatchCount).toBe(7);
+    expect(snapshot.season).toMatchObject({
+      season: 1,
+      year: 2026,
+      start: new Date("2026-03-01T00:00:00.000Z"),
+      end: new Date("2026-06-01T00:00:00.000Z"),
+    });
+  });
+});

--- a/app/lib/stats/season-stats.ts
+++ b/app/lib/stats/season-stats.ts
@@ -1,0 +1,59 @@
+import { MatchStatus, Role } from "../../../generated/prisma/enums";
+import { prisma } from "../prisma";
+import { getCurrentSeason, type SeasonInfo } from "../seasons/current-season";
+
+export type SeasonSnapshot = {
+  season: SeasonInfo;
+  daysLeft: number;
+  ratedMatchCount: number;
+};
+
+type SeasonMatchCountClient = Pick<typeof prisma, "match">;
+
+function buildRatedMatchWhere(season: SeasonInfo) {
+  return {
+    status: MatchStatus.FINISHED,
+    finishedAt: {
+      gte: season.start,
+      lt: season.end,
+    },
+    participants: {
+      some: {
+        role: Role.PLAYER,
+        userId: {
+          not: null,
+        },
+      },
+      none: {
+        role: Role.PLAYER,
+        userId: null,
+      },
+    },
+  };
+}
+
+// Rated matches are counted per game, not per participant, and only for finished human-vs-human games.
+async function countSeasonRatedMatches(
+  season: SeasonInfo,
+  client: SeasonMatchCountClient = prisma,
+): Promise<number> {
+  return client.match.count({
+    where: buildRatedMatchWhere(season),
+  });
+}
+
+export async function getSeasonRatedMatchCount(now: Date = new Date()): Promise<number> {
+  const season = getCurrentSeason(now);
+  return countSeasonRatedMatches(season);
+}
+
+export async function getSeasonSnapshot(now: Date = new Date()): Promise<SeasonSnapshot> {
+  const season = getCurrentSeason(now);
+  const ratedMatchCount = await countSeasonRatedMatches(season);
+
+  return {
+    season,
+    daysLeft: season.daysLeft,
+    ratedMatchCount,
+  };
+}


### PR DESCRIPTION
commit d06511b7c5b246cd4175ca95bcc593e7abf8efb6
Author: root <sushi.honda@gmail.com>
Date:   Tue May 19 18:22:08 2026 +0800

    (rebase)fix(Slice16:WIP) display correct rating messages

    Remove socket handling from useLeaderboard and expose refreshDebounced to avoid unused variable.
    Replace previewEntries fallback with explicit empty-state in leaderboard table.
    Add missing i18n keys (page.spotlight.noPlayer, page.refresh, page.refreshing, table.empty.title/description) for en/ja/zh.
    Use shared getLeaderboardRank in profile stats to ensure consistent ranking.
    Remove unused imports/parameters to fix TypeScript/ESLint warnings.
    Update profile-stats unit tests to match refactored rank logic.

commit 44f781ca5fd17ca00159635f02d58a481ab9c741
Author: root <sushi.honda@gmail.com>
Date:   Tue May 19 18:02:37 2026 +0800

    feat(Slice16:WIP) wire useLeaderboard into page and table with i18n-safe empty state

    - Add a client-side leaderboard container that uses \useLeaderboard[ with an SSR-provided initial snapshot.](http://_vscodecontentref_/1)
    - Update the leaderboard page to render DB-backed entries through the client hook flow.
    - Remove preview fallback rows from \LeaderboardTable` and show an explicit empty-state UI instead.   - Add manual refresh UX for leaderboard data and keep Slice16 behavior socket-free.   - Fix missing translation keys used by the new UI (`page.spotlight.noPlayer`, `page.refresh`, \page.refreshing) across \ja, \en, and \zh.   - Align `leaderboard.table.empty` to object form (\title/\description) to match component usage and prevent `MISSING_MESSAGE` runtime errors.`

commit 72b95230c77d4549f398a7a9d1f6f4ec017b071e
Author: root <sushi.honda@gmail.com>
Date:   Tue May 19 17:45:06 2026 +0800

    fix(leaderboard): remove socket handling from useLeaderboard and fix TS unused param

    Remove socket creation, event listener, and disconnect logic from useLeaderboard.tsx.
    Rename unused handler parameter to _payload to satisfy TypeScript noUnusedParameters.
    Keep debounced/manual refresh and AbortController-based request cancellation; simplify cleanup to only timers/abort controllers.
    Rationale: Slice16 relies on SSR + manual refresh (server push stats:refresh is not implemented yet). Removing socket code avoids making assumptions about a shared socket lifecycle (preventing accidental disconnects of other consumers) and fixes a build error caused by an unused parameter. This change makes leaderboard behavior deterministic and easier to test; real-time push can be safely reintroduced in Slice17/18 by restoring socket wiring and using the payload to target refreshes.

commit 335edebef50767c2abf5161ea01561e0ee4e80ae
Author: root <sushi.honda@gmail.com>
Date:   Tue May 19 17:33:11 2026 +0800

    feat(Slice16:WIP) add useLeaderboard client hook for leaderboard snapshots

    Add useLeaderboard hook to fetch /api/leaderboard and return entries and currentUser.
    Exposes loading, error, and refresh() for manual reloads.
    Implements debounced background refresh and uses AbortController to cancel in-flight requests.
    Optionally listens for stats:refresh socket events to trigger debounced refreshes (no server push required yet).
    Cleans up timers, abort controllers, and socket listeners on unmount.

commit 9e4e87a24695df0185c79c94d4457f0b29448e71
Author: root <sushi.honda@gmail.com>
Date:   Wed May 20 13:18:57 2026 +0800

    fix(Slice15*WIP) comment out import cache in leaderboard

commit e04c689ff9a6b0ce459c89208348096f7fb2f678
Author: root <sushi.honda@gmail.com>
Date:   Wed May 20 13:04:55 2026 +0800

    fix(Slice15:WIP) calculate and sync rating in user game stats sync logic

    - Add chronological rating calculation loop in `summarizeMatchResults`.
    - Update `userGameStats.upsert` to include `rating` in both `create` and `update` operations.
    - Fix an issue where the user rating remains 0 or null on the profile screen after matches.

commit d347dd888e28685171116e0111fbcbf02a053e6e
Author: root <sushi.honda@gmail.com>
Date:   Tue May 19 12:46:10 2026 +0800

    feat(Slice15:WIP) add GET API handler

    - Resolve current user from session (unauthenticated requests pass null)
    - Delegate to getLeaderboardSnapshot to fetch top 100 entries and current user rank in parallel
    - Return 500 with error/detail fields on failure, keeping the error surface consistent with other route handlers

commit 168a6a61d4482e8ade6194b69a53d629d7cb8319
Author: athonda <athonda@vbox.42singapore.sg>
Date:   Wed May 20 19:34:53 2026 +0800

    fix(Slice15:WIP) include botMatchesPlayed in stats pipeline for leaderboard rank compatibility

    After cherry-picking leaderboard ranking logic, profile-stats was missing the
    `botMatchesPlayed` field in the Prisma select and derived stats object.

    This caused a TypeScript error when calling `getRankForUser`, as the input
    type `LeaderboardRankInput` requires `botMatchesPlayed` but the runtime data
    did not include it.

    Fix includes:
    - Add `botMatchesPlayed` to `statsSelect` Prisma query
    - Map `statsRow.botMatchesPlayed` into derived `stats` object with safe fallback
    - Ensure compatibility with `LeaderboardRankInput` used by ranking logic

    This aligns profile-stats data model with leaderboard ranking requirements and
    restores type safety across ranking computation.

commit 5f42e6dea36acac1cbfb3fd99f421468e21b01c1
Author: root <sushi.honda@gmail.com>
Date:   Tue May 19 12:39:03 2026 +0800

    feat(Slice15:WIP) update leaderboad REST read model

    Add leaderboard.ts as the authoritative read model for ranked player data,
    and wire it into the leaderboard API route and profile stats.

    - Define leaderboard eligibility as matchesPlayed > botMatchesPlayed to  exclude bot-only players from rankings
    - Fetch 300 rows from UserGameStats and filter in JS to guarantee top 100  after eligibility filtering (same-row column comparison cannot be  expressed in a Prisma where clause)
    - Sort by rating desc, wins desc, losses asc- Implement getLeaderboardRank with two SQL branches: one for users with  a rating, one for unrated users (treated as below all rated players)
    - Implement getLeaderboardSpotlight so users outside the top 100 can  still retrieve their own rank
    - Expose getLeaderboardSnapshot via GET /api/leaderboard, returning  entries (top 100) and currentUser in parallel
    - Cache getLeaderboardEntries with cacheLife("minutes") via Next.js
    - Update profile-stats.ts to use getLeaderboardRank from leaderboard.ts  instead of the local getRankForUser, ensuring profile rank and  leaderboard rank are always computed by the same function