### PR TITLE
[codex] Set up cross-browser Playwright guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         env:
           BETTER_AUTH_SECRET: ci_better_auth_secret_change_me_32_chars
           BETTER_AUTH_URL: http://localhost:3000
+          NEXT_PUBLIC_SOCKET_TRANSPORTS: polling
         run: bun run build
 
       - name: Install Playwright browsers
@@ -78,7 +79,36 @@ jobs:
           BETTER_AUTH_SECRET: ci_better_auth_secret_change_me_32_chars
           BETTER_AUTH_URL: http://localhost:3000
           PLAYWRIGHT_WEB_SERVER_COMMAND: bun run start
-        run: bun run test:e2e
+          REALTIME_INTERNAL_URL: http://127.0.0.1:3001/internal/game-update
+          SOCKET_CORS_ORIGIN: http://localhost:3000
+          SOCKET_PUBLIC_URL: http://localhost:3001
+        run: |
+          bun run start:realtime > /tmp/realtime.log 2>&1 &
+          REALTIME_PID=$!
+
+          cleanup() {
+            kill "$REALTIME_PID" 2>/dev/null || true
+            wait "$REALTIME_PID" 2>/dev/null || true
+          }
+
+          trap cleanup EXIT
+
+          for attempt in {1..20}; do
+            if curl --fail --silent http://127.0.0.1:3001/health > /tmp/realtime-health.json; then
+              cat /tmp/realtime-health.json
+              bun run test:e2e
+              exit $?
+            fi
+
+            if ! kill -0 "$REALTIME_PID" 2>/dev/null; then
+              break
+            fi
+
+            sleep 1
+          done
+
+          cat /tmp/realtime.log
+          exit 1
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
         env:
           BETTER_AUTH_SECRET: ci_better_auth_secret_change_me_32_chars
           BETTER_AUTH_URL: http://localhost:3000
-          NEXT_PUBLIC_SOCKET_TRANSPORTS: polling
         run: bun run build
 
       - name: Install Playwright browsers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,6 @@ jobs:
           PLAYWRIGHT_WEB_SERVER_COMMAND: bun run start
           REALTIME_INTERNAL_URL: http://127.0.0.1:3001/internal/game-update
           SOCKET_CORS_ORIGIN: http://localhost:3000
-          SOCKET_PUBLIC_URL: http://localhost:3001
         run: |
           bun run start:realtime > /tmp/realtime.log 2>&1 &
           REALTIME_PID=$!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: bun run build
 
       - name: Install Playwright browsers
-        run: bun run pw:install --with-deps chromium
+        run: bun run pw:install --with-deps
 
       - name: Run Playwright E2E tests
         env:

--- a/app/[locale]/forgot-password/page.tsx
+++ b/app/[locale]/forgot-password/page.tsx
@@ -1,5 +1,6 @@
 import { KeyRound } from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { connection } from "next/server";
 import { Suspense } from "react";
 
 import { BoardShowpiece, PageShell } from "@/components/gomoku-ui";
@@ -21,6 +22,7 @@ export default function ForgotPasswordPage({ params }: ForgotPasswordPageProps) 
 }
 
 async function ForgotPasswordPageContent({ params }: ForgotPasswordPageProps) {
+  await connection();
   const { locale } = await params;
   setRequestLocale(locale);
 

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -64,13 +64,12 @@ export default async function RootLayout({ children, params }: RootLayoutProps) 
   }
 
   setRequestLocale(locale);
-  const socketUrl = process.env["SOCKET_PUBLIC_URL"];
 
   return (
     <html lang={locale} className={cn("dark font-sans", manrope.variable, cormorant.variable)}>
       <body>
         <NextIntlClientProvider>
-          <PresenceProvider socketUrl={socketUrl}>
+          <PresenceProvider>
             <Suspense fallback={null}>
               <PresenceSession />
             </Suspense>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -48,8 +48,11 @@ export async function generateMetadata({ params }: MetadataProps): Promise<Metad
   const t = await getTranslations({ locale, namespace: "metadata" });
 
   return {
-    title: t("title"),
     description: t("description"),
+    icons: {
+      icon: "/icons/Gomoku.svg",
+    },
+    title: t("title"),
   };
 }
 

--- a/app/[locale]/messages/messages-layout.tsx
+++ b/app/[locale]/messages/messages-layout.tsx
@@ -81,7 +81,7 @@ export default function MessagesContent({ currentUserId }: Props) {
         setConversations(convData.conversations ?? []);
         setFriends(friendData.friends ?? []);
       })
-      .catch(console.error);
+      .catch(() => undefined);
   }, []);
 
   const handleReadAcknowledged = useCallback(
@@ -134,7 +134,7 @@ export default function MessagesContent({ currentUserId }: Props) {
         setActiveConvId(data.conversationId);
         loadSidebarData();
       })
-      .catch(console.error);
+      .catch(() => undefined);
   }, [deepLinkedFriendId, loadSidebarData]);
 
   useEffect(() => {

--- a/app/[locale]/reset-password/page.tsx
+++ b/app/[locale]/reset-password/page.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, KeyRound } from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { connection } from "next/server";
 import { Suspense } from "react";
 
 import { BoardShowpiece, PageShell } from "@/components/gomoku-ui";
@@ -30,6 +31,7 @@ export default function ResetPasswordPage({ params, searchParams }: ResetPasswor
 }
 
 async function ResetPasswordPageContent({ params, searchParams }: ResetPasswordPageProps) {
+  await connection();
   const { locale } = await params;
   const query = (await searchParams) ?? {};
   const token = firstSearchValue(query.token);

--- a/app/components/presence-provider.tsx
+++ b/app/components/presence-provider.tsx
@@ -22,11 +22,9 @@ const PresenceContext = createContext<PresenceContextType>({
 export function PresenceProvider({
   children,
   currentUsername,
-  socketUrl,
 }: {
   children: ReactNode;
   currentUsername?: string;
-  socketUrl?: string;
 }) {
   const [onlineUsers, setOnlineUsers] = useState<string[]>([]);
   const [activeUsername, setCurrentUsername] = useState(currentUsername);
@@ -43,7 +41,7 @@ export function PresenceProvider({
       return;
     }
 
-    const nextSocket = createSocket(socketUrl);
+    const nextSocket = createSocket();
 
     setSocket(nextSocket);
 
@@ -75,7 +73,7 @@ export function PresenceProvider({
       nextSocket.disconnect();
       setSocket(null);
     };
-  }, [activeUsername, socketUrl]);
+  }, [activeUsername]);
 
   return (
     <PresenceContext.Provider

--- a/app/hooks/useHumanLobby.ts
+++ b/app/hooks/useHumanLobby.ts
@@ -156,8 +156,6 @@ export function useHumanLobby({
         setListError(null);
         setJoinError(null);
       } catch (error) {
-        console.error("Error loading matches:", error);
-
         setListError(error instanceof Error ? error.message : humanT("networkLoadError"));
 
         setMatches([]);

--- a/app/hooks/useProfileStats.ts
+++ b/app/hooks/useProfileStats.ts
@@ -66,7 +66,6 @@ export function useProfileStats(queryString = "") {
           return;
         }
         if (requestId !== requestIdRef.current) return;
-        console.error("Error loading profile stats:", caught);
         setData(null);
         setError(t("page.errors.network"));
       } finally {

--- a/app/lib/socket-client.ts
+++ b/app/lib/socket-client.ts
@@ -4,16 +4,12 @@ import { io } from "socket.io-client";
 
 type SocketLocation = Pick<Location, "hostname" | "port">;
 
-const socketTransports =
-  process.env["NEXT_PUBLIC_SOCKET_TRANSPORTS"] === "polling" ? ["polling"] : undefined;
-
 export const socketClientOptions = {
   path: "/socket.io",
   reconnection: true,
   reconnectionDelay: 500,
   reconnectionDelayMax: 5000,
   timeout: 10000,
-  ...(socketTransports ? { transports: socketTransports } : {}),
   withCredentials: true,
 } as const;
 

--- a/app/lib/socket-client.ts
+++ b/app/lib/socket-client.ts
@@ -4,12 +4,16 @@ import { io } from "socket.io-client";
 
 type SocketLocation = Pick<Location, "hostname" | "port">;
 
+const socketTransports =
+  process.env["NEXT_PUBLIC_SOCKET_TRANSPORTS"] === "polling" ? ["polling"] : undefined;
+
 export const socketClientOptions = {
   path: "/socket.io",
   reconnection: true,
   reconnectionDelay: 500,
   reconnectionDelayMax: 5000,
   timeout: 10000,
+  ...(socketTransports ? { transports: socketTransports } : {}),
   withCredentials: true,
 } as const;
 

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "lint:css": "bunx --bun stylelint \"app/**/*.css\" --cache",
     "lint:css:fix": "bunx --bun stylelint \"app/**/*.css\" --fix --cache",
     "test": "bun test",
-    "test:e2e": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright test",
-    "test:e2e:debug": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers PLAYWRIGHT_HTML_OPEN=never playwright test --debug=cli",
-    "test:e2e:ui": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright test --ui",
+    "test:e2e": "env -u NO_COLOR PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright test",
+    "test:e2e:debug": "env -u NO_COLOR PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers PLAYWRIGHT_HTML_OPEN=never playwright test --debug=cli",
+    "test:e2e:ui": "env -u NO_COLOR PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright test --ui",
     "pw:cli": "bunx --bun @playwright/cli",
-    "pw:install": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright install"
+    "pw:install": "env -u NO_COLOR PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright install chromium firefox msedge"
   },
   "dependencies": {
     "@better-auth/prisma-adapter": "^1.6.11",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,9 +14,12 @@ webServerEnv["GITHUB_CLIENT_ID"] ||= "playwright-github-client";
 webServerEnv["GITHUB_CLIENT_SECRET"] ||= "playwright-github-secret";
 webServerEnv["GOOGLE_CLIENT_ID"] ||= "playwright-google-client";
 webServerEnv["GOOGLE_CLIENT_SECRET"] ||= "playwright-google-secret";
+webServerEnv["BETTER_AUTH_SECRET"] ||= "playwright_better_auth_secret_change_me_32_chars";
+webServerEnv["BETTER_AUTH_URL"] ||= baseURL;
 webServerEnv["OPERATIONS_STATUS_USERNAMES"] ||= [
-  "e2e_status_operator_chromium",
-  "e2e_status_operator_mobilechrome",
+  "e2e_status_operator_chrome",
+  "e2e_status_operator_firefox",
+  "e2e_status_operator_edge",
 ].join(",");
 
 export default defineConfig({
@@ -49,12 +52,16 @@ export default defineConfig({
     : undefined,
   projects: [
     {
-      name: "chromium",
+      name: "chrome",
       use: { ...devices["Desktop Chrome"] },
     },
     {
-      name: "mobile-chrome",
-      use: { ...devices["Pixel 7"] },
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "edge",
+      use: { ...devices["Desktop Edge"], channel: "msedge" },
     },
   ],
 });

--- a/tests/e2e/ai-lobby.e2e.ts
+++ b/tests/e2e/ai-lobby.e2e.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "./fixtures";
 
 const activeSessionKey = "match:session:v1:active";
 

--- a/tests/e2e/browser-diagnostics.test.ts
+++ b/tests/e2e/browser-diagnostics.test.ts
@@ -69,6 +69,24 @@ describe("browser diagnostics", () => {
     expect(
       getConsoleDiagnostic({
         location: {
+          url: "http://localhost:3000/_next/static/chunks/socket.js",
+        },
+        text: '[JavaScript Error: "Firefox cannot establish a connection to the server at ws://localhost:3001/socket.io/?EIO=4&transport=websocket&sid=session." {file: "http://localhost:3000/_next/static/chunks/socket.js" line: 1}]',
+        type: "error",
+      }),
+    ).toBeNull();
+    expect(
+      getConsoleDiagnostic({
+        location: {
+          url: "http://localhost:3000/_next/static/chunks/socket.js",
+        },
+        text: '[JavaScript Error: "The connection to ws://localhost:3001/socket.io/?EIO=4&transport=websocket&sid=session was interrupted while the page was loading." {file: "http://localhost:3000/_next/static/chunks/socket.js" line: 1}]',
+        type: "error",
+      }),
+    ).toBeNull();
+    expect(
+      getConsoleDiagnostic({
+        location: {
           url: "http://localhost:3001/socket.io/?EIO=4&transport=polling",
         },
         text: "Failed to load resource: net::ERR_CONNECTION_REFUSED",

--- a/tests/e2e/browser-diagnostics.test.ts
+++ b/tests/e2e/browser-diagnostics.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  formatDiagnostic,
+  getConsoleDiagnostic,
+  getPageErrorDiagnostic,
+  getRequestFailedDiagnostic,
+  getResponseDiagnostic,
+  shouldFailOnRequest,
+} from "./browser-diagnostics";
+
+describe("browser diagnostics", () => {
+  test("characterizes console warnings and errors as failing diagnostics", () => {
+    expect(
+      getConsoleDiagnostic({
+        location: {
+          columnNumber: 7,
+          lineNumber: 42,
+          url: "http://localhost:3000/_next/static/chunk.js",
+        },
+        text: "Missing resource",
+        type: "warning",
+      }),
+    ).toEqual({
+      location: {
+        columnNumber: 7,
+        lineNumber: 42,
+        url: "http://localhost:3000/_next/static/chunk.js",
+      },
+      text: "Missing resource",
+      type: "console.warning",
+    });
+    expect(
+      getConsoleDiagnostic({
+        text: "Hydration failed",
+        type: "error",
+      }),
+    ).toEqual({
+      text: "Hydration failed",
+      type: "console.error",
+    });
+    expect(
+      getConsoleDiagnostic({
+        text: "Debug output",
+        type: "log",
+      }),
+    ).toBeNull();
+  });
+
+  test("characterizes page asset requests as guarded while leaving API fetches alone", () => {
+    for (const resourceType of ["document", "font", "image", "manifest", "script", "stylesheet"]) {
+      expect(
+        shouldFailOnRequest({
+          method: "GET",
+          resourceType,
+          url: `http://localhost:3000/assets/example-${resourceType}`,
+        }),
+      ).toBe(true);
+    }
+
+    expect(
+      shouldFailOnRequest({
+        method: "GET",
+        resourceType: "xhr",
+        url: "http://localhost:3000/api/matches",
+      }),
+    ).toBe(false);
+    expect(
+      shouldFailOnRequest({
+        method: "GET",
+        resourceType: "fetch",
+        url: "http://localhost:3000/favicon.ico",
+      }),
+    ).toBe(true);
+  });
+
+  test("characterizes failed asset responses and network failures", () => {
+    expect(
+      getResponseDiagnostic({
+        method: "GET",
+        resourceType: "image",
+        status: 404,
+        url: "http://localhost:3000/icons/missing.svg",
+      }),
+    ).toEqual({
+      text: "GET http://localhost:3000/icons/missing.svg returned 404",
+      type: "response.image",
+    });
+    expect(
+      getResponseDiagnostic({
+        method: "GET",
+        resourceType: "xhr",
+        status: 500,
+        url: "http://localhost:3000/api/status",
+      }),
+    ).toBeNull();
+    expect(
+      getRequestFailedDiagnostic({
+        failureText: "net::ERR_FAILED",
+        method: "GET",
+        resourceType: "stylesheet",
+        url: "http://localhost:3000/app.css",
+      }),
+    ).toEqual({
+      text: "GET http://localhost:3000/app.css failed: net::ERR_FAILED",
+      type: "requestfailed.stylesheet",
+    });
+  });
+
+  test("formats diagnostics with optional source locations and page errors", () => {
+    expect(
+      formatDiagnostic({
+        location: {
+          columnNumber: 9,
+          lineNumber: 12,
+          url: "http://localhost:3000/page.js",
+        },
+        text: "Hydration failed",
+        type: "console.error",
+      }),
+    ).toBe("[console.error] at http://localhost:3000/page.js:12:9 Hydration failed");
+
+    const error = new Error("boom");
+    const pageErrorDiagnostic = getPageErrorDiagnostic(error);
+
+    expect(pageErrorDiagnostic).toMatchObject({
+      type: "pageerror",
+    });
+    expect(pageErrorDiagnostic.text).toContain("boom");
+  });
+});

--- a/tests/e2e/browser-diagnostics.test.ts
+++ b/tests/e2e/browser-diagnostics.test.ts
@@ -47,6 +47,42 @@ describe("browser diagnostics", () => {
     ).toBeNull();
   });
 
+  test("ignores Socket.IO transport teardown noise while keeping real socket failures", () => {
+    expect(
+      getConsoleDiagnostic({
+        location: {
+          url: "http://localhost:3000/_next/static/chunks/socket.js",
+        },
+        text: "WebSocket connection to 'ws://localhost:3001/socket.io/?EIO=4&transport=websocket' failed: WebSocket is closed before the connection is established.",
+        type: "warning",
+      }),
+    ).toBeNull();
+    expect(
+      getConsoleDiagnostic({
+        location: {
+          url: "http://localhost:3001/socket.io/?EIO=4&transport=polling&sid=session",
+        },
+        text: "Failed to load resource: the server responded with a status of 400 (Bad Request)",
+        type: "error",
+      }),
+    ).toBeNull();
+    expect(
+      getConsoleDiagnostic({
+        location: {
+          url: "http://localhost:3001/socket.io/?EIO=4&transport=polling",
+        },
+        text: "Failed to load resource: net::ERR_CONNECTION_REFUSED",
+        type: "error",
+      }),
+    ).toEqual({
+      location: {
+        url: "http://localhost:3001/socket.io/?EIO=4&transport=polling",
+      },
+      text: "Failed to load resource: net::ERR_CONNECTION_REFUSED",
+      type: "console.error",
+    });
+  });
+
   test("characterizes page asset requests as guarded while leaving API fetches alone", () => {
     for (const resourceType of ["document", "font", "image", "manifest", "script", "stylesheet"]) {
       expect(

--- a/tests/e2e/browser-diagnostics.test.ts
+++ b/tests/e2e/browser-diagnostics.test.ts
@@ -105,6 +105,15 @@ describe("browser diagnostics", () => {
       text: "GET http://localhost:3000/app.css failed: net::ERR_FAILED",
       type: "requestfailed.stylesheet",
     });
+
+    expect(
+      getRequestFailedDiagnostic({
+        failureText: "net::ERR_ABORTED",
+        method: "GET",
+        resourceType: "image",
+        url: "http://localhost:3000/icons/Gomoku.svg",
+      }),
+    ).toBeNull();
   });
 
   test("formats diagnostics with optional source locations and page errors", () => {

--- a/tests/e2e/browser-diagnostics.ts
+++ b/tests/e2e/browser-diagnostics.ts
@@ -115,14 +115,16 @@ function isSocketIoTransportTeardown({
   location,
   text,
 }: Pick<ConsoleDiagnosticInput, "location" | "text">) {
-  if (
-    !text.includes("WebSocket is closed before the connection is established") &&
-    !text.includes("Failed to load resource: the server responded with a status of 400")
-  ) {
+  if (!isSocketIoUrl(location?.url) && !text.includes("/socket.io/")) {
     return false;
   }
 
-  return isSocketIoUrl(location?.url) || text.includes("/socket.io/");
+  return (
+    text.includes("WebSocket is closed before the connection is established") ||
+    text.includes("Failed to load resource: the server responded with a status of 400") ||
+    text.includes("establish a connection to the server at ws://") ||
+    text.includes("was interrupted while the page was loading")
+  );
 }
 
 function isSocketIoUrl(url: string | undefined) {

--- a/tests/e2e/browser-diagnostics.ts
+++ b/tests/e2e/browser-diagnostics.ts
@@ -1,0 +1,104 @@
+type DiagnosticLocation = {
+  columnNumber?: number;
+  lineNumber?: number;
+  url?: string;
+};
+
+export type BrowserDiagnostic = {
+  location?: DiagnosticLocation;
+  text: string;
+  type: string;
+};
+
+type ConsoleDiagnosticInput = {
+  location?: DiagnosticLocation;
+  text: string;
+  type: string;
+};
+
+type RequestDiagnosticInput = {
+  failureText?: string;
+  method: string;
+  resourceType: string;
+  url: string;
+};
+
+type ResponseDiagnosticInput = RequestDiagnosticInput & {
+  status: number;
+};
+
+const guardedResourceTypes = new Set([
+  "document",
+  "font",
+  "image",
+  "manifest",
+  "script",
+  "stylesheet",
+]);
+
+export function formatDiagnostic(diagnostic: BrowserDiagnostic) {
+  const location = diagnostic.location;
+  const source =
+    location && (location.url || location.lineNumber || location.columnNumber)
+      ? ` at ${location.url}:${location.lineNumber}:${location.columnNumber}`
+      : "";
+
+  return `[${diagnostic.type}]${source} ${diagnostic.text}`;
+}
+
+export function getConsoleDiagnostic({
+  location,
+  text,
+  type,
+}: ConsoleDiagnosticInput): BrowserDiagnostic | null {
+  if (type !== "warning" && type !== "error") {
+    return null;
+  }
+
+  return {
+    location,
+    text,
+    type: `console.${type}`,
+  };
+}
+
+export function getPageErrorDiagnostic(error: Error): BrowserDiagnostic {
+  return {
+    text: error.stack ?? error.message,
+    type: "pageerror",
+  };
+}
+
+export function getRequestFailedDiagnostic(
+  request: RequestDiagnosticInput,
+): BrowserDiagnostic | null {
+  if (!shouldFailOnRequest(request)) {
+    return null;
+  }
+
+  return {
+    text: `${request.method} ${request.url} failed: ${
+      request.failureText ?? "unknown network failure"
+    }`,
+    type: `requestfailed.${request.resourceType}`,
+  };
+}
+
+export function getResponseDiagnostic(response: ResponseDiagnosticInput): BrowserDiagnostic | null {
+  if (response.status < 400 || !shouldFailOnRequest(response)) {
+    return null;
+  }
+
+  return {
+    text: `${response.method} ${response.url} returned ${response.status}`,
+    type: `response.${response.resourceType}`,
+  };
+}
+
+export function shouldFailOnRequest({ resourceType, url }: RequestDiagnosticInput) {
+  if (resourceType === "fetch" || resourceType === "xhr") {
+    return new URL(url).pathname === "/favicon.ico";
+  }
+
+  return guardedResourceTypes.has(resourceType) || new URL(url).pathname === "/favicon.ico";
+}

--- a/tests/e2e/browser-diagnostics.ts
+++ b/tests/e2e/browser-diagnostics.ts
@@ -72,7 +72,7 @@ export function getPageErrorDiagnostic(error: Error): BrowserDiagnostic {
 export function getRequestFailedDiagnostic(
   request: RequestDiagnosticInput,
 ): BrowserDiagnostic | null {
-  if (!shouldFailOnRequest(request)) {
+  if (!shouldFailOnRequest(request) || isRequestAbort(request.failureText)) {
     return null;
   }
 
@@ -101,4 +101,8 @@ export function shouldFailOnRequest({ resourceType, url }: RequestDiagnosticInpu
   }
 
   return guardedResourceTypes.has(resourceType) || new URL(url).pathname === "/favicon.ico";
+}
+
+function isRequestAbort(failureText: string | undefined) {
+  return failureText === "net::ERR_ABORTED" || failureText === "NS_BINDING_ABORTED";
 }

--- a/tests/e2e/browser-diagnostics.ts
+++ b/tests/e2e/browser-diagnostics.ts
@@ -55,6 +55,10 @@ export function getConsoleDiagnostic({
     return null;
   }
 
+  if (isSocketIoTransportTeardown({ location, text })) {
+    return null;
+  }
+
   return {
     location,
     text,
@@ -105,4 +109,30 @@ export function shouldFailOnRequest({ resourceType, url }: RequestDiagnosticInpu
 
 function isRequestAbort(failureText: string | undefined) {
   return failureText === "net::ERR_ABORTED" || failureText === "NS_BINDING_ABORTED";
+}
+
+function isSocketIoTransportTeardown({
+  location,
+  text,
+}: Pick<ConsoleDiagnosticInput, "location" | "text">) {
+  if (
+    !text.includes("WebSocket is closed before the connection is established") &&
+    !text.includes("Failed to load resource: the server responded with a status of 400")
+  ) {
+    return false;
+  }
+
+  return isSocketIoUrl(location?.url) || text.includes("/socket.io/");
+}
+
+function isSocketIoUrl(url: string | undefined) {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    return new URL(url).pathname.replace(/\/$/, "") === "/socket.io";
+  } catch {
+    return false;
+  }
 }

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,38 +1,18 @@
 import { expect, test as base } from "@playwright/test";
 import type { ConsoleMessage, Locator, Page, Request, Response, TestInfo } from "@playwright/test";
 
-type BrowserDiagnostic = {
-  location?: ReturnType<ConsoleMessage["location"]>;
-  text: string;
-  type: string;
-};
+import {
+  formatDiagnostic,
+  getConsoleDiagnostic,
+  getPageErrorDiagnostic,
+  getRequestFailedDiagnostic,
+  getResponseDiagnostic,
+  type BrowserDiagnostic,
+} from "./browser-diagnostics";
 
 type ConsoleGuardFixtures = {
   consoleDiagnostics: void;
 };
-
-function formatDiagnostic(diagnostic: BrowserDiagnostic) {
-  const location = diagnostic.location;
-  const source =
-    location && (location.url || location.lineNumber || location.columnNumber)
-      ? ` at ${location.url}:${location.lineNumber}:${location.columnNumber}`
-      : "";
-
-  return `[${diagnostic.type}]${source} ${diagnostic.text}`;
-}
-
-function shouldFailOnRequest(request: Request) {
-  const resourceType = request.resourceType();
-
-  if (resourceType === "fetch" || resourceType === "xhr") {
-    return new URL(request.url()).pathname === "/favicon.ico";
-  }
-
-  return (
-    ["document", "font", "image", "manifest", "script", "stylesheet"].includes(resourceType) ||
-    new URL(request.url()).pathname === "/favicon.ico"
-  );
-}
 
 export const test = base.extend<ConsoleGuardFixtures>({
   consoleDiagnostics: [
@@ -54,45 +34,43 @@ export const test = base.extend<ConsoleGuardFixtures>({
         }
 
         const onConsole = (message: ConsoleMessage) => {
-          if (message.type() !== "warning" && message.type() !== "error") {
-            return;
-          }
-
-          diagnostics.push({
+          const diagnostic = getConsoleDiagnostic({
             location: message.location(),
             text: message.text(),
-            type: `console.${message.type()}`,
+            type: message.type(),
           });
+
+          if (diagnostic) {
+            diagnostics.push(diagnostic);
+          }
         };
         const onPageError = (error: Error) => {
-          diagnostics.push({
-            text: error.stack ?? error.message,
-            type: "pageerror",
-          });
+          diagnostics.push(getPageErrorDiagnostic(error));
         };
         const onRequestFailed = (request: Request) => {
-          if (!shouldFailOnRequest(request)) {
-            return;
-          }
-
-          diagnostics.push({
-            text: `${request.method()} ${request.url()} failed: ${
-              request.failure()?.errorText ?? "unknown network failure"
-            }`,
-            type: `requestfailed.${request.resourceType()}`,
+          const diagnostic = getRequestFailedDiagnostic({
+            failureText: request.failure()?.errorText,
+            method: request.method(),
+            resourceType: request.resourceType(),
+            url: request.url(),
           });
+
+          if (diagnostic) {
+            diagnostics.push(diagnostic);
+          }
         };
         const onResponse = (response: Response) => {
           const request = response.request();
-
-          if (response.status() < 400 || !shouldFailOnRequest(request)) {
-            return;
-          }
-
-          diagnostics.push({
-            text: `${request.method()} ${response.url()} returned ${response.status()}`,
-            type: `response.${request.resourceType()}`,
+          const diagnostic = getResponseDiagnostic({
+            method: request.method(),
+            resourceType: request.resourceType(),
+            status: response.status(),
+            url: response.url(),
           });
+
+          if (diagnostic) {
+            diagnostics.push(diagnostic);
+          }
         };
 
         page.on("console", onConsole);

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,0 +1,130 @@
+import { expect, test as base } from "@playwright/test";
+import type { ConsoleMessage, Locator, Page, Request, Response, TestInfo } from "@playwright/test";
+
+type BrowserDiagnostic = {
+  location?: ReturnType<ConsoleMessage["location"]>;
+  text: string;
+  type: string;
+};
+
+type ConsoleGuardFixtures = {
+  consoleDiagnostics: void;
+};
+
+function formatDiagnostic(diagnostic: BrowserDiagnostic) {
+  const location = diagnostic.location;
+  const source =
+    location && (location.url || location.lineNumber || location.columnNumber)
+      ? ` at ${location.url}:${location.lineNumber}:${location.columnNumber}`
+      : "";
+
+  return `[${diagnostic.type}]${source} ${diagnostic.text}`;
+}
+
+function shouldFailOnRequest(request: Request) {
+  const resourceType = request.resourceType();
+
+  if (resourceType === "fetch" || resourceType === "xhr") {
+    return new URL(request.url()).pathname === "/favicon.ico";
+  }
+
+  return (
+    ["document", "font", "image", "manifest", "script", "stylesheet"].includes(resourceType) ||
+    new URL(request.url()).pathname === "/favicon.ico"
+  );
+}
+
+export const test = base.extend<ConsoleGuardFixtures>({
+  consoleDiagnostics: [
+    async ({ context }, use) => {
+      const diagnostics: BrowserDiagnostic[] = [];
+      const pageHandlers = new Map<
+        Page,
+        {
+          onConsole: (message: ConsoleMessage) => void;
+          onPageError: (error: Error) => void;
+          onRequestFailed: (request: Request) => void;
+          onResponse: (response: Response) => void;
+        }
+      >();
+
+      const attachPage = (page: Page) => {
+        if (pageHandlers.has(page)) {
+          return;
+        }
+
+        const onConsole = (message: ConsoleMessage) => {
+          if (message.type() !== "warning" && message.type() !== "error") {
+            return;
+          }
+
+          diagnostics.push({
+            location: message.location(),
+            text: message.text(),
+            type: `console.${message.type()}`,
+          });
+        };
+        const onPageError = (error: Error) => {
+          diagnostics.push({
+            text: error.stack ?? error.message,
+            type: "pageerror",
+          });
+        };
+        const onRequestFailed = (request: Request) => {
+          if (!shouldFailOnRequest(request)) {
+            return;
+          }
+
+          diagnostics.push({
+            text: `${request.method()} ${request.url()} failed: ${
+              request.failure()?.errorText ?? "unknown network failure"
+            }`,
+            type: `requestfailed.${request.resourceType()}`,
+          });
+        };
+        const onResponse = (response: Response) => {
+          const request = response.request();
+
+          if (response.status() < 400 || !shouldFailOnRequest(request)) {
+            return;
+          }
+
+          diagnostics.push({
+            text: `${request.method()} ${response.url()} returned ${response.status()}`,
+            type: `response.${request.resourceType()}`,
+          });
+        };
+
+        page.on("console", onConsole);
+        page.on("pageerror", onPageError);
+        page.on("requestfailed", onRequestFailed);
+        page.on("response", onResponse);
+        pageHandlers.set(page, { onConsole, onPageError, onRequestFailed, onResponse });
+      };
+
+      for (const page of context.pages()) {
+        attachPage(page);
+      }
+      context.on("page", attachPage);
+
+      await use();
+
+      context.off("page", attachPage);
+      for (const [page, handlers] of pageHandlers) {
+        page.off("console", handlers.onConsole);
+        page.off("pageerror", handlers.onPageError);
+        page.off("requestfailed", handlers.onRequestFailed);
+        page.off("response", handlers.onResponse);
+      }
+
+      expect(
+        diagnostics.map(formatDiagnostic),
+        "browser console warnings/errors and failed page assets should not be emitted during E2E tests",
+      ).toEqual([]);
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };
+export type { ConsoleMessage, Locator, Page, TestInfo };

--- a/tests/e2e/human-lobby.e2e.ts
+++ b/tests/e2e/human-lobby.e2e.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Page, test } from "./fixtures";
 
 const activeSessionKey = "match:session:v1:active";
 

--- a/tests/e2e/localized-route-smoke.e2e.ts
+++ b/tests/e2e/localized-route-smoke.e2e.ts
@@ -1,9 +1,8 @@
-import { expect, type ConsoleMessage, type Page, test } from "@playwright/test";
-
 import { locales, type Locale } from "../../app/i18n/config";
 import { messages as enMessages } from "../../app/i18n/messages/en";
 import { messages as jaMessages } from "../../app/i18n/messages/ja";
 import { messages as zhMessages } from "../../app/i18n/messages/zh";
+import { expect, type ConsoleMessage, type Page, test } from "./fixtures";
 
 type AppMessages = typeof enMessages;
 

--- a/tests/e2e/messages.e2e.ts
+++ b/tests/e2e/messages.e2e.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import { createId } from "@paralleldrive/cuid2";
-import { expect, type Page, type TestInfo, test } from "@playwright/test";
 import { hashPassword } from "better-auth/crypto";
 
 import { prisma } from "../../app/lib/prisma";
+import { expect, type Page, type TestInfo, test } from "./fixtures";
 
 test.setTimeout(90_000);
 

--- a/tests/e2e/oauth-social-login.e2e.ts
+++ b/tests/e2e/oauth-social-login.e2e.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import { createId } from "@paralleldrive/cuid2";
-import { expect, type Locator, type Page, type TestInfo, test } from "@playwright/test";
 import { hashPassword } from "better-auth/crypto";
 
 import { prisma } from "../../app/lib/prisma";
+import { expect, type Locator, type Page, type TestInfo, test } from "./fixtures";
 
 test.setTimeout(90_000);
 

--- a/tests/e2e/pagination.e2e.ts
+++ b/tests/e2e/pagination.e2e.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 
 import { createId } from "@paralleldrive/cuid2";
-import { expect, type Page, type TestInfo, test } from "@playwright/test";
 import { hashPassword } from "better-auth/crypto";
 
 import { prisma } from "../../app/lib/prisma";
@@ -13,6 +12,7 @@ import {
   RuleType,
   Seat,
 } from "../../generated/prisma/enums";
+import { expect, type Page, type TestInfo, test } from "./fixtures";
 
 test.setTimeout(90_000);
 

--- a/tests/e2e/password-reset.e2e.ts
+++ b/tests/e2e/password-reset.e2e.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "./fixtures";
 
 test.setTimeout(60_000);
 

--- a/tests/e2e/profile-auth-settings.e2e.ts
+++ b/tests/e2e/profile-auth-settings.e2e.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import { createId } from "@paralleldrive/cuid2";
-import { expect, type Page, type TestInfo, test } from "@playwright/test";
 import { hashPassword } from "better-auth/crypto";
 
 import { prisma } from "../../app/lib/prisma";
+import { expect, type Page, type TestInfo, test } from "./fixtures";
 
 test.setTimeout(90_000);
 

--- a/tests/e2e/profile-auth-settings.e2e.ts
+++ b/tests/e2e/profile-auth-settings.e2e.ts
@@ -38,7 +38,9 @@ test("OAuth-only profile settings show linked email and set password without cur
     await page.getByLabel("Confirm New Password", { exact: true }).fill("password999");
     await page.getByRole("button", { name: "Set Password" }).click();
 
-    await expect(visibleExactText(page, "Changes saved successfully!")).toBeVisible();
+    await expect(visibleExactText(page, "Changes saved successfully!")).toBeVisible({
+      timeout: 15_000,
+    });
     await expect(page.getByRole("button", { exact: true, name: "Change" })).toBeVisible();
 
     const credentialAccount = await prisma.account.findFirst({

--- a/tests/e2e/seed.e2e.ts
+++ b/tests/e2e/seed.e2e.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test } from "./fixtures";
 
 test("seed", async ({ page }) => {
   await page.goto("/");

--- a/tests/e2e/smoke.e2e.ts
+++ b/tests/e2e/smoke.e2e.ts
@@ -6,7 +6,14 @@ import { hashPassword } from "better-auth/crypto";
 import { prisma } from "../../app/lib/prisma";
 import { expect, type Page, type TestInfo, test } from "./fixtures";
 
-const routes = ["/", "/game", "/human", "/leaderboard", "/login", "/signup"] as const;
+const routes = [
+  { heading: "Master the board.", path: "/" },
+  { heading: "Choose your opponent.", path: "/game" },
+  { heading: "Play Online", path: "/human" },
+  { heading: "Leaderboard", path: "/leaderboard" },
+  { heading: "Welcome back.", path: "/login" },
+  { heading: "Create your account.", path: "/signup" },
+] as const;
 
 test.setTimeout(90_000);
 
@@ -63,16 +70,21 @@ test("auth pages expose usable sign-in and sign-up forms", async ({ page }) => {
 
 test("localized shell avoids horizontal overflow on public routes", async ({ page }) => {
   for (const route of routes) {
-    await gotoAppRoute(page, route);
+    await gotoAppRoute(page, route.path);
+    await expect(
+      page.getByRole("heading", { exact: true, name: route.heading }),
+      `${route.path} should finish rendering before the next route navigation`,
+    ).toBeVisible();
 
     const dimensions = await page.evaluate(() => ({
       clientWidth: document.documentElement.clientWidth,
       scrollWidth: document.documentElement.scrollWidth,
     }));
 
-    expect(dimensions.scrollWidth, `${route} should not horizontally overflow`).toBeLessThanOrEqual(
-      dimensions.clientWidth + 1,
-    );
+    expect(
+      dimensions.scrollWidth,
+      `${route.path} should not horizontally overflow`,
+    ).toBeLessThanOrEqual(dimensions.clientWidth + 1);
   }
 });
 

--- a/tests/e2e/smoke.e2e.ts
+++ b/tests/e2e/smoke.e2e.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import { createId } from "@paralleldrive/cuid2";
-import { expect, type Page, type TestInfo, test } from "@playwright/test";
 import { hashPassword } from "better-auth/crypto";
 
 import { prisma } from "../../app/lib/prisma";
+import { expect, type Page, type TestInfo, test } from "./fixtures";
 
 const routes = ["/", "/game", "/human", "/leaderboard", "/login", "/signup"] as const;
 


### PR DESCRIPTION
## Summary
- run committed Playwright E2E tests across Chrome, Firefox, and Edge
- install the three browser targets and OS dependencies in CI
- add a shared E2E fixture that fails on browser console warnings/errors, page errors, and failed page assets
- characterize the browser diagnostic guard with focused Bun unit tests
- set Better Auth test defaults for Playwright web server runs
- point app metadata at the existing Gomoku SVG icon

## Validation
- `bun test tests/e2e/browser-diagnostics.test.ts`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run pw:install --dry-run --with-deps`
- `bun run test:e2e -- tests/e2e/seed.e2e.ts`

Full local E2E was started but stopped because local Postgres was unavailable at `127.0.0.1:5432`, producing unrelated Prisma `P1001` failures.