### PR TITLE
[codex] Fix LAN dev auth and realtime origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,11 @@ DATABASE_URL=postgresql://transcendence:change_me_please@localhost:5432/transcen
 # Better Auth
 BETTER_AUTH_SECRET=change_me_to_a_32_byte_random_secret
 BETTER_AUTH_URL=https://localhost:8443
-# LAN testing example:
-# CADDY_SITE_ADDRESS="https://localhost:8443, https://10.11.5.5:8443"
-# CADDY_DEFAULT_SNI=10.11.5.5
-# BETTER_AUTH_URL=https://10.11.5.5:8443
-# BETTER_AUTH_TRUSTED_ORIGINS=https://localhost:8443,https://10.11.5.5:8443
+# LAN testing example, replace <LAN_IP> with this machine's current network IP:
+# CADDY_SITE_ADDRESS="https://localhost:8443, https://<LAN_IP>:8443"
+# CADDY_DEFAULT_SNI=<LAN_IP>
+# BETTER_AUTH_URL=https://<LAN_IP>:8443
+# BETTER_AUTH_TRUSTED_ORIGINS=https://localhost:8443,https://<LAN_IP>:8443
 # Auth email delivery modes:
 # - console: print password-reset links to the server console for local development
 # - resend-smtp: send password-reset emails through Resend SMTP
@@ -51,7 +51,7 @@ GOOGLE_CLIENT_SECRET=
 # SOCKET_CORS_ORIGIN=http://localhost:3000,https://localhost:8443
 # LAN testing with Caddy:
 # Leave SOCKET_PUBLIC_URL unset so each browser uses its current origin.
-# SOCKET_CORS_ORIGIN=https://localhost:8443,https://10.11.5.5:8443
+# SOCKET_CORS_ORIGIN=https://localhost:8443,https://<LAN_IP>:8443
 # REALTIME_INTERNAL_URL=http://localhost:3001/internal/game-update
 # REALTIME_FRIENDSHIP_INTERNAL_URL=http://localhost:3001/internal/friendship-update
 # REALTIME_INTERNAL_SECRET=change_me_to_a_shared_internal_secret

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ DATABASE_URL=postgresql://transcendence:change_me_please@localhost:5432/transcen
 # Better Auth
 BETTER_AUTH_SECRET=change_me_to_a_32_byte_random_secret
 BETTER_AUTH_URL=https://localhost:8443
+# LAN testing example:
+# CADDY_SITE_ADDRESS="https://localhost:8443, https://10.11.5.5:8443"
+# CADDY_DEFAULT_SNI=10.11.5.5
+# BETTER_AUTH_URL=https://10.11.5.5:8443
+# BETTER_AUTH_TRUSTED_ORIGINS=https://localhost:8443,https://10.11.5.5:8443
 # Auth email delivery modes:
 # - console: print password-reset links to the server console for local development
 # - resend-smtp: send password-reset emails through Resend SMTP
@@ -44,6 +49,9 @@ GOOGLE_CLIENT_SECRET=
 # Leave these unset when using the same-origin Caddy entrypoint.
 # SOCKET_PUBLIC_URL=http://localhost:3001
 # SOCKET_CORS_ORIGIN=http://localhost:3000,https://localhost:8443
+# LAN testing with Caddy:
+# Leave SOCKET_PUBLIC_URL unset so each browser uses its current origin.
+# SOCKET_CORS_ORIGIN=https://localhost:8443,https://10.11.5.5:8443
 # REALTIME_INTERNAL_URL=http://localhost:3001/internal/game-update
 # REALTIME_FRIENDSHIP_INTERNAL_URL=http://localhost:3001/internal/friendship-update
 # REALTIME_INTERNAL_SECRET=change_me_to_a_shared_internal_secret

--- a/app/[locale]/friends/actions.test.ts
+++ b/app/[locale]/friends/actions.test.ts
@@ -16,6 +16,7 @@ const fetchMock = mock(async () => new Response(null, { status: 200 }));
 const originalFetch = globalThis.fetch;
 const originalRealtimeInternalSecret = process.env["REALTIME_INTERNAL_SECRET"];
 const originalRealtimeFriendshipInternalUrl = process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"];
+const friendshipUpdateUrl = "http://localhost:3001/internal/friendship-update";
 
 await mock.module("next-intl/server", () => ({
   getLocale,
@@ -66,6 +67,16 @@ const pendingFriendship = {
   userLowId: "user-ada",
 };
 
+function expectFriendshipRefresh(usernames: string[]) {
+  expect(fetchMock).toHaveBeenCalledWith(
+    friendshipUpdateUrl,
+    expect.objectContaining({
+      body: JSON.stringify({ usernames }),
+      method: "POST",
+    }),
+  );
+}
+
 beforeEach(() => {
   getLocale.mockReset();
   getTranslations.mockReset();
@@ -81,8 +92,7 @@ beforeEach(() => {
 
   globalThis.fetch = fetchMock as unknown as typeof fetch;
   process.env["REALTIME_INTERNAL_SECRET"] = "friend-secret";
-  process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"] =
-    "http://localhost:3001/internal/friendship-update";
+  process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"] = friendshipUpdateUrl;
   getLocale.mockResolvedValue("en");
   getTranslations.mockImplementation(
     async ({ namespace }: { namespace: string }) =>
@@ -145,7 +155,7 @@ describe("sendFriendRequest", () => {
     });
   });
 
-  test("creates a pending friendship and revalidates shared navigation", async () => {
+  test("creates a pending friendship, notifies both players, and revalidates shared navigation", async () => {
     const result = await sendFriendRequest("grace");
 
     expect(result).toEqual({ success: true });
@@ -157,6 +167,7 @@ describe("sendFriendRequest", () => {
         userLowId: "user-ada",
       },
     });
+    expectFriendshipRefresh(["ada", "grace"]);
     expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
   });
 });
@@ -204,6 +215,7 @@ describe("respondToRequest", () => {
       where: { id: 42 },
     });
     expect(deleteFriendship).not.toHaveBeenCalled();
+    expectFriendshipRefresh(["ada", "grace"]);
     expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
   });
 
@@ -214,13 +226,7 @@ describe("respondToRequest", () => {
 
     expect(result).toEqual({ success: true });
     expect(deleteFriendship).toHaveBeenCalledWith({ where: { id: 42 } });
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:3001/internal/friendship-update",
-      expect.objectContaining({
-        body: JSON.stringify({ usernames: ["ada", "grace"] }),
-        method: "POST",
-      }),
-    );
+    expectFriendshipRefresh(["ada", "grace"]);
     expect(updateFriendship).not.toHaveBeenCalled();
   });
 });
@@ -246,7 +252,7 @@ describe("removeFriend", () => {
 
     expect(result).toEqual({ success: true });
     expect(deleteFriendship).toHaveBeenCalledWith({ where: { id: 42 } });
-    expect(fetchMock).toHaveBeenCalled();
+    expectFriendshipRefresh(["ada", "grace"]);
     expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
   });
 });

--- a/app/[locale]/friends/actions.ts
+++ b/app/[locale]/friends/actions.ts
@@ -4,7 +4,11 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { revalidatePath } from "next/cache";
 
 import { getCurrentSession } from "@/lib/auth";
-import { deleteFriendshipAndNotify, getLowHighIds } from "@/lib/friendships/friendship-mutations";
+import {
+  deleteFriendshipAndNotify,
+  getLowHighIds,
+  notifyFriendshipUpdateForUserIdsSafely,
+} from "@/lib/friendships/friendship-mutations";
 import { prisma } from "@/lib/prisma";
 
 export async function sendFriendRequest(targetUsername: string) {
@@ -38,6 +42,7 @@ export async function sendFriendRequest(targetUsername: string) {
       status: "PENDING",
     },
   });
+  await notifyFriendshipUpdateForUserIdsSafely(userLowId, userHighId);
 
   revalidatePath("/", "layout");
   return { success: true };
@@ -68,6 +73,7 @@ export async function respondToRequest(friendshipId: number, accept: boolean) {
         respondedAt: new Date(),
       },
     });
+    await notifyFriendshipUpdateForUserIdsSafely(friendship.userLowId, friendship.userHighId);
   } else {
     await deleteFriendshipAndNotify(friendship);
   }

--- a/app/[locale]/profile/[username]/actions.test.ts
+++ b/app/[locale]/profile/[username]/actions.test.ts
@@ -13,6 +13,7 @@ const fetchMock = mock(async () => new Response(null, { status: 200 }));
 const originalFetch = globalThis.fetch;
 const originalRealtimeInternalSecret = process.env["REALTIME_INTERNAL_SECRET"];
 const originalRealtimeFriendshipInternalUrl = process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"];
+const friendshipUpdateUrl = "http://localhost:3001/internal/friendship-update";
 
 await mock.module("next/cache", () => ({
   revalidatePath,
@@ -48,6 +49,16 @@ const friendship = {
   status: "ACCEPTED",
 };
 
+function expectFriendshipRefresh(usernames: string[]) {
+  expect(fetchMock).toHaveBeenCalledWith(
+    friendshipUpdateUrl,
+    expect.objectContaining({
+      body: JSON.stringify({ usernames }),
+      method: "POST",
+    }),
+  );
+}
+
 beforeEach(() => {
   getCurrentSession.mockReset();
   findManyUsers.mockReset();
@@ -60,8 +71,7 @@ beforeEach(() => {
 
   globalThis.fetch = fetchMock as unknown as typeof fetch;
   process.env["REALTIME_INTERNAL_SECRET"] = "friend-secret";
-  process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"] =
-    "http://localhost:3001/internal/friendship-update";
+  process.env["REALTIME_FRIENDSHIP_INTERNAL_URL"] = friendshipUpdateUrl;
   getCurrentSession.mockResolvedValue({
     user: { id: "user-a" },
   });
@@ -70,7 +80,9 @@ beforeEach(() => {
     { id: "user-b", username: "bob" },
   ]);
   findFriendship.mockResolvedValue(friendship);
+  createFriendship.mockResolvedValue({});
   deleteFriendship.mockResolvedValue({});
+  updateFriendship.mockResolvedValue({});
   fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
 });
 
@@ -91,18 +103,52 @@ afterEach(() => {
 });
 
 describe("processFriendAction", () => {
+  test("notifies both players when adding a friend from a profile", async () => {
+    findFriendship.mockResolvedValueOnce(null);
+
+    const result = await processFriendAction("user-b", "ADD");
+
+    expect(result).toEqual({ success: true });
+    expect(createFriendship).toHaveBeenCalledWith({
+      data: {
+        requestedById: "user-a",
+        status: "PENDING",
+        userHighId: "user-b",
+        userLowId: "user-a",
+      },
+    });
+    expectFriendshipRefresh(["ada", "bob"]);
+    expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
+  });
+
+  test("notifies both players when accepting a profile friend request", async () => {
+    findFriendship.mockResolvedValueOnce({
+      ...friendship,
+      requestedById: "user-b",
+      status: "PENDING",
+    });
+
+    const result = await processFriendAction("user-b", "ACCEPT");
+
+    expect(result).toEqual({ success: true });
+    expect(updateFriendship).toHaveBeenCalledWith({
+      data: {
+        acceptedAt: expect.any(Date),
+        respondedAt: expect.any(Date),
+        status: "ACCEPTED",
+      },
+      where: { userLowId_userHighId: { userLowId: "user-a", userHighId: "user-b" } },
+    });
+    expectFriendshipRefresh(["ada", "bob"]);
+    expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
+  });
+
   test("uses the shared delete-and-notify path for profile removals", async () => {
     const result = await processFriendAction("user-b", "REMOVE");
 
     expect(result).toEqual({ success: true });
     expect(deleteFriendship).toHaveBeenCalledWith({ where: { id: 42 } });
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:3001/internal/friendship-update",
-      expect.objectContaining({
-        body: JSON.stringify({ usernames: ["ada", "bob"] }),
-        method: "POST",
-      }),
-    );
+    expectFriendshipRefresh(["ada", "bob"]);
     expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
   });
 

--- a/app/[locale]/profile/[username]/actions.ts
+++ b/app/[locale]/profile/[username]/actions.ts
@@ -3,7 +3,11 @@
 import { revalidatePath } from "next/cache";
 
 import { getCurrentSession } from "@/lib/auth";
-import { deleteFriendshipAndNotify, getLowHighIds } from "@/lib/friendships/friendship-mutations";
+import {
+  deleteFriendshipAndNotify,
+  getLowHighIds,
+  notifyFriendshipUpdateForUserIdsSafely,
+} from "@/lib/friendships/friendship-mutations";
 import { prisma } from "@/lib/prisma";
 
 export async function processFriendAction(
@@ -35,6 +39,7 @@ export async function processFriendAction(
           status: "PENDING",
         },
       });
+      await notifyFriendshipUpdateForUserIdsSafely(userLowId, userHighId);
     } else if (action === "ACCEPT") {
       if (!existing || existing.status !== "PENDING" || existing.requestedById === loggedInUserId) {
         return { error: "Invalid transition" };
@@ -48,6 +53,7 @@ export async function processFriendAction(
           respondedAt: new Date(),
         },
       });
+      await notifyFriendshipUpdateForUserIdsSafely(userLowId, userHighId);
     } else if (action === "DECLINE" || action === "REMOVE" || action === "CANCEL") {
       if (!existing) return { error: "Not found" };
 

--- a/app/api/auth/auth-routes.test.ts
+++ b/app/api/auth/auth-routes.test.ts
@@ -19,6 +19,8 @@ const getDuplicateSignupFields = mock();
 const findUnique = mock();
 const updateUser = mock();
 const originalBetterAuthUrl = process.env["BETTER_AUTH_URL"];
+const originalBetterAuthTrustedOrigins = process.env["BETTER_AUTH_TRUSTED_ORIGINS"];
+const originalCaddySiteAddress = process.env["CADDY_SITE_ADDRESS"];
 
 await mock.module("next/cache", () => ({
   revalidatePath,
@@ -118,6 +120,21 @@ function hostileJsonRequest(path: string, body: unknown) {
   });
 }
 
+function trustedOriginJsonRequest(origin: string, path: string, body: unknown) {
+  const host = new URL(origin).host;
+
+  return new Request(`${origin}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin,
+      "x-forwarded-host": host,
+      "x-forwarded-proto": "https",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
 function malformedJsonRequest(path: string) {
   return new Request(`http://localhost${path}`, {
     method: "POST",
@@ -140,6 +157,8 @@ function formData(values: Record<string, string>) {
 
 beforeEach(() => {
   delete process.env["BETTER_AUTH_URL"];
+  delete process.env["BETTER_AUTH_TRUSTED_ORIGINS"];
+  delete process.env["CADDY_SITE_ADDRESS"];
 
   changePassword.mockReset();
   signInEmail.mockReset();
@@ -175,6 +194,18 @@ afterEach(() => {
     delete process.env["BETTER_AUTH_URL"];
   } else {
     process.env["BETTER_AUTH_URL"] = originalBetterAuthUrl;
+  }
+
+  if (originalBetterAuthTrustedOrigins === undefined) {
+    delete process.env["BETTER_AUTH_TRUSTED_ORIGINS"];
+  } else {
+    process.env["BETTER_AUTH_TRUSTED_ORIGINS"] = originalBetterAuthTrustedOrigins;
+  }
+
+  if (originalCaddySiteAddress === undefined) {
+    delete process.env["CADDY_SITE_ADDRESS"];
+  } else {
+    process.env["CADDY_SITE_ADDRESS"] = originalCaddySiteAddress;
   }
 });
 
@@ -252,6 +283,25 @@ describe("auth API routes", () => {
 
     expect(call.body).toMatchObject({
       callbackURL: "https://canonical.test/en/profile",
+      email: "max@example.com",
+      password: "password123",
+    });
+  });
+
+  test("login keeps callbacks on the current request origin when it is trusted", async () => {
+    process.env["BETTER_AUTH_URL"] = "https://10.11.5.5:8443";
+    process.env["BETTER_AUTH_TRUSTED_ORIGINS"] = "https://localhost:8443,https://10.11.5.5:8443";
+
+    await loginRoute.POST(
+      trustedOriginJsonRequest("https://localhost:8443", "/api/auth/login", {
+        email: "MAX@example.COM",
+        password: "password123",
+      }),
+    );
+    const call = signInEmail.mock.calls[0]?.[0] as AuthApiCall;
+
+    expect(call.body).toMatchObject({
+      callbackURL: "https://localhost:8443/en/profile",
       email: "max@example.com",
       password: "password123",
     });

--- a/app/api/auth/auth-routes.test.ts
+++ b/app/api/auth/auth-routes.test.ts
@@ -289,8 +289,9 @@ describe("auth API routes", () => {
   });
 
   test("login keeps callbacks on the current request origin when it is trusted", async () => {
-    process.env["BETTER_AUTH_URL"] = "https://10.11.5.5:8443";
-    process.env["BETTER_AUTH_TRUSTED_ORIGINS"] = "https://localhost:8443,https://10.11.5.5:8443";
+    process.env["BETTER_AUTH_URL"] = "https://lan-host.test:8443";
+    process.env["BETTER_AUTH_TRUSTED_ORIGINS"] =
+      "https://localhost:8443,https://lan-host.test:8443";
 
     await loginRoute.POST(
       trustedOriginJsonRequest("https://localhost:8443", "/api/auth/login", {

--- a/app/api/auth/logout/route.test.ts
+++ b/app/api/auth/logout/route.test.ts
@@ -2,12 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { createAuthModuleMock } from "@/test-utils/auth-module-mock";
 
-const headers = mock();
 const signOut = mock();
-
-await mock.module("next/headers", () => ({
-  headers,
-}));
 
 await mock.module("../../../lib/auth", () =>
   createAuthModuleMock({
@@ -22,35 +17,47 @@ await mock.module("../../../lib/auth", () =>
 const route = await import("./route");
 
 beforeEach(() => {
-  headers.mockReset();
   signOut.mockReset();
 
-  headers.mockResolvedValue(new Headers({ cookie: "session=1" }));
   signOut.mockResolvedValue({
     headers: new Headers({ "set-cookie": "session=; Max-Age=0" }),
   });
 });
 
+function logoutRequest(cookie = "better-auth.session_token=abc") {
+  return new Request("https://10.11.5.5:8443/api/auth/logout", {
+    method: "POST",
+    headers: { cookie },
+  });
+}
+
 describe("POST /api/auth/logout", () => {
   test("returns success and forwards Better Auth response headers", async () => {
-    const response = await route.POST();
+    const request = logoutRequest();
+    const response = await route.POST(request);
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ success: true });
     expect(response.headers.get("set-cookie")).toBe("session=; Max-Age=0");
     expect(signOut).toHaveBeenCalledWith({
-      headers: expect.any(Headers),
+      headers: request.headers,
+      request,
       returnHeaders: true,
     });
   });
 
-  test("still returns success when Better Auth sign-out fails", async () => {
+  test("still expires auth cookies when Better Auth sign-out fails", async () => {
     signOut.mockRejectedValueOnce(new Error("session store down"));
 
-    const response = await route.POST();
+    const response = await route.POST(
+      logoutRequest("better-auth.session_token=abc; better-auth.session_data.0=chunk"),
+    );
+    const setCookieHeader = response.headers.get("set-cookie");
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ success: true });
-    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(setCookieHeader).toContain("better-auth.session_token=");
+    expect(setCookieHeader).toContain("better-auth.session_data.0=");
+    expect(setCookieHeader).toContain("Max-Age=0");
   });
 });

--- a/app/api/auth/logout/route.test.ts
+++ b/app/api/auth/logout/route.test.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
 });
 
 function logoutRequest(cookie = "better-auth.session_token=abc") {
-  return new Request("https://10.11.5.5:8443/api/auth/logout", {
+  return new Request("https://lan-host.test:8443/api/auth/logout", {
     method: "POST",
     headers: { cookie },
   });

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,17 +1,74 @@
-import { headers } from "next/headers";
-
 import { auth } from "../../../lib/auth";
 
-export async function POST() {
+const authCookieNames = [
+  "better-auth.session_token",
+  "better-auth.session_data",
+  "better-auth.account_data",
+  "better-auth.dont_remember",
+];
+
+function getRequestCookieNames(request: Request): string[] {
+  const cookieHeader = request.headers.get("cookie") ?? "";
+
+  return cookieHeader
+    .split(";")
+    .map((cookie) => cookie.split("=")[0]?.trim())
+    .filter((name): name is string => Boolean(name));
+}
+
+function isSecureRequest(request: Request): boolean {
+  const forwardedProto = request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+
+  if (forwardedProto) {
+    return forwardedProto === "https";
+  }
+
+  return new URL(request.url).protocol === "https:";
+}
+
+function appendExpiredCookie(headers: Headers, name: string, secure: boolean) {
+  const secureAttribute = secure ? "; Secure" : "";
+
+  headers.append(
+    "set-cookie",
+    `${name}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax${secureAttribute}`,
+  );
+}
+
+function appendFallbackAuthCookieExpirations(headers: Headers, request: Request) {
+  const secure = isSecureRequest(request);
+  const cookieNames = new Set([
+    ...authCookieNames,
+    ...authCookieNames.map((name) => `__Secure-${name}`),
+    ...getRequestCookieNames(request).filter((name) =>
+      authCookieNames.some(
+        (authCookieName) =>
+          name === authCookieName ||
+          name === `__Secure-${authCookieName}` ||
+          name.startsWith(`${authCookieName}.`) ||
+          name.startsWith(`__Secure-${authCookieName}.`),
+      ),
+    ),
+  ]);
+
+  for (const name of cookieNames) {
+    appendExpiredCookie(headers, name, secure);
+  }
+}
+
+export async function POST(request: Request) {
   const authResponse = await auth.api
     .signOut({
-      headers: await headers(),
+      headers: request.headers,
+      request,
       returnHeaders: true,
     })
     .catch(() => null);
+  const responseHeaders = new Headers(authResponse?.headers);
 
-  return Response.json(
-    { success: true },
-    authResponse ? { headers: authResponse.headers } : undefined,
-  );
+  if (!responseHeaders.has("set-cookie")) {
+    appendFallbackAuthCookieExpirations(responseHeaders, request);
+  }
+
+  return Response.json({ success: true }, { headers: responseHeaders });
 }

--- a/app/components/logout-button.tsx
+++ b/app/components/logout-button.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 import { useState } from "react";
 
 import { useRouter } from "@/i18n/navigation";
-import { authClient } from "@/lib/auth-client";
+import { signOutCurrentSession } from "@/lib/auth-client";
 
 export const LogoutButton = () => {
   const router = useRouter();
@@ -17,13 +17,7 @@ export const LogoutButton = () => {
     setError(null);
 
     try {
-      const { error: signOutError } = await authClient.signOut();
-
-      if (signOutError) {
-        setError(signOutError.message ?? t("unavailable"));
-        return;
-      }
-
+      await signOutCurrentSession();
       router.push("/login");
       router.refresh();
     } catch (unknownError) {

--- a/app/components/player-menu.tsx
+++ b/app/components/player-menu.tsx
@@ -7,7 +7,7 @@ import { useRouter } from "next/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/navigation";
-import { authClient } from "@/lib/auth-client";
+import { signOutCurrentSession } from "@/lib/auth-client";
 
 interface UserProps {
   username?: string;
@@ -42,7 +42,7 @@ export function PlayerLogout({ className, iconOnly }: { className?: string; icon
 
   const handleLogout = async () => {
     try {
-      await authClient.signOut();
+      await signOutCurrentSession();
       router.push("/login");
       router.refresh();
     } catch (error) {

--- a/app/lib/auth-client.ts
+++ b/app/lib/auth-client.ts
@@ -3,3 +3,28 @@
 import { createAuthClient } from "better-auth/react";
 
 export const authClient = createAuthClient();
+
+async function signOutViaSameOriginRoute() {
+  const response = await fetch("/api/auth/logout", {
+    credentials: "same-origin",
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    throw new Error("Logout request failed.");
+  }
+}
+
+export async function signOutCurrentSession() {
+  try {
+    const { error } = await authClient.signOut();
+
+    if (!error) {
+      return;
+    }
+  } catch {
+    // Fall through to the same-origin route below.
+  }
+
+  await signOutViaSameOriginRoute();
+}

--- a/app/lib/auth-origins.ts
+++ b/app/lib/auth-origins.ts
@@ -1,0 +1,93 @@
+const originEnvKeys = ["BETTER_AUTH_TRUSTED_ORIGINS", "CADDY_SITE_ADDRESS", "BETTER_AUTH_URL"];
+
+function getFirstHeaderValue(value: string | null): string | null {
+  return value?.split(",")[0]?.trim() || null;
+}
+
+function normalizeOrigin(value: string): string | null {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return null;
+  }
+}
+
+function splitOriginList(value: string | undefined): string[] {
+  return (
+    value
+      ?.split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean) ?? []
+  );
+}
+
+export function getConfiguredAuthBaseUrl(env: NodeJS.ProcessEnv = process.env): string | null {
+  return normalizeOrigin(env["BETTER_AUTH_URL"] ?? "");
+}
+
+export function getTrustedAuthOrigins(env: NodeJS.ProcessEnv = process.env): string[] {
+  const origins = new Set<string>();
+
+  for (const key of originEnvKeys) {
+    for (const rawOrigin of splitOriginList(env[key])) {
+      const origin = normalizeOrigin(rawOrigin);
+
+      if (origin) {
+        origins.add(origin);
+      }
+    }
+  }
+
+  return Array.from(origins);
+}
+
+export function getTrustedAuthHosts(env: NodeJS.ProcessEnv = process.env): string[] {
+  return getTrustedAuthOrigins(env)
+    .map((origin) => {
+      try {
+        return new URL(origin).host;
+      } catch {
+        return null;
+      }
+    })
+    .filter((host): host is string => Boolean(host));
+}
+
+export function getRequestOrigin(headers?: Headers, requestUrl?: string): string | null {
+  const origin = normalizeOrigin(headers?.get("origin") ?? "");
+
+  if (origin) {
+    return origin;
+  }
+
+  const forwardedHost = getFirstHeaderValue(headers?.get("x-forwarded-host") ?? null);
+  const host = forwardedHost ?? headers?.get("host")?.trim();
+
+  if (host) {
+    const forwardedProto = getFirstHeaderValue(headers?.get("x-forwarded-proto") ?? null);
+    const proto = forwardedProto ?? (host.startsWith("localhost") ? "http" : "https");
+    return normalizeOrigin(`${proto}://${host}`);
+  }
+
+  if (requestUrl) {
+    return normalizeOrigin(requestUrl);
+  }
+
+  return null;
+}
+
+export function isTrustedAuthOrigin(origin: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  const trustedOrigins = getTrustedAuthOrigins(env);
+
+  if (trustedOrigins.length === 0) {
+    return true;
+  }
+
+  return trustedOrigins.includes(origin);
+}

--- a/app/lib/auth-urls.ts
+++ b/app/lib/auth-urls.ts
@@ -1,42 +1,38 @@
 import "server-only";
 import type { Locale } from "../i18n/config";
+import {
+  getConfiguredAuthBaseUrl,
+  getRequestOrigin,
+  getTrustedAuthOrigins,
+  isTrustedAuthOrigin,
+} from "./auth-origins";
 
 type AuthUrlContext = {
   headers?: Headers;
   requestUrl?: string;
 };
 
-function getFirstHeaderValue(value: string | null): string | null {
-  return value?.split(",")[0]?.trim() || null;
-}
-
 export function getAuthAppBaseUrl({ headers, requestUrl }: AuthUrlContext = {}): string {
-  const configuredBaseUrl = process.env["BETTER_AUTH_URL"]?.trim();
+  const requestOrigin = getRequestOrigin(headers, requestUrl);
+
+  if (requestOrigin && isTrustedAuthOrigin(requestOrigin)) {
+    return requestOrigin;
+  }
+
+  const configuredBaseUrl = getConfiguredAuthBaseUrl();
 
   if (configuredBaseUrl) {
     return configuredBaseUrl;
   }
 
-  const origin = headers?.get("origin")?.trim();
+  const [firstTrustedOrigin] = getTrustedAuthOrigins();
 
-  if (origin) {
-    return origin;
+  if (firstTrustedOrigin) {
+    return firstTrustedOrigin;
   }
 
-  const forwardedHost = getFirstHeaderValue(headers?.get("x-forwarded-host") ?? null);
-  const host = forwardedHost ?? headers?.get("host")?.trim();
-
-  if (host) {
-    const forwardedProto = getFirstHeaderValue(headers?.get("x-forwarded-proto") ?? null) ?? "http";
-    return `${forwardedProto}://${host}`;
-  }
-
-  if (requestUrl) {
-    try {
-      return new URL(requestUrl).origin;
-    } catch {
-      return "http://localhost:3000";
-    }
+  if (requestOrigin) {
+    return requestOrigin;
   }
 
   return "http://localhost:3000";

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -9,6 +9,11 @@ import { z } from "zod";
 import type { User } from "../../generated/prisma/client";
 import { defaultLocale } from "../i18n/config";
 import type { DuplicateSignupFields } from "./auth-duplicate-fields";
+import {
+  getConfiguredAuthBaseUrl,
+  getTrustedAuthHosts,
+  getTrustedAuthOrigins,
+} from "./auth-origins";
 import { authCredentialPolicy } from "./auth-policy";
 import { oauthProviderIds, type OAuthProviderId } from "./oauth-providers";
 import { prisma } from "./prisma";
@@ -142,11 +147,28 @@ function getPasswordResetUrl(url: string, token: string): string {
 
 const githubCredentials = getOAuthCredentials("github");
 const googleCredentials = getOAuthCredentials("google");
+const trustedOrigins = getTrustedAuthOrigins();
+
+function getBetterAuthBaseUrl() {
+  const fallback = getConfiguredAuthBaseUrl() ?? trustedOrigins[0];
+  const allowedHosts = getTrustedAuthHosts();
+
+  if (allowedHosts.length > 0) {
+    return {
+      allowedHosts,
+      fallback,
+      protocol: "auto" as const,
+    };
+  }
+
+  return fallback ?? process.env["BETTER_AUTH_URL"];
+}
 
 export const auth = betterAuth({
   appName: "42 Transcendence Gomoku",
-  baseURL: process.env["BETTER_AUTH_URL"],
+  baseURL: getBetterAuthBaseUrl(),
   secret: process.env["BETTER_AUTH_SECRET"],
+  trustedOrigins,
   database: prismaAdapter(prisma, {
     provider: "postgresql",
   }),

--- a/app/lib/friendships/friendship-mutations.ts
+++ b/app/lib/friendships/friendship-mutations.ts
@@ -36,14 +36,21 @@ export async function notifyFriendshipUpdateForUserIds(userLowId: string, userHi
   await publishFriendshipUpdate([userLowUsername, userHighUsername]);
 }
 
+export async function notifyFriendshipUpdateForUserIdsSafely(
+  userLowId: string,
+  userHighId: string,
+) {
+  try {
+    await notifyFriendshipUpdateForUserIds(userLowId, userHighId);
+  } catch (error) {
+    console.error("Failed to notify realtime server", error);
+  }
+}
+
 export async function deleteFriendshipAndNotify(friendship: FriendshipSnapshot) {
   await prisma.friendship.delete({
     where: { id: friendship.id },
   });
 
-  try {
-    await notifyFriendshipUpdateForUserIds(friendship.userLowId, friendship.userHighId);
-  } catch (error) {
-    console.error("Failed to notify realtime server", error);
-  }
+  await notifyFriendshipUpdateForUserIdsSafely(friendship.userLowId, friendship.userHighId);
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
       target: dev
     environment:
       NODE_ENV: development
-      SOCKET_PUBLIC_URL: https://localhost:8443
+      SOCKET_PUBLIC_URL: ${SOCKET_PUBLIC_URL:-}
     volumes:
       - .:/app
       - app_node_modules:/app/node_modules
@@ -30,7 +30,7 @@ services:
       NODE_ENV: development
       SOCKET_HOST: 0.0.0.0
       SOCKET_PORT: 3001
-      SOCKET_CORS_ORIGIN: https://localhost:8443
+      SOCKET_CORS_ORIGIN: ${SOCKET_CORS_ORIGIN:-https://localhost:8443}
     volumes:
       - .:/app
       - app_node_modules:/app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-transcendence}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@database:5432/${POSTGRES_DB:-transcendence}?schema=public
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-https://localhost:8443}
+      BETTER_AUTH_TRUSTED_ORIGINS: ${BETTER_AUTH_TRUSTED_ORIGINS:-${BETTER_AUTH_URL:-https://localhost:8443}}
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
@@ -32,7 +33,7 @@ services:
       REALTIME_INTERNAL_URL: http://realtime:3001/internal/game-update
       REALTIME_FRIENDSHIP_INTERNAL_URL: http://realtime:3001/internal/friendship-update
       REALTIME_INTERNAL_SECRET: ${REALTIME_INTERNAL_SECRET:-}
-      SOCKET_PUBLIC_URL: ${SOCKET_PUBLIC_URL:-https://localhost:8443}
+      SOCKET_PUBLIC_URL: ${SOCKET_PUBLIC_URL:-}
     depends_on:
       database:
         condition: service_healthy
@@ -62,6 +63,7 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-transcendence}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@database:5432/${POSTGRES_DB:-transcendence}?schema=public
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-https://localhost:8443}
+      BETTER_AUTH_TRUSTED_ORIGINS: ${BETTER_AUTH_TRUSTED_ORIGINS:-${BETTER_AUTH_URL:-https://localhost:8443}}
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
@@ -90,6 +92,9 @@ services:
 
   caddy:
     image: caddy:2.11.2-alpine
+    environment:
+      CADDY_DEFAULT_SNI: ${CADDY_DEFAULT_SNI:-localhost}
+      CADDY_SITE_ADDRESS: ${CADDY_SITE_ADDRESS:-https://localhost:8443}
     depends_on:
       app:
         condition: service_healthy

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,4 +1,8 @@
-https://localhost:8443 {
+{
+	default_sni {$CADDY_DEFAULT_SNI:localhost}
+}
+
+{$CADDY_SITE_ADDRESS:https://localhost:8443} {
 	tls internal
 
 	@socket path /socket.io/*

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,8 +6,60 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 const withNextIntl = createNextIntlPlugin("./app/i18n/request.ts");
+const devOriginEnvKeys = [
+  "BETTER_AUTH_TRUSTED_ORIGINS",
+  "CADDY_SITE_ADDRESS",
+  "BETTER_AUTH_URL",
+  "SOCKET_CORS_ORIGIN",
+];
+const devHostEnvKeys = ["CADDY_DEFAULT_SNI"];
+
+function getHostname(value: string): string | null {
+  const trimmed = value.trim().replace(/^['"]|['"]$/g, "");
+
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return new URL(trimmed).hostname.toLowerCase();
+  } catch {
+    try {
+      return new URL(`https://${trimmed}`).hostname.toLowerCase();
+    } catch {
+      return null;
+    }
+  }
+}
+
+function getAllowedDevOrigins(): string[] {
+  const hostnames = new Set<string>();
+
+  for (const key of devOriginEnvKeys) {
+    for (const entry of process.env[key]?.split(",") ?? []) {
+      const hostname = getHostname(entry);
+
+      if (hostname) {
+        hostnames.add(hostname);
+      }
+    }
+  }
+
+  for (const key of devHostEnvKeys) {
+    const hostname = getHostname(process.env[key] ?? "");
+
+    if (hostname) {
+      hostnames.add(hostname);
+    }
+  }
+
+  return Array.from(hostnames);
+}
+
+const allowedDevOrigins = getAllowedDevOrigins();
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: allowedDevOrigins.length > 0 ? allowedDevOrigins : undefined,
   cacheComponents: true,
   experimental: {
     instantNavigationDevToolsToggle: true,


### PR DESCRIPTION
## Summary

- Allow local LAN HTTPS origins to be configured through env-driven Caddy, Better Auth, Socket.IO, and Next dev settings.
- Keep Socket.IO same-origin by default so localhost and LAN browsers do not fight over one hardcoded public URL.
- Notify friendship updates from server mutations and harden logout so auth cookies are cleared even if the client sign-out path fails.
- Document LAN setup with a `<LAN_IP>` placeholder instead of committing a machine-specific address.

## Root Cause

LAN browsers were reaching the app through a different HTTPS origin than `localhost`. Caddy, Better Auth, Socket.IO, and Next dev all needed to agree on that origin. In development specifically, Next was blocking dev-only HMR/client resources from the LAN host, which made hydrated client actions such as logout, friends updates, and profile stats unreliable.

## Validation

- `bun run typecheck`
- `bun test`
- `bun test app/api/auth/auth-routes.test.ts app/api/auth/logout/route.test.ts`
- Browser smoke against the configured LAN HTTPS origin: login succeeded, logout posted to `/api/auth/sign-out`, and `/api/auth/session` changed from `200` to `401`.