### PR TITLE
[codex] Fix auth email console mode

### DIFF
--- a/app/lib/auth-email.test.ts
+++ b/app/lib/auth-email.test.ts
@@ -168,6 +168,31 @@ describe("sendPasswordResetEmail", () => {
 });
 
 describe("sendEmailVerificationEmail", () => {
+  test("prints verification emails in console mode without creating an SMTP transport", async () => {
+    process.env["AUTH_EMAIL_MODE"] = "console";
+
+    const originalConsoleInfo = console.info;
+    const consoleInfo = mock((_message: string) => undefined);
+    console.info = consoleInfo as typeof console.info;
+
+    try {
+      await sendEmailVerificationEmail({
+        email: "player@example.com",
+        verificationUrl: "https://app.test/api/auth/verify-email?token=verify123",
+      });
+    } finally {
+      console.info = originalConsoleInfo;
+    }
+
+    expect(createTransport).not.toHaveBeenCalled();
+    expect(sendMail).not.toHaveBeenCalled();
+    expect(consoleInfo).toHaveBeenCalledTimes(1);
+    expect(consoleInfo.mock.calls[0]?.[0]).toContain("player@example.com");
+    expect(consoleInfo.mock.calls[0]?.[0]).toContain(
+      "https://app.test/api/auth/verify-email?token=verify123",
+    );
+  });
+
   test("sends verification emails through the shared auth email transport", async () => {
     process.env["AUTH_EMAIL_MODE"] = "resend-smtp";
     process.env["RESEND_API_KEY"] = "re_verify_key";

--- a/app/lib/auth-email.ts
+++ b/app/lib/auth-email.ts
@@ -1,5 +1,4 @@
 import "server-only";
-import nodemailer from "nodemailer";
 
 type AuthEmailMessage = {
   html: string;
@@ -28,7 +27,9 @@ type ResendSmtpConfig = {
   user: string;
 };
 
-type ResendSmtpTransport = ReturnType<typeof nodemailer.createTransport>;
+type NodemailerModule = typeof import("nodemailer");
+type NodemailerRuntimeModule = NodemailerModule & { default?: NodemailerModule };
+type ResendSmtpTransport = import("nodemailer").Transporter;
 
 const defaultResendSmtpHost = "smtp.resend.com";
 const defaultResendSmtpPort = 465;
@@ -102,7 +103,7 @@ function getResendSmtpConfig(): ResendSmtpConfig {
   };
 }
 
-function getResendTransport(config: ResendSmtpConfig): ResendSmtpTransport {
+async function getResendTransport(config: ResendSmtpConfig): Promise<ResendSmtpTransport> {
   const key = JSON.stringify({
     apiKey: config.apiKey,
     host: config.host,
@@ -115,7 +116,8 @@ function getResendTransport(config: ResendSmtpConfig): ResendSmtpTransport {
     return cachedResendTransport.transport;
   }
 
-  const transport = nodemailer.createTransport({
+  const nodemailer: NodemailerRuntimeModule = await import("nodemailer");
+  const transport = (nodemailer.default ?? nodemailer).createTransport({
     auth: {
       pass: config.apiKey,
       user: config.user,
@@ -131,7 +133,7 @@ function getResendTransport(config: ResendSmtpConfig): ResendSmtpTransport {
 
 async function sendResendSmtpEmail(message: AuthEmailMessage): Promise<void> {
   const config = getResendSmtpConfig();
-  const transport = getResendTransport(config);
+  const transport = await getResendTransport(config);
 
   const result = await transport.sendMail({
     from: config.from,


### PR DESCRIPTION
## What changed

- Lazily loads Nodemailer only when auth email delivery is running in `resend-smtp` mode.
- Keeps `AUTH_EMAIL_MODE=console` verification and reset emails on the console-only path without initializing SMTP transport code.
- Adds a regression test for verification email console delivery.

## Why

Next dev externalizes `nodemailer` through `serverExternalPackages`. The previous static `import nodemailer from "nodemailer"` ran at module evaluation time, so console mode could fail while resolving the externalized package even though it did not need SMTP delivery.

## Validation

- `bun test app/lib/auth-email.test.ts`
- `bun run lint:js`
- `git diff --check HEAD~1..HEAD`