### PR TITLE
Pr honda leaderboard friend filter

### DIFF
--- a/app/[locale]/friends/page.tsx
+++ b/app/[locale]/friends/page.tsx
@@ -4,6 +4,10 @@ import { Suspense } from "react";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
 import { getCurrentSession } from "@/lib/auth";
+import {
+  friendshipForUserWhere,
+  getOtherFriendshipUser,
+} from "@/lib/friendships/friendship-queries";
 import { prisma } from "@/lib/prisma";
 
 import FriendsContent from "./friends-layout";
@@ -46,9 +50,7 @@ async function FriendsPageContent({ params, searchParams }: FriendsPageProps) {
   const searchQuery = getSearchQuery(query);
 
   const friendships = await prisma.friendship.findMany({
-    where: {
-      OR: [{ userLowId: currentUserId }, { userHighId: currentUserId }],
-    },
+    where: friendshipForUserWhere(currentUserId),
     include: {
       userLow: {
         include: { gameStats: { where: { ruleType: "GOMOKU" } } },
@@ -84,8 +86,7 @@ async function FriendsPageContent({ params, searchParams }: FriendsPageProps) {
   const sentRequests = [];
 
   for (const friendship of friendships) {
-    const isUserLow = friendship.userLowId === currentUserId;
-    const otherUser = isUserLow ? friendship.userHigh : friendship.userLow;
+    const otherUser = getOtherFriendshipUser(friendship, currentUserId);
 
     const rawStats = otherUser.gameStats[0];
 

--- a/app/[locale]/leaderboard/page.tsx
+++ b/app/[locale]/leaderboard/page.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, BarChart3, Globe2, Medal, Trophy, Users } from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import Link from "next/link";
 import { connection } from "next/server";
 import { Suspense } from "react";
 
@@ -11,6 +12,7 @@ import {
   getLeaderboardSnapshot,
   type LeaderboardSnapshot,
   type LeaderboardEntry,
+  type LeaderboardScope,
 } from "@/lib/leaderboard";
 import { getSeasonSnapshot, type SeasonSnapshot } from "@/lib/stats/season-stats";
 
@@ -18,12 +20,15 @@ type LeaderBoardProps = {
   params: Promise<{
     locale: string;
   }>;
+  searchParams: Promise<{
+    scope?: string | string[];
+  }>;
 };
 
-export default function LeaderBoard({ params }: LeaderBoardProps) {
+export default function LeaderBoard({ params, searchParams }: LeaderBoardProps) {
   return (
     <Suspense fallback={<PageLoadingShell />}>
-      <LeaderBoardContent params={params} />
+      <LeaderBoardContent params={params} searchParams={searchParams} />
     </Suspense>
   );
 }
@@ -65,8 +70,9 @@ function LeaderboardEmptyState({ description, title }: { description: string; ti
   );
 }
 
-async function LeaderBoardContent({ params }: LeaderBoardProps) {
+async function LeaderBoardContent({ params, searchParams }: LeaderBoardProps) {
   const { locale } = await params;
+  const { scope: rawScope } = await searchParams;
   setRequestLocale(locale);
   await connection();
 
@@ -84,11 +90,12 @@ async function LeaderBoardContent({ params }: LeaderBoardProps) {
     },
   };
   let leaderboardUnavailable = false;
+  const scope = rawScope === "friends" ? "friends" : "all";
 
   try {
     const session = await getCurrentSession();
     const [leaderboardData, seasonData] = await Promise.all([
-      getLeaderboardSnapshot(session?.user.id ?? null),
+      getLeaderboardSnapshot(session?.user.id ?? null, { scope }),
       getSeasonSnapshot(),
     ]);
     snapshot = leaderboardData;
@@ -125,6 +132,14 @@ async function LeaderBoardContent({ params }: LeaderBoardProps) {
       : [];
   const topPlayers = entries.slice(0, 3);
 
+  const tabBaseClass =
+    "inline-flex min-h-10 min-w-32 items-center justify-center rounded-sm px-4 text-sm font-black transition-colors";
+  const activeTabClass = "bg-[var(--mint-soft)] text-[var(--mint)]";
+  const inactiveTabClass = "text-[var(--muted-text)] hover:text-[var(--text)]";
+
+  const buildScopeHref = (nextScope: LeaderboardScope) =>
+    nextScope === "friends" ? "?scope=friends" : "?scope=all";
+
   return (
     <PageShell>
       <PageHeader
@@ -135,19 +150,18 @@ async function LeaderBoardContent({ params }: LeaderBoardProps) {
         actions={
           <>
             <div className="inline-flex rounded-md border border-[var(--panel-border-soft)] bg-[var(--panel-solid)] p-1">
-              {[t("page.tabs.allPlayers"), t("page.tabs.friends")].map((item, index) => (
-                <button
-                  key={item}
-                  type="button"
-                  className={`min-h-10 min-w-32 rounded-sm px-4 text-sm font-black ${
-                    index === 0
-                      ? "bg-[var(--mint-soft)] text-[var(--mint)]"
-                      : "text-[var(--muted-text)]"
-                  }`}
-                >
-                  {item}
-                </button>
-              ))}
+              <Link
+                className={`${tabBaseClass} ${scope === "all" ? activeTabClass : inactiveTabClass}`}
+                href={buildScopeHref("all")}
+              >
+                {t("page.tabs.allPlayers")}
+              </Link>
+              <Link
+                className={`${tabBaseClass} ${scope === "friends" ? activeTabClass : inactiveTabClass}`}
+                href={buildScopeHref("friends")}
+              >
+                {t("page.tabs.friends")}
+              </Link>
             </div>
             <Badge tone="brass">
               <Globe2 aria-hidden="true" className="size-3.5" />
@@ -166,7 +180,7 @@ async function LeaderBoardContent({ params }: LeaderBoardProps) {
             />
           ) : (
             <>
-              <LeaderboardClient initial={snapshot} />
+              <LeaderboardClient initial={snapshot} scope={scope} />
             </>
           )}
         </Surface>

--- a/app/[locale]/leaderboard/page.tsx
+++ b/app/[locale]/leaderboard/page.tsx
@@ -131,6 +131,8 @@ async function LeaderBoardContent({ params, searchParams }: LeaderBoardProps) {
         ].map((band) => ({ ...band, share: `${Math.round((band.count / entries.length) * 100)}%` }))
       : [];
   const topPlayers = entries.slice(0, 3);
+  const ScopeIcon = scope === "friends" ? Users : Globe2;
+  const scopeLabel = scope === "friends" ? t("page.scope.friends") : t("page.scope.global");
 
   const tabBaseClass =
     "inline-flex min-h-10 min-w-32 items-center justify-center rounded-sm px-4 text-sm font-black transition-colors";
@@ -164,8 +166,8 @@ async function LeaderBoardContent({ params, searchParams }: LeaderBoardProps) {
               </Link>
             </div>
             <Badge tone="brass">
-              <Globe2 aria-hidden="true" className="size-3.5" />
-              {t("page.scope.global")}
+              <ScopeIcon aria-hidden="true" className="size-3.5" />
+              {scopeLabel}
             </Badge>
           </>
         }

--- a/app/api/friends/route.ts
+++ b/app/api/friends/route.ts
@@ -4,6 +4,10 @@
 
 import { getErrorMessage } from "@/lib/api-errors";
 import { getCurrentSession } from "@/lib/auth";
+import {
+  acceptedFriendshipWhere,
+  getOtherFriendshipUser,
+} from "@/lib/friendships/friendship-queries";
 import { prisma } from "@/lib/prisma";
 
 export async function GET() {
@@ -14,10 +18,7 @@ export async function GET() {
 
   try {
     const friendships = await prisma.friendship.findMany({
-      where: {
-        status: "ACCEPTED",
-        OR: [{ userLowId: session.user.id }, { userHighId: session.user.id }],
-      },
+      where: acceptedFriendshipWhere(session.user.id),
       include: {
         userLow: {
           select: { id: true, username: true, displayName: true, avatarUrl: true },
@@ -30,7 +31,7 @@ export async function GET() {
 
     // For each friendship, return the OTHER user (not the current user)
     const friends = friendships.map((f) => {
-      const other = f.userLowId === session.user.id ? f.userHigh : f.userLow;
+      const other = getOtherFriendshipUser(f, session.user.id);
       return {
         id: other.id,
         username: other.username,

--- a/app/api/leaderboard/route.test.ts
+++ b/app/api/leaderboard/route.test.ts
@@ -73,6 +73,17 @@ describe("GET /api/leaderboard", () => {
     });
   });
 
+  test("passes friends scope from the request query", async () => {
+    const response = await route.GET(new Request("http://localhost/api/leaderboard?scope=friends"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getLeaderboardSnapshot).toHaveBeenCalledWith("user-ada", { scope: "friends" });
+    expect(payload).toMatchObject({
+      entries: [{ playerId: "user-ada", rank: 1 }],
+    });
+  });
+
   test("returns a server error when snapshot fails to load", async () => {
     getLeaderboardSnapshot.mockRejectedValueOnce(new Error("boom"));
 

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -9,11 +9,16 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }
 
-export async function GET(request: Request) {
+export async function GET(request?: Request) {
   try {
     const context = await getCurrentSession();
-    const scope = resolveScope(new URL(request.url).searchParams);
-    const snapshot = await getLeaderboardSnapshot(context?.user.id ?? null, { scope });
+    const scope = resolveScope(
+      new URL(request?.url ?? "http://localhost/api/leaderboard").searchParams,
+    );
+    const snapshot =
+      scope === "friends"
+        ? await getLeaderboardSnapshot(context?.user.id ?? null, { scope })
+        : await getLeaderboardSnapshot(context?.user.id ?? null);
 
     return Response.json(snapshot);
   } catch (error) {

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,14 +1,19 @@
 import { getCurrentSession } from "@/lib/auth";
-import { getLeaderboardSnapshot } from "@/lib/leaderboard";
+import { getLeaderboardSnapshot, type LeaderboardScope } from "@/lib/leaderboard";
+
+function resolveScope(searchParams: URLSearchParams): LeaderboardScope {
+  return searchParams.get("scope") === "friends" ? "friends" : "all";
+}
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
     const context = await getCurrentSession();
-    const snapshot = await getLeaderboardSnapshot(context?.user.id ?? null);
+    const scope = resolveScope(new URL(request.url).searchParams);
+    const snapshot = await getLeaderboardSnapshot(context?.user.id ?? null, { scope });
 
     return Response.json(snapshot);
   } catch (error) {

--- a/app/components/leaderboard-client.tsx
+++ b/app/components/leaderboard-client.tsx
@@ -5,25 +5,17 @@ import { useTranslations } from "next-intl";
 
 import LeaderboardTable from "@/components/leaderboardtable";
 import { useLeaderboard } from "@/hooks/useLeaderboard";
+import type { LeaderboardScope, LeaderboardSnapshot } from "@/lib/leaderboard";
 
-type LeaderboardEntry = {
-  playerId: string;
-  rank: number;
-  player: string;
-  rating: number;
-  wins: number;
-  losses: number;
-  winRate: string;
-};
-
-type LeaderboardSnapshot = {
-  entries: LeaderboardEntry[];
-  currentUser: LeaderboardEntry | null;
-};
-
-export default function LeaderboardClient({ initial }: { initial?: LeaderboardSnapshot | null }) {
+export default function LeaderboardClient({
+  initial,
+  scope = "all",
+}: {
+  initial?: LeaderboardSnapshot | null;
+  scope?: LeaderboardScope;
+}) {
   const t = useTranslations("leaderboard");
-  const { entries, currentUser, loading, error, refresh } = useLeaderboard(initial ?? null);
+  const { entries, currentUser, loading, error, refresh } = useLeaderboard(initial ?? null, scope);
 
   return (
     <>

--- a/app/hooks/useLeaderboard.test.ts
+++ b/app/hooks/useLeaderboard.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+import { getLeaderboardApiPath } from "./useLeaderboard";
+
+describe("getLeaderboardApiPath", () => {
+  test("uses the default leaderboard endpoint for all players", () => {
+    expect(getLeaderboardApiPath("all")).toBe("/api/leaderboard");
+  });
+
+  test("forwards the friends scope to the leaderboard endpoint", () => {
+    expect(getLeaderboardApiPath("friends")).toBe("/api/leaderboard?scope=friends");
+  });
+});

--- a/app/hooks/useLeaderboard.tsx
+++ b/app/hooks/useLeaderboard.tsx
@@ -4,6 +4,14 @@ import { useEffect, useRef, useState, useCallback } from "react";
 
 import type { LeaderboardEntry, LeaderboardScope, LeaderboardSnapshot } from "@/lib/leaderboard";
 
+export function getLeaderboardApiPath(scope: LeaderboardScope): string {
+  if (scope === "friends") {
+    return "/api/leaderboard?scope=friends";
+  }
+
+  return "/api/leaderboard";
+}
+
 export function useLeaderboard(
   initial?: LeaderboardSnapshot | null,
   scope: LeaderboardScope = "all",
@@ -31,15 +39,7 @@ export function useLeaderboard(
       setLoading(true);
       setError(null);
       try {
-        const searchParams = new URLSearchParams();
-        if (scope === "friends") {
-          searchParams.set("scope", scope);
-        }
-
-        const res = await fetch(
-          `/api/leaderboard${searchParams.size > 0 ? `?${searchParams.toString()}` : ""}`,
-          { signal },
-        );
+        const res = await fetch(getLeaderboardApiPath(scope), { signal });
         if (!res.ok) throw new Error(`status ${res.status}`);
         const body: LeaderboardSnapshot = await res.json();
         setEntries(body.entries ?? []);

--- a/app/hooks/useLeaderboard.tsx
+++ b/app/hooks/useLeaderboard.tsx
@@ -2,22 +2,13 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 
-type LeaderboardEntry = {
-  playerId: string;
-  rank: number;
-  player: string;
-  rating: number;
-  wins: number;
-  losses: number;
-  winRate: string;
-};
+import type { LeaderboardEntry, LeaderboardScope, LeaderboardSnapshot } from "@/lib/leaderboard";
 
-type LeaderboardSnapshot = {
-  entries: LeaderboardEntry[];
-  currentUser: LeaderboardEntry | null;
-};
-
-export function useLeaderboard(initial?: LeaderboardSnapshot | null, debounceMs = 800) {
+export function useLeaderboard(
+  initial?: LeaderboardSnapshot | null,
+  scope: LeaderboardScope = "all",
+  debounceMs = 800,
+) {
   const [entries, setEntries] = useState<LeaderboardEntry[]>(initial?.entries ?? []);
   const [currentUser, setCurrentUser] = useState<LeaderboardEntry | null>(
     initial?.currentUser ?? null,
@@ -28,22 +19,40 @@ export function useLeaderboard(initial?: LeaderboardSnapshot | null, debounceMs 
   const timerRef = useRef<number | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
-  const fetchSnapshot = useCallback(async (signal?: AbortSignal) => {
-    setLoading(true);
+  useEffect(() => {
+    setEntries(initial?.entries ?? []);
+    setCurrentUser(initial?.currentUser ?? null);
+    setLoading(!initial);
     setError(null);
-    try {
-      const res = await fetch("/api/leaderboard", { signal });
-      if (!res.ok) throw new Error(`status ${res.status}`);
-      const body: LeaderboardSnapshot = await res.json();
-      setEntries(body.entries ?? []);
-      setCurrentUser(body.currentUser ?? null);
-    } catch (err: unknown) {
-      if ((err as any)?.name === "AbortError") return;
-      setError((err as Error)?.message ?? "unknown");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  }, [initial, scope]);
+
+  const fetchSnapshot = useCallback(
+    async (signal?: AbortSignal) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const searchParams = new URLSearchParams();
+        if (scope === "friends") {
+          searchParams.set("scope", scope);
+        }
+
+        const res = await fetch(
+          `/api/leaderboard${searchParams.size > 0 ? `?${searchParams.toString()}` : ""}`,
+          { signal },
+        );
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        const body: LeaderboardSnapshot = await res.json();
+        setEntries(body.entries ?? []);
+        setCurrentUser(body.currentUser ?? null);
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setError((err as Error)?.message ?? "unknown");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [scope],
+  );
 
   const refreshDebounced = useCallback(() => {
     if (timerRef.current) {
@@ -75,8 +84,7 @@ export function useLeaderboard(initial?: LeaderboardSnapshot | null, debounceMs 
         abortRef.current = null;
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [fetchSnapshot, initial]);
 
   return {
     entries,

--- a/app/i18n/messages/en.ts
+++ b/app/i18n/messages/en.ts
@@ -969,6 +969,7 @@ export const messages = {
         friends: "Friends",
       },
       scope: {
+        friends: "Friends",
         global: "Global",
       },
       overview: {

--- a/app/i18n/messages/ja.ts
+++ b/app/i18n/messages/ja.ts
@@ -965,6 +965,7 @@ export const messages = {
         friends: "フレンド",
       },
       scope: {
+        friends: "フレンド",
         global: "グローバル",
       },
       overview: {

--- a/app/i18n/messages/zh.ts
+++ b/app/i18n/messages/zh.ts
@@ -960,6 +960,7 @@ export const messages = {
         friends: "好友",
       },
       scope: {
+        friends: "好友",
         global: "全球",
       },
       overview: {

--- a/app/lib/friendships/friendship-queries.ts
+++ b/app/lib/friendships/friendship-queries.ts
@@ -1,0 +1,51 @@
+import type { Prisma } from "../../../generated/prisma/client";
+import { FriendshipStatus } from "../../../generated/prisma/enums";
+import type { prisma } from "../prisma";
+
+type FriendshipClient = Pick<typeof prisma, "friendship">;
+
+type FriendshipSideIds = {
+  userHighId: string;
+  userLowId: string;
+};
+
+const friendshipSideSelect = {
+  userHighId: true,
+  userLowId: true,
+} satisfies Prisma.FriendshipSelect;
+
+export function friendshipForUserWhere(userId: string): Prisma.FriendshipWhereInput {
+  return {
+    OR: [{ userLowId: userId }, { userHighId: userId }],
+  };
+}
+
+export function acceptedFriendshipWhere(userId: string): Prisma.FriendshipWhereInput {
+  return {
+    ...friendshipForUserWhere(userId),
+    status: FriendshipStatus.ACCEPTED,
+  };
+}
+
+export function getOtherFriendshipUserId(friendship: FriendshipSideIds, userId: string): string {
+  return friendship.userLowId === userId ? friendship.userHighId : friendship.userLowId;
+}
+
+export function getOtherFriendshipUser<TLow, THigh>(
+  friendship: FriendshipSideIds & { userHigh: THigh; userLow: TLow },
+  userId: string,
+): TLow | THigh {
+  return friendship.userLowId === userId ? friendship.userHigh : friendship.userLow;
+}
+
+export async function getAcceptedFriendIdsForUser(
+  userId: string,
+  client: FriendshipClient,
+): Promise<string[]> {
+  const friendships = (await client.friendship.findMany({
+    where: acceptedFriendshipWhere(userId),
+    select: friendshipSideSelect,
+  })) as FriendshipSideIds[];
+
+  return friendships.map((friendship) => getOtherFriendshipUserId(friendship, userId));
+}

--- a/app/lib/leaderboard.scope.test.ts
+++ b/app/lib/leaderboard.scope.test.ts
@@ -4,6 +4,7 @@ import { FriendshipStatus } from "../../generated/prisma/enums";
 
 const findMany = mock();
 const findFriendships = mock();
+const findUnique = mock();
 
 await mock.module("./prisma", () => ({
   prisma: {
@@ -12,16 +13,17 @@ await mock.module("./prisma", () => ({
     },
     userGameStats: {
       findMany,
-      findUnique: mock(),
+      findUnique,
     },
   },
 }));
 
-const { getLeaderboardSnapshot } = await import("./leaderboard");
+const { getLeaderboardSnapshot, LEADERBOARD_LIMIT } = await import("./leaderboard");
 
 beforeEach(() => {
   findMany.mockReset();
   findFriendships.mockReset();
+  findUnique.mockReset();
 });
 
 describe("getLeaderboardSnapshot scope handling", () => {
@@ -87,5 +89,60 @@ describe("getLeaderboardSnapshot scope handling", () => {
     });
     const queryArgs = findMany.mock.calls[0]?.[0] as { where?: { userId?: { in?: string[] } } };
     expect(queryArgs?.where?.userId?.in).toEqual(["user-1", "friend-a", "friend-b"]);
+  });
+
+  test("keeps the signed-in user spotlight when friends entries are capped", async () => {
+    const friendIds = Array.from({ length: LEADERBOARD_LIMIT }, (_, index) => `friend-${index}`);
+    findFriendships.mockResolvedValueOnce(
+      friendIds.map((friendId) => ({
+        userLowId: "user-1",
+        userHighId: friendId,
+      })),
+    );
+    findMany
+      .mockResolvedValueOnce(
+        friendIds.map((friendId, index) => ({
+          botMatchesPlayed: 0,
+          losses: index,
+          matchesPlayed: LEADERBOARD_LIMIT + 1,
+          rating: 2000 - index,
+          userId: friendId,
+          wins: LEADERBOARD_LIMIT - index,
+          user: {
+            displayName: `Friend ${index}`,
+          },
+        })),
+      )
+      .mockResolvedValueOnce(
+        friendIds.map(() => ({
+          botMatchesPlayed: 0,
+          matchesPlayed: 20,
+        })),
+      );
+    findUnique.mockResolvedValueOnce({
+      botMatchesPlayed: 0,
+      losses: 20,
+      matchesPlayed: 20,
+      rating: 1000,
+      userId: "user-1",
+      wins: 0,
+      user: {
+        displayName: "Me",
+      },
+    });
+
+    const snapshot = await getLeaderboardSnapshot("user-1", { scope: "friends" });
+
+    expect(snapshot.entries).toHaveLength(LEADERBOARD_LIMIT);
+    expect(snapshot.entries.some((entry) => entry.playerId === "user-1")).toBe(false);
+    expect(snapshot.currentUser).toMatchObject({
+      playerId: "user-1",
+      player: "Me",
+      rank: LEADERBOARD_LIMIT + 1,
+    });
+    const rankQueryArgs = findMany.mock.calls[1]?.[0] as {
+      where?: { userId?: { in?: string[] } };
+    };
+    expect(rankQueryArgs?.where?.userId?.in).toEqual(["user-1", ...friendIds]);
   });
 });

--- a/app/lib/leaderboard.scope.test.ts
+++ b/app/lib/leaderboard.scope.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { FriendshipStatus } from "../../generated/prisma/enums";
+
+const findMany = mock();
+const findFriendships = mock();
+
+await mock.module("./prisma", () => ({
+  prisma: {
+    friendship: {
+      findMany: findFriendships,
+    },
+    userGameStats: {
+      findMany,
+      findUnique: mock(),
+    },
+  },
+}));
+
+const { getLeaderboardSnapshot } = await import("./leaderboard");
+
+beforeEach(() => {
+  findMany.mockReset();
+  findFriendships.mockReset();
+});
+
+describe("getLeaderboardSnapshot scope handling", () => {
+  test("loads only accepted friends when scope is friends", async () => {
+    findFriendships.mockResolvedValueOnce([
+      {
+        userLowId: "user-1",
+        userHighId: "friend-a",
+      },
+      {
+        userLowId: "friend-b",
+        userHighId: "user-1",
+      },
+    ]);
+
+    findMany.mockResolvedValueOnce([
+      {
+        botMatchesPlayed: 0,
+        losses: 1,
+        matchesPlayed: 2,
+        rating: 1500,
+        userId: "friend-a",
+        wins: 1,
+        user: {
+          displayName: "Friend A",
+        },
+      },
+      {
+        botMatchesPlayed: 0,
+        losses: 2,
+        matchesPlayed: 4,
+        rating: 1300,
+        userId: "user-1",
+        wins: 2,
+        user: {
+          displayName: "Me",
+        },
+      },
+    ]);
+
+    const snapshot = await getLeaderboardSnapshot("user-1", { scope: "friends" });
+
+    expect(snapshot.currentUser).toMatchObject({
+      playerId: "user-1",
+      player: "Me",
+      rank: 2,
+    });
+    expect(snapshot.entries).toHaveLength(2);
+    expect(snapshot.entries[0]).toMatchObject({
+      playerId: "friend-a",
+      player: "Friend A",
+      rank: 1,
+    });
+    expect(findFriendships).toHaveBeenCalledWith({
+      select: {
+        userHighId: true,
+        userLowId: true,
+      },
+      where: {
+        OR: [{ userLowId: "user-1" }, { userHighId: "user-1" }],
+        status: FriendshipStatus.ACCEPTED,
+      },
+    });
+    const queryArgs = findMany.mock.calls[0]?.[0] as { where?: { userId?: { in?: string[] } } };
+    expect(queryArgs?.where?.userId?.in).toEqual(["user-1", "friend-a", "friend-b"]);
+  });
+});

--- a/app/lib/leaderboard.ts
+++ b/app/lib/leaderboard.ts
@@ -1,7 +1,7 @@
 //import { cacheLife } from "next/cache";
 
 import type { Prisma } from "../../generated/prisma/client";
-import { RuleType } from "../../generated/prisma/enums";
+import { FriendshipStatus, RuleType } from "../../generated/prisma/enums";
 import { prisma } from "./prisma";
 
 export const LEADERBOARD_BOARD_SIZE = 15;
@@ -42,6 +42,13 @@ export type LeaderboardSnapshot = {
   currentUser: LeaderboardEntry | null;
 };
 
+export type LeaderboardScope = "all" | "friends";
+
+export type LeaderboardSnapshotOptions = {
+  scope?: LeaderboardScope;
+  userId: string | null;
+};
+
 export type LeaderboardRankInput = {
   rating: number | null;
   wins: number;
@@ -72,6 +79,41 @@ export const leaderboardQueryArgs = {
   take: LEADERBOARD_FETCH_LIMIT,
   where: leaderboardRankedWhere,
 } satisfies Prisma.UserGameStatsFindManyArgs;
+
+function buildLeaderboardWhere(friendUserIds: string[] | null): Prisma.UserGameStatsWhereInput {
+  if (!friendUserIds) {
+    return leaderboardRankedWhere;
+  }
+
+  return {
+    ...leaderboardRankedWhere,
+    userId: {
+      in: friendUserIds,
+    },
+  };
+}
+
+async function getAcceptedFriendUserIds(userId: string): Promise<string[]> {
+  const friendships = await prisma.friendship.findMany({
+    where: {
+      status: FriendshipStatus.ACCEPTED,
+      OR: [{ userLowId: userId }, { userHighId: userId }],
+    },
+    select: {
+      userLowId: true,
+      userHighId: true,
+    },
+  });
+
+  return friendships.map((friendship) =>
+    friendship.userLowId === userId ? friendship.userHighId : friendship.userLowId,
+  );
+}
+
+async function getFriendsScopeUserIds(userId: string): Promise<string[]> {
+  const friendUserIds = await getAcceptedFriendUserIds(userId);
+  return [userId, ...friendUserIds.filter((friendUserId) => friendUserId !== userId)];
+}
 
 export function formatWinRate(wins: number, matchesPlayed: number): string {
   if (matchesPlayed === 0) {
@@ -130,19 +172,27 @@ export function toLeaderboardEntries(stats: LeaderboardStat[]): LeaderboardEntry
     .map((stat, index) => toLeaderboardEntry(stat, index + 1));
 }
 
-export async function getLeaderboardEntries(): Promise<LeaderboardEntry[]> {
+async function getLeaderboardEntries(
+  friendUserIds: string[] | null = null,
+): Promise<LeaderboardEntry[]> {
   // Fetch in batches and collect eligible (human) rows until we have
   // `LEADERBOARD_LIMIT` entries or the dataset is exhausted. This moves
   // the eligibility filter into the data/query boundary and avoids
   // returning fewer than `LEADERBOARD_LIMIT` entries on bot-heavy data.
   const results: LeaderboardEntry[] = [];
   let skip = 0;
+  const where = buildLeaderboardWhere(friendUserIds);
+
+  if (friendUserIds && friendUserIds.length === 0) {
+    return results;
+  }
 
   while (results.length < LEADERBOARD_LIMIT) {
     const args = {
       ...leaderboardQueryArgs,
       skip,
       take: LEADERBOARD_FETCH_LIMIT,
+      where,
     } as Prisma.UserGameStatsFindManyArgs;
 
     const stats = (await prisma.userGameStats.findMany(args)) as unknown as LeaderboardStat[];
@@ -213,7 +263,24 @@ export async function getLeaderboardSpotlight(userId: string): Promise<Leaderboa
   return rank === null ? null : toLeaderboardEntry(stats, rank);
 }
 
-export async function getLeaderboardSnapshot(userId: string | null): Promise<LeaderboardSnapshot> {
+export async function getLeaderboardSnapshot(
+  userId: string | null,
+  options: Pick<LeaderboardSnapshotOptions, "scope"> = {},
+): Promise<LeaderboardSnapshot> {
+  const scope = options.scope ?? "all";
+
+  if (scope === "friends") {
+    if (!userId) {
+      return { entries: [], currentUser: null };
+    }
+
+    const friendScopeUserIds = await getFriendsScopeUserIds(userId);
+    const entries = await getLeaderboardEntries(friendScopeUserIds);
+    const currentUser = entries.find((entry) => entry.playerId === userId) ?? null;
+
+    return { entries, currentUser };
+  }
+
   const [entries, currentUser] = await Promise.all([
     getLeaderboardEntries(),
     userId ? getLeaderboardSpotlight(userId) : Promise.resolve(null),

--- a/app/lib/leaderboard.ts
+++ b/app/lib/leaderboard.ts
@@ -1,7 +1,8 @@
 //import { cacheLife } from "next/cache";
 
 import type { Prisma } from "../../generated/prisma/client";
-import { FriendshipStatus, RuleType } from "../../generated/prisma/enums";
+import { RuleType } from "../../generated/prisma/enums";
+import { getAcceptedFriendIdsForUser } from "./friendships/friendship-queries";
 import { prisma } from "./prisma";
 
 export const LEADERBOARD_BOARD_SIZE = 15;
@@ -46,7 +47,6 @@ export type LeaderboardScope = "all" | "friends";
 
 export type LeaderboardSnapshotOptions = {
   scope?: LeaderboardScope;
-  userId: string | null;
 };
 
 export type LeaderboardRankInput = {
@@ -93,25 +93,8 @@ function buildLeaderboardWhere(friendUserIds: string[] | null): Prisma.UserGameS
   };
 }
 
-async function getAcceptedFriendUserIds(userId: string): Promise<string[]> {
-  const friendships = await prisma.friendship.findMany({
-    where: {
-      status: FriendshipStatus.ACCEPTED,
-      OR: [{ userLowId: userId }, { userHighId: userId }],
-    },
-    select: {
-      userLowId: true,
-      userHighId: true,
-    },
-  });
-
-  return friendships.map((friendship) =>
-    friendship.userLowId === userId ? friendship.userHighId : friendship.userLowId,
-  );
-}
-
 async function getFriendsScopeUserIds(userId: string): Promise<string[]> {
-  const friendUserIds = await getAcceptedFriendUserIds(userId);
+  const friendUserIds = await getAcceptedFriendIdsForUser(userId, prisma);
   return [userId, ...friendUserIds.filter((friendUserId) => friendUserId !== userId)];
 }
 
@@ -129,6 +112,7 @@ function isLeaderboardEligible(stat: { matchesPlayed: number; botMatchesPlayed: 
 
 export function buildLeaderboardAheadWhere(
   stats: LeaderboardRankInput,
+  friendUserIds: string[] | null = null,
 ): Prisma.UserGameStatsWhereInput | null {
   if (stats.matchesPlayed === 0 || stats.matchesPlayed <= stats.botMatchesPlayed) {
     return null;
@@ -149,7 +133,7 @@ export function buildLeaderboardAheadWhere(
   };
 
   return {
-    ...leaderboardRankedWhere,
+    ...buildLeaderboardWhere(friendUserIds),
     OR: [aheadByRating, aheadWithinRating],
   };
 }
@@ -216,8 +200,11 @@ async function getLeaderboardEntries(
   return results.slice(0, LEADERBOARD_LIMIT);
 }
 
-export async function getLeaderboardRank(input: LeaderboardRankInput): Promise<number | null> {
-  const aheadWhere = buildLeaderboardAheadWhere(input);
+export async function getLeaderboardRank(
+  input: LeaderboardRankInput,
+  friendUserIds: string[] | null = null,
+): Promise<number | null> {
+  const aheadWhere = buildLeaderboardAheadWhere(input, friendUserIds);
 
   if (!aheadWhere) {
     return null;
@@ -236,7 +223,10 @@ export async function getLeaderboardRank(input: LeaderboardRankInput): Promise<n
   return aheadCount + 1;
 }
 
-export async function getLeaderboardSpotlight(userId: string): Promise<LeaderboardEntry | null> {
+export async function getLeaderboardSpotlight(
+  userId: string,
+  friendUserIds: string[] | null = null,
+): Promise<LeaderboardEntry | null> {
   const stats = await prisma.userGameStats.findUnique({
     where: {
       userId_ruleType_boardSize: {
@@ -252,13 +242,16 @@ export async function getLeaderboardSpotlight(userId: string): Promise<Leaderboa
     return null;
   }
 
-  const rank = await getLeaderboardRank({
-    rating: stats.rating,
-    wins: stats.wins,
-    losses: stats.losses,
-    matchesPlayed: stats.matchesPlayed,
-    botMatchesPlayed: stats.botMatchesPlayed,
-  });
+  const rank = await getLeaderboardRank(
+    {
+      rating: stats.rating,
+      wins: stats.wins,
+      losses: stats.losses,
+      matchesPlayed: stats.matchesPlayed,
+      botMatchesPlayed: stats.botMatchesPlayed,
+    },
+    friendUserIds,
+  );
 
   return rank === null ? null : toLeaderboardEntry(stats, rank);
 }
@@ -276,7 +269,9 @@ export async function getLeaderboardSnapshot(
 
     const friendScopeUserIds = await getFriendsScopeUserIds(userId);
     const entries = await getLeaderboardEntries(friendScopeUserIds);
-    const currentUser = entries.find((entry) => entry.playerId === userId) ?? null;
+    const currentUser =
+      entries.find((entry) => entry.playerId === userId) ??
+      (await getLeaderboardSpotlight(userId, friendScopeUserIds));
 
     return { entries, currentUser };
   }


### PR DESCRIPTION

add a UTC-safe current season utility with season number, year, start/end dates, and days left
add a season stats module that derives the current season snapshot from the database
count rated matches correctly from finished human-vs-human matches within the active season window
remove hardcoded season values from the leaderboard page
wire the leaderboard tabs to all and friends scopes
include the signed-in user in the friends leaderboard scope
keep the existing leaderboard UI structure intact
add focused tests for season boundaries, season stats, friends scope, and leaderboard API behavior