### PR TITLE
[codex] Add session cookie cache

### DIFF
--- a/app/[locale]/friends/page.tsx
+++ b/app/[locale]/friends/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
-import { getCurrentSession } from "@/lib/auth";
+import { getCurrentSessionIdentity } from "@/lib/auth";
 import {
   friendshipForUserWhere,
   getOtherFriendshipUser,
@@ -39,7 +39,7 @@ async function FriendsPageContent({ params, searchParams }: FriendsPageProps) {
   const { query } = await searchParams;
   setRequestLocale(locale);
 
-  const sessionData = await getCurrentSession();
+  const sessionData = await getCurrentSessionIdentity();
 
   if (!sessionData) {
     redirect({ href: "/login", locale });

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -12,7 +12,7 @@ import { Suspense, type ReactNode } from "react";
 import AppSidebar from "@/components/app-sidebar";
 import { PresenceProvider, PresenceSessionSync } from "@/components/presence-provider";
 import { routing } from "@/i18n/routing";
-import { getCurrentSession } from "@/lib/auth";
+import { getCurrentSessionIdentity } from "@/lib/auth";
 import { cn } from "@/lib/utils";
 
 const manrope = Manrope({
@@ -97,7 +97,7 @@ export default async function RootLayout({ children, params }: RootLayoutProps) 
 }
 
 async function PresenceSession() {
-  const context = await getCurrentSession();
+  const context = await getCurrentSessionIdentity();
 
   return <PresenceSessionSync username={context?.user.username} />;
 }

--- a/app/[locale]/leaderboard/page.tsx
+++ b/app/[locale]/leaderboard/page.tsx
@@ -7,7 +7,7 @@ import { Suspense } from "react";
 import { Badge, MetricCard, PageHeader, PageShell, Surface } from "@/components/gomoku-ui";
 import LeaderboardClient from "@/components/leaderboard-client";
 import { PageLoadingShell } from "@/components/page-loading-shell";
-import { getCurrentSession } from "@/lib/auth";
+import { getCurrentSessionIdentity } from "@/lib/auth";
 import {
   getLeaderboardSnapshot,
   type LeaderboardSnapshot,
@@ -93,7 +93,7 @@ async function LeaderBoardContent({ params, searchParams }: LeaderBoardProps) {
   const scope = rawScope === "friends" ? "friends" : "all";
 
   try {
-    const session = await getCurrentSession();
+    const session = await getCurrentSessionIdentity();
     const [leaderboardData, seasonData] = await Promise.all([
       getLeaderboardSnapshot(session?.user.id ?? null, { scope }),
       getSeasonSnapshot(),

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -6,7 +6,7 @@ import { BoardShowpiece, PageShell } from "@/components/gomoku-ui";
 import { LoginForm } from "@/components/login-form";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
-import { getConfiguredOAuthProviders, getCurrentSession } from "@/lib/auth";
+import { getConfiguredOAuthProviders, getCurrentSessionIdentity } from "@/lib/auth";
 
 type LoginPageProps = {
   params: Promise<{
@@ -26,7 +26,7 @@ async function LoginPageContent({ params }: LoginPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const session = await getCurrentSession();
+  const session = await getCurrentSessionIdentity();
 
   if (session) {
     redirect({ href: "/account", locale });

--- a/app/[locale]/messages/page.tsx
+++ b/app/[locale]/messages/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
-import { getCurrentSession } from "@/lib/auth";
+import { getCurrentSessionIdentity } from "@/lib/auth";
 
 import MessagesContent from "./messages-layout";
 
@@ -25,7 +25,7 @@ async function MessagesPageContent({ params }: MessagesPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const sessionData = await getCurrentSession();
+  const sessionData = await getCurrentSessionIdentity();
 
   if (!sessionData) {
     redirect({ href: "/login", locale });

--- a/app/[locale]/profile/[username]/page.tsx
+++ b/app/[locale]/profile/[username]/page.tsx
@@ -16,7 +16,7 @@ import { Suspense } from "react";
 import { MatchResult, MatchStatus, Role } from "@/../generated/prisma/enums";
 import { Badge, MetricCard, PageShell, Surface } from "@/components/gomoku-ui";
 import { PageLoadingShell } from "@/components/page-loading-shell";
-import { getCurrentSession } from "@/lib/auth";
+import { getCurrentSessionIdentity } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getProfileStatsForUser } from "@/lib/stats/profile-stats";
 
@@ -125,7 +125,7 @@ async function PublicProfilePageContent({ params, searchParams }: ProfilePagePro
     notFound();
   }
 
-  const session = await getCurrentSession();
+  const session = await getCurrentSessionIdentity();
   const loggedInUserId = session?.user?.id;
 
   let relationshipState: "NOT_FRIENDS" | "FRIENDS" | "REQUEST_SENT" | "REQUEST_RECEIVED" | "SELF" =

--- a/app/[locale]/profile/edit/actions.ts
+++ b/app/[locale]/profile/edit/actions.ts
@@ -35,7 +35,7 @@ export async function saveDisplayName(
 ): Promise<ProfileSettingsActionState> {
   const locale = await getLocale();
   const t = await getTranslations({ locale, namespace: "profile.errors" });
-  const sessionData = await getCurrentSession();
+  const sessionData = await getCurrentSession({ disableCookieCache: true });
 
   if (!sessionData) {
     return { fields: {}, message: t("loginRequired"), successMessage: null };
@@ -74,7 +74,7 @@ export async function changeAccountPassword(
 ): Promise<ProfileSettingsActionState> {
   const locale = await getLocale();
   const t = await getTranslations({ locale, namespace: "profile.errors" });
-  const sessionData = await getCurrentSession();
+  const sessionData = await getCurrentSession({ disableCookieCache: true });
 
   if (!sessionData) {
     return { fields: {}, message: t("loginRequired"), successMessage: null };
@@ -125,7 +125,7 @@ export async function setAccountPassword(
 ): Promise<ProfileSettingsActionState> {
   const locale = await getLocale();
   const t = await getTranslations({ locale, namespace: "profile.errors" });
-  const sessionData = await getCurrentSession();
+  const sessionData = await getCurrentSession({ disableCookieCache: true });
 
   if (!sessionData) {
     return { fields: {}, message: t("loginRequired"), successMessage: null };

--- a/app/[locale]/signup/page.tsx
+++ b/app/[locale]/signup/page.tsx
@@ -6,7 +6,7 @@ import { BoardShowpiece, PageShell } from "@/components/gomoku-ui";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { SignupForm } from "@/components/signup-form";
 import { redirect } from "@/i18n/navigation";
-import { getConfiguredOAuthProviders, getCurrentSession } from "@/lib/auth";
+import { getConfiguredOAuthProviders, getCurrentSessionIdentity } from "@/lib/auth";
 
 type SignupPageProps = {
   params: Promise<{
@@ -26,7 +26,7 @@ async function SignupPageContent({ params }: SignupPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const session = await getCurrentSession();
+  const session = await getCurrentSessionIdentity();
 
   if (session) {
     redirect({ href: "/account", locale });

--- a/app/api/auth/auth-routes.test.ts
+++ b/app/api/auth/auth-routes.test.ts
@@ -664,6 +664,9 @@ describe("auth API routes", () => {
       }),
     );
 
+    expect(getCurrentSession).toHaveBeenCalledWith({
+      disableCookieCache: true,
+    });
     expect(updateUser).toHaveBeenCalledWith({
       where: { id: user.id },
       data: { displayName: "Max J" },
@@ -801,6 +804,9 @@ describe("auth API routes", () => {
       }),
     );
 
+    expect(getCurrentSession).toHaveBeenCalledWith({
+      disableCookieCache: true,
+    });
     expect(changePassword).toHaveBeenCalledWith({
       body: {
         currentPassword: "password123",
@@ -906,6 +912,9 @@ describe("auth API routes", () => {
       }),
     );
 
+    expect(getCurrentSession).toHaveBeenCalledWith({
+      disableCookieCache: true,
+    });
     expect(setPassword).toHaveBeenCalledWith({
       body: {
         newPassword: "password999",

--- a/app/api/leaderboard/route.test.ts
+++ b/app/api/leaderboard/route.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const getCurrentSession = mock();
+const getCurrentSessionIdentity = mock();
 const getLeaderboardSnapshot = mock();
 
 await mock.module("@/lib/auth", () => ({
-  getCurrentSession,
+  getCurrentSessionIdentity,
 }));
 
 await mock.module("@/lib/leaderboard", () => ({
@@ -14,10 +14,10 @@ await mock.module("@/lib/leaderboard", () => ({
 const route = await import("./route");
 
 beforeEach(() => {
-  getCurrentSession.mockReset();
+  getCurrentSessionIdentity.mockReset();
   getLeaderboardSnapshot.mockReset();
 
-  getCurrentSession.mockResolvedValue({
+  getCurrentSessionIdentity.mockResolvedValue({
     user: {
       id: "user-ada",
     },
@@ -61,7 +61,7 @@ describe("GET /api/leaderboard", () => {
   });
 
   test("allows anonymous access", async () => {
-    getCurrentSession.mockResolvedValueOnce(null);
+    getCurrentSessionIdentity.mockResolvedValueOnce(null);
 
     const response = await route.GET();
     const payload = await response.json();

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,4 +1,4 @@
-import { getCurrentSession } from "@/lib/auth";
+import { getCurrentSessionIdentity } from "@/lib/auth";
 import { getLeaderboardSnapshot, type LeaderboardScope } from "@/lib/leaderboard";
 
 function resolveScope(searchParams: URLSearchParams): LeaderboardScope {
@@ -11,7 +11,7 @@ function getErrorMessage(error: unknown): string {
 
 export async function GET(request?: Request) {
   try {
-    const context = await getCurrentSession();
+    const context = await getCurrentSessionIdentity();
     const scope = resolveScope(
       new URL(request?.url ?? "http://localhost/api/leaderboard").searchParams,
     );

--- a/app/components/app-sidebar.tsx
+++ b/app/components/app-sidebar.tsx
@@ -7,7 +7,7 @@ import { PlayerProfile, PlayerLogout } from "@/components/player-menu";
 import { SidebarNav, type SidebarNavItem } from "@/components/sidebar-nav";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/navigation";
-import { getCurrentSession } from "@/lib/auth";
+import { getCurrentSessionIdentity } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
 const productLinkMeta = [
@@ -19,7 +19,7 @@ const productLinkMeta = [
 
 export default async function AppSidebar() {
   const [sessionData, brand, nav] = await Promise.all([
-    getCurrentSession(),
+    getCurrentSessionIdentity(),
     getTranslations("brand"),
     getTranslations("nav"),
   ]);

--- a/app/components/nav-bar.tsx
+++ b/app/components/nav-bar.tsx
@@ -6,11 +6,11 @@ import { LocaleSwitcher } from "@/components/locale-switcher";
 import { PlayerProfile } from "@/components/player-menu";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/navigation";
-import { getCurrentSession } from "@/lib/auth";
+import { getCurrentSessionIdentity } from "@/lib/auth";
 
 export default async function Navbar() {
   const [sessionData, brand, nav] = await Promise.all([
-    getCurrentSession(),
+    getCurrentSessionIdentity(),
     getTranslations("brand"),
     getTranslations("nav"),
   ]);

--- a/app/lib/auth-session-access.test.ts
+++ b/app/lib/auth-session-access.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { User } from "../../generated/prisma/client";
+import { createAuthSessionAccessors, toAuthSessionUser } from "./auth-session-access";
+
+type TestSessionData = {
+  session: {
+    id: string;
+    token: string;
+  };
+  user: {
+    avatarUrl?: string | null;
+    displayName?: string | null;
+    email?: string | null;
+    emailVerified?: boolean | null;
+    id: string;
+    image?: string | null;
+    name?: string | null;
+    username?: string | null;
+  };
+};
+
+const requestHeaders = new Headers({ cookie: "better-auth.session_token=session-token" });
+const session = {
+  id: "session-1",
+  token: "session-token",
+};
+const sessionData = {
+  session,
+  user: {
+    avatarUrl: "https://cdn.example.test/ada.png",
+    displayName: "Ada Lovelace",
+    email: "ada@example.test",
+    emailVerified: true,
+    id: "user-ada",
+    username: "ada",
+  },
+} satisfies TestSessionData;
+const databaseUser = {
+  avatarUrl: "https://cdn.example.test/ada-db.png",
+  bio: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  displayName: "Ada Database",
+  email: "ada@example.test",
+  emailVerified: true,
+  id: "user-ada",
+  kind: "HUMAN",
+  lastSeenAt: null,
+  statusMessage: null,
+  updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+  username: "ada_db",
+} as User;
+
+const getHeaders = mock(async () => requestHeaders);
+const getSession = mock(async () => sessionData);
+const findUserById = mock(async () => databaseUser);
+
+function createAccessors() {
+  return createAuthSessionAccessors<TestSessionData>({
+    findUserById,
+    getHeaders,
+    getSession,
+  });
+}
+
+beforeEach(() => {
+  getHeaders.mockReset();
+  getSession.mockReset();
+  findUserById.mockReset();
+
+  getHeaders.mockResolvedValue(requestHeaders);
+  getSession.mockResolvedValue(sessionData);
+  findUserById.mockResolvedValue(databaseUser);
+});
+
+describe("auth session accessors", () => {
+  test("returns session identity without reading the database user", async () => {
+    const accessors = createAccessors();
+
+    const result = await accessors.getCurrentSessionIdentity();
+
+    expect(getSession).toHaveBeenCalledWith({ headers: requestHeaders });
+    expect(findUserById).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      session,
+      user: {
+        avatarUrl: "https://cdn.example.test/ada.png",
+        displayName: "Ada Lovelace",
+        email: "ada@example.test",
+        emailVerified: true,
+        id: "user-ada",
+        username: "ada",
+      },
+    });
+  });
+
+  test("keeps DB-backed session lookup authoritative and forwards cookie-cache bypass", async () => {
+    const accessors = createAccessors();
+
+    const result = await accessors.getCurrentSession({ disableCookieCache: true });
+
+    expect(getSession).toHaveBeenCalledWith({
+      headers: requestHeaders,
+      query: { disableCookieCache: true },
+    });
+    expect(findUserById).toHaveBeenCalledWith("user-ada");
+    expect(result).toEqual({
+      session,
+      user: databaseUser,
+    });
+  });
+
+  test("normalizes Better Auth user field aliases for cached session identity", () => {
+    expect(
+      toAuthSessionUser({
+        email: null,
+        emailVerified: null,
+        id: "user-fallback",
+        image: "https://cdn.example.test/fallback.png",
+        name: "Fallback Name",
+      }),
+    ).toEqual({
+      avatarUrl: "https://cdn.example.test/fallback.png",
+      displayName: "Fallback Name",
+      email: null,
+      emailVerified: false,
+      id: "user-fallback",
+      username: "user-fallback",
+    });
+  });
+});

--- a/app/lib/auth-session-access.ts
+++ b/app/lib/auth-session-access.ts
@@ -1,0 +1,121 @@
+import type { User } from "../../generated/prisma/client";
+
+export type SessionLookupOptions = {
+  disableCookieCache?: boolean;
+};
+
+type BetterAuthSessionUser = {
+  avatarUrl?: string | null;
+  displayName?: string | null;
+  email?: string | null;
+  emailVerified?: boolean | null;
+  id: string;
+  image?: string | null;
+  name?: string | null;
+  username?: string | null;
+};
+
+type BetterAuthSessionData = {
+  session: unknown;
+  user: BetterAuthSessionUser;
+};
+
+type GetSessionParams = {
+  headers: Headers;
+  query?: {
+    disableCookieCache: true;
+  };
+};
+
+type AuthSessionAccessDependencies<SessionData extends BetterAuthSessionData> = {
+  findUserById: (userId: string) => Promise<User | null>;
+  getHeaders: () => Promise<Headers>;
+  getSession: (params: GetSessionParams) => Promise<SessionData | null>;
+};
+
+export type AuthSessionUser = Pick<
+  User,
+  "avatarUrl" | "displayName" | "email" | "emailVerified" | "id" | "username"
+>;
+
+export type AuthSessionIdentity<Session> = {
+  session: Session;
+  user: AuthSessionUser;
+};
+
+export type AuthContext<Session> = {
+  session: Session;
+  user: User;
+};
+
+function getSessionDisplayName(user: BetterAuthSessionUser): string {
+  return user.displayName ?? user.name ?? user.username ?? "Gomoku Player";
+}
+
+function getSessionUsername(user: BetterAuthSessionUser): string {
+  return user.username ?? user.id;
+}
+
+export function toAuthSessionUser(user: BetterAuthSessionUser): AuthSessionUser {
+  return {
+    avatarUrl: user.avatarUrl ?? user.image ?? null,
+    displayName: getSessionDisplayName(user),
+    email: user.email ?? null,
+    emailVerified: Boolean(user.emailVerified),
+    id: user.id,
+    username: getSessionUsername(user),
+  };
+}
+
+export function createAuthSessionAccessors<SessionData extends BetterAuthSessionData>({
+  findUserById,
+  getHeaders,
+  getSession,
+}: AuthSessionAccessDependencies<SessionData>) {
+  async function getBetterAuthSession(options: SessionLookupOptions = {}) {
+    const query = options.disableCookieCache ? { disableCookieCache: true as const } : undefined;
+
+    return getSession({
+      headers: await getHeaders(),
+      ...(query ? { query } : {}),
+    });
+  }
+
+  async function getCurrentSessionIdentity(
+    options: SessionLookupOptions = {},
+  ): Promise<AuthSessionIdentity<SessionData["session"]> | null> {
+    const sessionData = await getBetterAuthSession(options);
+
+    if (!sessionData) {
+      return null;
+    }
+
+    return {
+      session: sessionData.session,
+      user: toAuthSessionUser(sessionData.user),
+    };
+  }
+
+  async function getCurrentSession(
+    options: SessionLookupOptions = {},
+  ): Promise<AuthContext<SessionData["session"]> | null> {
+    const sessionData = await getBetterAuthSession(options);
+
+    if (!sessionData) {
+      return null;
+    }
+
+    const user = await findUserById(sessionData.user.id);
+
+    if (!user) {
+      return null;
+    }
+
+    return { session: sessionData.session, user };
+  }
+
+  return {
+    getCurrentSession,
+    getCurrentSessionIdentity,
+  };
+}

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -15,6 +15,13 @@ import {
   getTrustedAuthOrigins,
 } from "./auth-origins";
 import { authCredentialPolicy } from "./auth-policy";
+import {
+  createAuthSessionAccessors,
+  type AuthContext as BaseAuthContext,
+  type AuthSessionIdentity as BaseAuthSessionIdentity,
+  type AuthSessionUser,
+  type SessionLookupOptions,
+} from "./auth-session-access";
 import { oauthProviderIds, type OAuthProviderId } from "./oauth-providers";
 import { prisma } from "./prisma";
 import { authValidationLimits } from "./validation/auth-profile-limits";
@@ -302,102 +309,27 @@ export const auth = betterAuth({
 });
 
 type BetterAuthSessionData = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>;
-type BetterAuthSessionUser = BetterAuthSessionData["user"] & {
-  avatarUrl?: string | null;
-  displayName?: string | null;
-  image?: string | null;
-  name?: string | null;
-  username?: string | null;
-};
-
-type SessionLookupOptions = {
-  disableCookieCache?: boolean;
-};
 
 type UserEmailVerification = {
   emailVerified?: boolean | null;
   emailVerifiedAt?: Date | null;
 };
 
-export type AuthSessionUser = Pick<
-  User,
-  "avatarUrl" | "displayName" | "email" | "emailVerified" | "id" | "username"
->;
+export type { AuthSessionUser, SessionLookupOptions };
+export type AuthSessionIdentity = BaseAuthSessionIdentity<BetterAuthSessionData["session"]>;
+export type AuthContext = BaseAuthContext<BetterAuthSessionData["session"]>;
 
-export type AuthSessionIdentity = {
-  session: BetterAuthSessionData["session"];
-  user: AuthSessionUser;
-};
+const sessionAccessors = createAuthSessionAccessors<BetterAuthSessionData>({
+  findUserById: (userId) =>
+    prisma.user.findUnique({
+      where: { id: userId },
+    }),
+  getHeaders: headers,
+  getSession: (params) => auth.api.getSession(params),
+});
 
-export type AuthContext = {
-  session: BetterAuthSessionData["session"];
-  user: User;
-};
-
-async function getBetterAuthSession(options: SessionLookupOptions = {}) {
-  const query = options.disableCookieCache ? { disableCookieCache: true } : undefined;
-
-  return auth.api.getSession({
-    headers: await headers(),
-    ...(query ? { query } : {}),
-  });
-}
-
-function getSessionDisplayName(user: BetterAuthSessionUser): string {
-  return user.displayName ?? user.name ?? user.username ?? "Gomoku Player";
-}
-
-function getSessionUsername(user: BetterAuthSessionUser): string {
-  return user.username ?? user.id;
-}
-
-function toAuthSessionUser(user: BetterAuthSessionData["user"]): AuthSessionUser {
-  const sessionUser = user as BetterAuthSessionUser;
-
-  return {
-    avatarUrl: sessionUser.avatarUrl ?? sessionUser.image ?? null,
-    displayName: getSessionDisplayName(sessionUser),
-    email: sessionUser.email ?? null,
-    emailVerified: Boolean(sessionUser.emailVerified),
-    id: sessionUser.id,
-    username: getSessionUsername(sessionUser),
-  };
-}
-
-export async function getCurrentSessionIdentity(
-  options: SessionLookupOptions = {},
-): Promise<AuthSessionIdentity | null> {
-  const sessionData = await getBetterAuthSession(options);
-
-  if (!sessionData) {
-    return null;
-  }
-
-  return {
-    session: sessionData.session,
-    user: toAuthSessionUser(sessionData.user),
-  };
-}
-
-export async function getCurrentSession(
-  options: SessionLookupOptions = {},
-): Promise<AuthContext | null> {
-  const sessionData = await getBetterAuthSession(options);
-
-  if (!sessionData) {
-    return null;
-  }
-
-  const user = await prisma.user.findUnique({
-    where: { id: sessionData.user.id },
-  });
-
-  if (!user) {
-    return null;
-  }
-
-  return { session: sessionData.session, user };
-}
+export const getCurrentSessionIdentity = sessionAccessors.getCurrentSessionIdentity;
+export const getCurrentSession = sessionAccessors.getCurrentSession;
 
 export async function hasCredentialPassword(userId: string): Promise<boolean> {
   const account = await prisma.account.findFirst({

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -21,6 +21,7 @@ import { authValidationLimits } from "./validation/auth-profile-limits";
 
 const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
 const SESSION_REFRESH_SECONDS = 24 * 60 * 60;
+const SESSION_COOKIE_CACHE_SECONDS = 60;
 const usernamePattern = /^[A-Za-z0-9_-]+$/;
 const OAUTH_USERNAME_SUFFIX_LENGTH = 6;
 
@@ -234,6 +235,11 @@ export const auth = betterAuth({
     fields: {
       token: "sessionToken",
     },
+    cookieCache: {
+      enabled: true,
+      maxAge: SESSION_COOKIE_CACHE_SECONDS,
+      strategy: "compact",
+    },
     expiresIn: SESSION_TTL_SECONDS,
     updateAge: SESSION_REFRESH_SECONDS,
     freshAge: 0,
@@ -296,10 +302,31 @@ export const auth = betterAuth({
 });
 
 type BetterAuthSessionData = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>;
+type BetterAuthSessionUser = BetterAuthSessionData["user"] & {
+  avatarUrl?: string | null;
+  displayName?: string | null;
+  image?: string | null;
+  name?: string | null;
+  username?: string | null;
+};
+
+type SessionLookupOptions = {
+  disableCookieCache?: boolean;
+};
 
 type UserEmailVerification = {
   emailVerified?: boolean | null;
   emailVerifiedAt?: Date | null;
+};
+
+export type AuthSessionUser = Pick<
+  User,
+  "avatarUrl" | "displayName" | "email" | "emailVerified" | "id" | "username"
+>;
+
+export type AuthSessionIdentity = {
+  session: BetterAuthSessionData["session"];
+  user: AuthSessionUser;
 };
 
 export type AuthContext = {
@@ -307,10 +334,55 @@ export type AuthContext = {
   user: User;
 };
 
-export async function getCurrentSession(): Promise<AuthContext | null> {
-  const sessionData = await auth.api.getSession({
+async function getBetterAuthSession(options: SessionLookupOptions = {}) {
+  const query = options.disableCookieCache ? { disableCookieCache: true } : undefined;
+
+  return auth.api.getSession({
     headers: await headers(),
+    ...(query ? { query } : {}),
   });
+}
+
+function getSessionDisplayName(user: BetterAuthSessionUser): string {
+  return user.displayName ?? user.name ?? user.username ?? "Gomoku Player";
+}
+
+function getSessionUsername(user: BetterAuthSessionUser): string {
+  return user.username ?? user.id;
+}
+
+function toAuthSessionUser(user: BetterAuthSessionData["user"]): AuthSessionUser {
+  const sessionUser = user as BetterAuthSessionUser;
+
+  return {
+    avatarUrl: sessionUser.avatarUrl ?? sessionUser.image ?? null,
+    displayName: getSessionDisplayName(sessionUser),
+    email: sessionUser.email ?? null,
+    emailVerified: Boolean(sessionUser.emailVerified),
+    id: sessionUser.id,
+    username: getSessionUsername(sessionUser),
+  };
+}
+
+export async function getCurrentSessionIdentity(
+  options: SessionLookupOptions = {},
+): Promise<AuthSessionIdentity | null> {
+  const sessionData = await getBetterAuthSession(options);
+
+  if (!sessionData) {
+    return null;
+  }
+
+  return {
+    session: sessionData.session,
+    user: toAuthSessionUser(sessionData.user),
+  };
+}
+
+export async function getCurrentSession(
+  options: SessionLookupOptions = {},
+): Promise<AuthContext | null> {
+  const sessionData = await getBetterAuthSession(options);
 
   if (!sessionData) {
     return null;

--- a/app/test-utils/auth-module-mock.ts
+++ b/app/test-utils/auth-module-mock.ts
@@ -16,7 +16,8 @@ type AuthModuleMock = {
     api: Record<string, unknown>;
   };
   getConfiguredOAuthProviders: () => string[];
-  getCurrentSession: () => Promise<unknown>;
+  getCurrentSession: (...args: unknown[]) => Promise<unknown>;
+  getCurrentSessionIdentity: (...args: unknown[]) => Promise<unknown>;
   getDuplicateSignupFields: (email: string, username: string) => Promise<DuplicateSignupFields>;
   hasCredentialPassword: (userId: string) => Promise<boolean>;
   serializeUserForResponse: (user: UserForResponse) => {
@@ -35,6 +36,7 @@ export function createAuthModuleMock(overrides: Partial<AuthModuleMock> = {}): A
     },
     getConfiguredOAuthProviders: () => [],
     getCurrentSession: async () => null,
+    getCurrentSessionIdentity: async () => null,
     getDuplicateSignupFields: async () => ({}),
     hasCredentialPassword: async () => false,
     serializeUserForResponse: (user) => ({


### PR DESCRIPTION
## Summary

- Enable Better Auth's compact session cookie cache with a short 60-second lifetime.
- Add a lightweight `getCurrentSessionIdentity()` helper for read-only/session-display paths so those paths can benefit from cookie-cache reads without an extra user-table lookup.
- Keep authoritative `getCurrentSession()` reads for mutation-heavy paths, and force cache bypass for profile/security actions.

## Validation

- `bun test`
- `bun run typecheck`
- `bun run lint:js`

## Notes

This keeps Better Auth's documented delayed-revocation tradeoff bounded to 60 seconds while avoiding extra user-table reads for low-risk UI/session identity checks.