### PR TITLE
[codex] fix database backup script execution

### DIFF
--- a/scripts/postgres-backup-loop.sh
+++ b/scripts/postgres-backup-loop.sh
@@ -6,7 +6,9 @@ if [ "${POSTGRES_BACKUP_DISABLED:-false}" = "true" ]; then
   exec tail -f /dev/null
 fi
 
+backup_script="${POSTGRES_BACKUP_SCRIPT:-/usr/local/bin/postgres-backup}"
+
 while true; do
-  /usr/local/bin/postgres-backup
+  sh "$backup_script"
   sleep "${POSTGRES_BACKUP_INTERVAL_SECONDS:-86400}"
 done

--- a/scripts/postgres-backup-restore.test.ts
+++ b/scripts/postgres-backup-restore.test.ts
@@ -189,6 +189,7 @@ exit 42
       "scripts/postgres-backup-loop.sh",
       createEnv({
         FAKE_SCRIPT_LOG_DIR: logDir,
+        POSTGRES_BACKUP_DISABLED: "false",
         POSTGRES_BACKUP_INTERVAL_SECONDS: "1",
         POSTGRES_BACKUP_SCRIPT: backupScript,
       }),

--- a/scripts/postgres-backup-restore.test.ts
+++ b/scripts/postgres-backup-restore.test.ts
@@ -171,6 +171,33 @@ exit 0
 }
 
 describe("PostgreSQL backup and restore scripts", () => {
+  test("backup loop runs a mounted backup script through sh", async () => {
+    const root = await createTempRoot();
+    const logDir = join(root, "logs");
+    const backupScript = join(root, "postgres-backup");
+    await mkdirp(logDir);
+    await writeFile(
+      backupScript,
+      `#!/bin/sh
+set -eu
+printf "ran\\n" > "$FAKE_SCRIPT_LOG_DIR/backup-ran"
+exit 42
+`,
+    );
+
+    const result = await runShellScript(
+      "scripts/postgres-backup-loop.sh",
+      createEnv({
+        FAKE_SCRIPT_LOG_DIR: logDir,
+        POSTGRES_BACKUP_INTERVAL_SECONDS: "1",
+        POSTGRES_BACKUP_SCRIPT: backupScript,
+      }),
+    );
+
+    expect(result.exitCode).toBe(42);
+    expect(await readFile(join(logDir, "backup-ran"), "utf8")).toBe("ran\n");
+  });
+
   test("creates a dump and checksum artifact that the restore script accepts", async () => {
     const root = await createTempRoot();
     const backupDir = join(root, "backups");


### PR DESCRIPTION
## Summary

- Run the mounted PostgreSQL backup script through `sh` from the backup loop.
- Add a regression test that covers a readable but non-executable mounted backup script.

## Root Cause

The `database-backup` service bind-mounts `scripts/postgres-backup.sh` into the Postgres image. The host file is tracked as `100644`, so invoking `/usr/local/bin/postgres-backup` directly fails with `Permission denied` inside the container.

## Impact

The backup container can now execute the mounted script without requiring executable bits on the host checkout. The `POSTGRES_BACKUP_SCRIPT` override also makes the loop easier to test without changing the production default.

## Validation

- `bun test scripts/postgres-backup-restore.test.ts`
- `git diff --check`
- Docker compose shell-parse check for mounted backup scripts
