### PR TITLE
[codex] rename AI opponent route to ai

### DIFF
--- a/app/[locale]/ai/page.tsx
+++ b/app/[locale]/ai/page.tsx
@@ -2,13 +2,13 @@ import { setRequestLocale } from "next-intl/server";
 
 import AiLobbyClient from "@/components/ai-lobby-client";
 
-type GamePageProps = {
+type AiPageProps = {
   params: Promise<{
     locale: string;
   }>;
 };
 
-export default async function GamePage({ params }: GamePageProps) {
+export default async function AiPage({ params }: AiPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 

--- a/app/components/app-sidebar.tsx
+++ b/app/components/app-sidebar.tsx
@@ -13,7 +13,7 @@ import { prisma } from "@/lib/prisma";
 
 const productLinkMeta = [
   { href: "/", icon: "home", labelKey: "home" },
-  { href: "/game", icon: "game", labelKey: "vsAi" },
+  { href: "/ai", icon: "game", labelKey: "vsAi" },
   { href: "/human", icon: "human", labelKey: "vsHuman" },
   { href: "/leaderboard", icon: "leaderboard", labelKey: "leaderboard" },
 ] as const satisfies ReadonlyArray<Omit<SidebarNavItem, "label"> & { labelKey: string }>;

--- a/app/components/home-dashboard.tsx
+++ b/app/components/home-dashboard.tsx
@@ -59,7 +59,7 @@ export default async function HomeDashboard() {
           <ActionCard
             body={t("cards.ai.body")}
             cta={t("cards.ai.cta")}
-            href="/game"
+            href="/ai"
             icon={Bot}
             title={t("cards.ai.title")}
             tone="mint"

--- a/app/components/nav-bar.tsx
+++ b/app/components/nav-bar.tsx
@@ -19,7 +19,7 @@ export default async function Navbar() {
   const avatarUrl = sessionData?.user.avatarUrl;
   const navItems = [
     { href: "/", icon: Home, label: nav("home") },
-    { href: "/game", icon: Bot, label: nav("vsAi") },
+    { href: "/ai", icon: Bot, label: nav("vsAi") },
     { href: "/human", icon: Swords, label: nav("vsHuman") },
     { href: "/leaderboard", icon: Trophy, label: nav("leaderboard") },
   ] as const;

--- a/docs/ui-docs/design-system.md
+++ b/docs/ui-docs/design-system.md
@@ -344,7 +344,7 @@ Acceptance markers:
 ### 02 Active Game / vs AI
 
 Reference: [02-active-game.png](./02-active-game.png)  
-Route: `/[locale]/game`
+Route: `/[locale]/ai`
 
 Purpose:
 

--- a/specs/ai-solo-mode.md
+++ b/specs/ai-solo-mode.md
@@ -4,7 +4,7 @@ Issue #42 is implemented as a private server-authoritative match.
 
 - `/api/matches/solo` creates a normal `Match` with two `PLAYER` participants: the signed-in user and `Kata Reader`, an AI participant with `userId: null`.
 - `/api/matches/[id]/ai-turn` is the only endpoint that can submit AI moves. It verifies the signed-in user owns the human participant, rechecks state inside a transaction, and writes the AI move with the same `MatchMove` model as human play.
-- The match screen in `/game` uses `MatchBoard`, the extracted board component also used by `HumanMatchRoom`, so the actual board UI stays shared across vs AI and vs Human.
+- The match screen in `/ai` uses `MatchBoard`, the extracted board component also used by `HumanMatchRoom`, so the actual board UI stays shared across vs AI and vs Human.
 
 The AI engine lives in `app/lib/matches/ai-engine.ts`.
 

--- a/tests/e2e/ai-lobby.e2e.ts
+++ b/tests/e2e/ai-lobby.e2e.ts
@@ -39,7 +39,7 @@ test("AI lobby starts a solo match and renders the shared match board", async ({
     },
   );
 
-  await page.goto("/en/game", { waitUntil: "domcontentloaded" });
+  await page.goto("/en/ai", { waitUntil: "domcontentloaded" });
   await expect(
     page.getByRole("heading", { level: 1, name: "Choose your opponent." }),
   ).toBeVisible();

--- a/tests/e2e/localized-route-smoke.e2e.ts
+++ b/tests/e2e/localized-route-smoke.e2e.ts
@@ -64,7 +64,7 @@ const publicRouteCases = [
     visibleText: (messages: AppMessages) => messages.human.createRoom.title,
   },
   {
-    path: "/game",
+    path: "/ai",
     heading: (messages: AppMessages) => messages.aiLobby.hero.title,
     visibleText: (messages: AppMessages) => messages.aiLobby.preview.openingPreview,
   },
@@ -97,7 +97,7 @@ for (const locale of locales) {
     const messages = messagesByLocale[locale];
     const verifyNoRuntimeErrors = watchRuntimeTranslationErrors(page);
 
-    await gotoLocalizedRoute(page, locale, "/game");
+    await gotoLocalizedRoute(page, locale, "/ai");
 
     await expect(
       page.getByRole("heading", { level: 1, name: messages.aiLobby.hero.title }),
@@ -105,7 +105,7 @@ for (const locale of locales) {
     await expect(
       page.getByText(messages.aiLobby.preview.openingPreview, { exact: true }),
     ).toBeVisible();
-    await expectNoTranslationArtifacts(page, `${locale}/game lobby`);
+    await expectNoTranslationArtifacts(page, `${locale}/ai lobby`);
 
     const startTrainingButton = page.getByRole("button", {
       name: messages.aiLobby.setup.startButton,
@@ -123,8 +123,8 @@ for (const locale of locales) {
     await expect(
       page.getByRole("grid", { name: messages.aiLobby.matchRoom.board.ariaLabel }),
     ).toBeVisible();
-    await expectNoTranslationArtifacts(page, `${locale}/game active match`);
-    verifyNoRuntimeErrors(`${locale}/game active match`);
+    await expectNoTranslationArtifacts(page, `${locale}/ai active match`);
+    verifyNoRuntimeErrors(`${locale}/ai active match`);
   });
 }
 

--- a/tests/e2e/smoke.e2e.ts
+++ b/tests/e2e/smoke.e2e.ts
@@ -8,7 +8,7 @@ import { expect, type Page, type TestInfo, test } from "./fixtures";
 
 const routes = [
   { heading: "Master the board.", path: "/" },
-  { heading: "Choose your opponent.", path: "/game" },
+  { heading: "Choose your opponent.", path: "/ai" },
   { heading: "Play Online", path: "/human" },
   { heading: "Leaderboard", path: "/leaderboard" },
   { heading: "Welcome back.", path: "/login" },
@@ -34,7 +34,7 @@ test("home page renders the redesigned command center", async ({ page }) => {
 });
 
 test("primary game routes render their new page shells", async ({ page }) => {
-  await gotoAppRoute(page, "/game");
+  await gotoAppRoute(page, "/ai");
   await expect(
     page.getByRole("heading", { level: 1, name: "Choose your opponent." }),
   ).toBeVisible();


### PR DESCRIPTION
## Summary

- Rename the localized AI opponent route segment from `/game` to `/ai`.
- Update navigation, home dashboard CTA, E2E route expectations, and route documentation/spec notes to use `/ai`.
- Leave internal game-domain modules and realtime `/internal/game-update` endpoints unchanged.

## Validation

- `bun run typecheck`
- `bun run lint:js`
- Manual browser probe for `/en/ai` and localized home links to `/en/ai`
- `bun run build`

## Notes

A focused `tests/e2e/ai-lobby.e2e.ts` run reached `/en/ai`, but the repo's global browser diagnostics failed because the default Playwright web server starts only Next dev: the realtime Socket.IO service at `localhost:3001` was unavailable, and Next dev emitted its cache-bypass warning.