### PR TITLE
Exclude local files from Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,41 @@
+# Dependencies and generated build output
 node_modules
 .next
 generated
+next-env.d.ts
+tsconfig.tsbuildinfo
+bun.lockb
+
+# Runtime/local uploads and local service data
 public/uploads
+.docker-data
+
+# Secrets and local environment files
+.env
+.env.*
+!.env.example
+caddy-local-root.crt
+
+# VCS, editor, and agent/tooling state
+.git
+.github
+.vscode
+.idea
+.agents
+
+# Test/browser artifacts
+.playwright-browsers
+playwright-report
+test-results
+output/playwright
+coverage
+
+# Caches and logs
+.stylelintcache
+.DS_Store
+*.log
 bun-debug.log*
 npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*


### PR DESCRIPTION
## Summary
- Expand `.dockerignore` to keep local agent/tooling state, VCS/editor files, secrets, generated output, uploads, test artifacts, and logs out of Docker build contexts
- Keep `.env.example` included while excluding real `.env*` files

## Verification
- Verified ignore behavior for `.agents`, `.env`, `.env.example`, `.git`, `.github`, `.vscode`, `node_modules`, `.next`, `public/uploads`, `Dockerfile`, and `package.json` using the repo ignore matcher

## Notes
- Rebases this branch onto current `main` so the PR contains only the Docker context cleanup diff.