### PR TITLE
[codex] Localize page metadata

### DIFF
--- a/app/[locale]/account/page.tsx
+++ b/app/[locale]/account/page.tsx
@@ -19,6 +19,7 @@ import {
   serializeUserForResponse,
 } from "@/lib/auth";
 import { oauthProviderIds, type OAuthProviderId } from "@/lib/oauth-providers";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type SessionPayload = {
   user: {
@@ -80,6 +81,8 @@ type AccountPageProps = {
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("account");
 
 export default function AccountPage({ params }: AccountPageProps) {
   return (

--- a/app/[locale]/ai/page.tsx
+++ b/app/[locale]/ai/page.tsx
@@ -1,12 +1,15 @@
 import { setRequestLocale } from "next-intl/server";
 
 import AiLobbyClient from "@/components/ai-lobby-client";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type AiPageProps = {
   params: Promise<{
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("ai");
 
 export default async function AiPage({ params }: AiPageProps) {
   const { locale } = await params;

--- a/app/[locale]/forgot-password/page.tsx
+++ b/app/[locale]/forgot-password/page.tsx
@@ -6,12 +6,15 @@ import { Suspense } from "react";
 import { BoardShowpiece, PageShell } from "@/components/gomoku-ui";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { PasswordResetRequestForm } from "@/components/password-reset-request-form";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type ForgotPasswordPageProps = {
   params: Promise<{
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("forgotPassword");
 
 export default function ForgotPasswordPage({ params }: ForgotPasswordPageProps) {
   return (

--- a/app/[locale]/friends/page.tsx
+++ b/app/[locale]/friends/page.tsx
@@ -8,6 +8,7 @@ import {
   friendshipForUserWhere,
   getOtherFriendshipUser,
 } from "@/lib/friendships/friendship-queries";
+import { createPageMetadata } from "@/lib/page-metadata";
 import { prisma } from "@/lib/prisma";
 
 import FriendsContent from "./friends-layout";
@@ -20,6 +21,8 @@ type FriendsPageProps = {
     query?: string | string[];
   }>;
 };
+
+export const generateMetadata = createPageMetadata("friends");
 
 function getSearchQuery(query: string | string[] | undefined) {
   const rawQuery = Array.isArray(query) ? query[0] : query;

--- a/app/[locale]/home/page.tsx
+++ b/app/[locale]/home/page.tsx
@@ -1,12 +1,15 @@
 import { setRequestLocale } from "next-intl/server";
 
 import HomeDashboard from "@/components/home-dashboard";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type HomePageProps = {
   params: Promise<{
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("home", "/home");
 
 export default async function HomePage({ params }: HomePageProps) {
   const { locale } = await params;

--- a/app/[locale]/human/page.tsx
+++ b/app/[locale]/human/page.tsx
@@ -1,12 +1,15 @@
 import { setRequestLocale } from "next-intl/server";
 
 import HumanLobbyClient from "@/components/human-lobby-client";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type VsHumanProps = {
   params: Promise<{
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("human");
 
 export default async function VsHuman({ params }: VsHumanProps) {
   const { locale } = await params;

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -13,6 +13,7 @@ import AppSidebar from "@/components/app-sidebar";
 import { PresenceProvider, PresenceSessionSync } from "@/components/presence-provider";
 import { routing } from "@/i18n/routing";
 import { getCurrentSessionIdentity } from "@/lib/auth";
+import { getLocaleOpenGraphLocale, getRootMetadataBase } from "@/lib/page-metadata";
 import { cn } from "@/lib/utils";
 
 const manrope = Manrope({
@@ -46,13 +47,37 @@ export function generateStaticParams() {
 export async function generateMetadata({ params }: MetadataProps): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "metadata" });
+  const appName = t("appName");
 
   return {
+    applicationName: appName,
+    appleWebApp: {
+      title: appName,
+    },
     description: t("description"),
+    formatDetection: {
+      address: false,
+      email: false,
+      telephone: false,
+    },
     icons: {
       icon: "/icons/Gomoku.svg",
     },
-    title: t("title"),
+    metadataBase: getRootMetadataBase(),
+    openGraph: {
+      description: t("description"),
+      locale: getLocaleOpenGraphLocale(locale),
+      siteName: appName,
+      title: appName,
+      type: "website",
+    },
+    referrer: "origin-when-cross-origin",
+    title: appName,
+    twitter: {
+      card: "summary",
+      description: t("description"),
+      title: appName,
+    },
   };
 }
 

--- a/app/[locale]/leaderboard/page.tsx
+++ b/app/[locale]/leaderboard/page.tsx
@@ -15,6 +15,7 @@ import {
   type LeaderboardEntry,
   type LeaderboardScope,
 } from "@/lib/leaderboard";
+import { createPageMetadata } from "@/lib/page-metadata";
 import { getSeasonSnapshot, type SeasonSnapshot } from "@/lib/stats/season-stats";
 
 type LeaderBoardProps = {
@@ -33,6 +34,8 @@ type LeaderBoardProps = {
     sort?: string | string[];
   }>;
 };
+
+export const generateMetadata = createPageMetadata("leaderboard");
 
 export default function LeaderBoard({ params, searchParams }: LeaderBoardProps) {
   return (

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -7,12 +7,15 @@ import { LoginForm } from "@/components/login-form";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
 import { getConfiguredOAuthProviders, getCurrentSessionIdentity } from "@/lib/auth";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type LoginPageProps = {
   params: Promise<{
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("login");
 
 export default function LoginPage({ params }: LoginPageProps) {
   return (

--- a/app/[locale]/messages/page.tsx
+++ b/app/[locale]/messages/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
 import { getCurrentSessionIdentity } from "@/lib/auth";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 import MessagesContent from "./messages-layout";
 
@@ -12,6 +13,8 @@ type MessagesPageProps = {
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("messages");
 
 export default function MessagesPage({ params }: MessagesPageProps) {
   return (

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -2,12 +2,15 @@ import { setRequestLocale } from "next-intl/server";
 import { use } from "react";
 
 import HomeDashboard from "@/components/home-dashboard";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type HomeProps = {
   params: Promise<{
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("home", "/");
 
 export default function Home({ params }: HomeProps) {
   const { locale } = use(params);

--- a/app/[locale]/privacy/page.tsx
+++ b/app/[locale]/privacy/page.tsx
@@ -2,12 +2,15 @@ import { Database, FileText, LockKeyhole, ShieldCheck } from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import { Badge, MetricCard, PageHeader, PageShell, Surface } from "@/components/gomoku-ui";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type PrivacyPageProps = {
   params: Promise<{
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("privacy");
 
 export default async function PrivacyPage({ params }: PrivacyPageProps) {
   const { locale } = await params;

--- a/app/[locale]/profile/[username]/page.tsx
+++ b/app/[locale]/profile/[username]/page.tsx
@@ -17,6 +17,7 @@ import { MatchResult, MatchStatus, Role } from "@/../generated/prisma/enums";
 import { Badge, MetricCard, PageShell, Surface } from "@/components/gomoku-ui";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { getCurrentSessionIdentity } from "@/lib/auth";
+import { buildPageMetadata } from "@/lib/page-metadata";
 import { prisma } from "@/lib/prisma";
 import { getProfileStatsForUser } from "@/lib/stats/profile-stats";
 
@@ -36,6 +37,19 @@ type ProfilePageProps = {
 };
 
 const achievements = ["sharpOpening", "calmEndgame", "fastRematch"] as const;
+
+export async function generateMetadata({ params }: ProfilePageProps) {
+  const { locale, username } = await params;
+
+  return buildPageMetadata({
+    locale,
+    page: "publicProfile",
+    path: `/profile/${encodeURIComponent(username)}`,
+    values: {
+      username,
+    },
+  });
+}
 
 function getSearchParamNumber(value: string | string[] | undefined) {
   const rawValue = Array.isArray(value) ? value[0] : value;

--- a/app/[locale]/profile/edit/page.tsx
+++ b/app/[locale]/profile/edit/page.tsx
@@ -17,6 +17,7 @@ import {
   hasCredentialPassword,
 } from "@/lib/auth";
 import { oauthProviderIds, type OAuthProviderId } from "@/lib/oauth-providers";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 import ProfilePicture from "../profile-picture";
 import EditProfileForm from "./edit-form";
@@ -26,6 +27,8 @@ type EditProfilePageProps = {
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("editProfile");
 
 async function loadOAuthProviders(): Promise<OAuthProviderConnection[]> {
   const accounts = await auth.api.listUserAccounts({

--- a/app/[locale]/profile/page.tsx
+++ b/app/[locale]/profile/page.tsx
@@ -7,12 +7,15 @@ import { PageLoadingShell } from "@/components/page-loading-shell";
 import ProfileStatsPanel from "@/components/profile-stats-panel";
 import { Link, redirect } from "@/i18n/navigation";
 import { getCurrentSession } from "@/lib/auth";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type ProfilePageProps = {
   params: Promise<{
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("profile");
 
 export default function ProfilePage({ params }: ProfilePageProps) {
   return (

--- a/app/[locale]/reset-password/page.tsx
+++ b/app/[locale]/reset-password/page.tsx
@@ -7,6 +7,7 @@ import { BoardShowpiece, PageShell } from "@/components/gomoku-ui";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { PasswordResetConfirmForm } from "@/components/password-reset-confirm-form";
 import { Link } from "@/i18n/navigation";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type ResetPasswordPageProps = {
   params: Promise<{
@@ -17,6 +18,8 @@ type ResetPasswordPageProps = {
     token?: string | string[];
   }>;
 };
+
+export const generateMetadata = createPageMetadata("resetPassword");
 
 function firstSearchValue(value: string | string[] | undefined) {
   return Array.isArray(value) ? value[0] : value;

--- a/app/[locale]/signup/page.tsx
+++ b/app/[locale]/signup/page.tsx
@@ -7,12 +7,15 @@ import { PageLoadingShell } from "@/components/page-loading-shell";
 import { SignupForm } from "@/components/signup-form";
 import { redirect } from "@/i18n/navigation";
 import { getConfiguredOAuthProviders, getCurrentSessionIdentity } from "@/lib/auth";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type SignupPageProps = {
   params: Promise<{
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("signup");
 
 export default function SignupPage({ params }: SignupPageProps) {
   return (

--- a/app/[locale]/status/page.tsx
+++ b/app/[locale]/status/page.tsx
@@ -27,6 +27,7 @@ import {
   type SystemHealthPayload,
   type SystemStatus,
 } from "@/lib/operations/system-health";
+import { createPageMetadata } from "@/lib/page-metadata";
 import { cn } from "@/lib/utils";
 
 type StatusPageProps = {
@@ -34,6 +35,8 @@ type StatusPageProps = {
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("status");
 
 const checkIcons = {
   app: ServerCog,

--- a/app/[locale]/terms/page.tsx
+++ b/app/[locale]/terms/page.tsx
@@ -3,12 +3,15 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import { Badge, PageHeader, PageShell, Surface } from "@/components/gomoku-ui";
 import { Link } from "@/i18n/navigation";
+import { createPageMetadata } from "@/lib/page-metadata";
 
 type TermsPageProps = {
   params: Promise<{
     locale: string;
   }>;
 };
+
+export const generateMetadata = createPageMetadata("terms");
 
 export default async function TermsPage({ params }: TermsPageProps) {
   const { locale } = await params;

--- a/app/[locale]/test/page.tsx
+++ b/app/[locale]/test/page.tsx
@@ -1,5 +1,8 @@
 import CreateRoomCard from "@/components/create-room-card";
 import GameLobbyTableClient from "@/components/game-lobby-table-client";
+import { createPageMetadata } from "@/lib/page-metadata";
+
+export const generateMetadata = createPageMetadata("test");
 
 const entries = [
   {

--- a/app/components/app-sidebar.tsx
+++ b/app/components/app-sidebar.tsx
@@ -71,21 +71,21 @@ export default async function AppSidebar() {
 
   return (
     <>
-      <aside className="app-sidebar" aria-label="Primary navigation">
+      <aside className="app-sidebar" aria-label={nav("primaryLabel")}>
         <Link href="/" className="sidebar-brand">
           <Image src="/icons/Gomoku.svg" alt={brand("logoAlt")} width={52} height={52} priority />
           <span>
             <span className="sidebar-brand-mark" translate="no">
               {brand("name")}
             </span>
-            <span className="sidebar-brand-subtitle">Competitive Gomoku</span>
+            <span className="sidebar-brand-subtitle">{brand("subtitle")}</span>
           </span>
         </Link>
 
         <SidebarNav
           groups={[
-            { label: "Play", items: productLinks },
-            { label: "Social", items: socialLinks },
+            { label: nav("groups.play"), items: productLinks },
+            { label: nav("groups.social"), items: socialLinks },
           ]}
         />
 
@@ -102,7 +102,7 @@ export default async function AppSidebar() {
             <div className="flex items-center justify-between gap-2 text-xs font-bold text-[var(--muted-strong)]">
               <div className="flex items-center gap-2">
                 <ShieldCheck aria-hidden="true" className="size-4 text-[var(--mint)]" />
-                <span>Ranked Session</span>
+                <span>{nav("session")}</span>
               </div>
               <div className="-mr-2">
                 <LocaleSwitcher />

--- a/app/i18n/messages/en.ts
+++ b/app/i18n/messages/en.ts
@@ -1,13 +1,92 @@
 export const messages = {
   metadata: {
-    title: "Transcendence",
-    description: "Local full-stack Next.js app for 42 Transcendence.",
+    appName: "Gomoku Heroes",
+    title: "Gomoku Heroes",
+    titleTemplate: "{pageTitle} | {appName}",
+    description:
+      "Train against AI, challenge friends, and track your Gomoku ladder in Gomoku Heroes.",
+    pages: {
+      account: {
+        title: "Account Settings",
+        description: "Manage your Gomoku Heroes account, profile, security, and connections.",
+      },
+      ai: {
+        title: "vs AI",
+        description: "Practice Gomoku against adjustable AI opponents and review your training.",
+      },
+      editProfile: {
+        title: "Edit Profile",
+        description: "Update your Gomoku Heroes display name, avatar, and account details.",
+      },
+      forgotPassword: {
+        title: "Reset Password",
+        description: "Request a secure password reset link for your Gomoku Heroes account.",
+      },
+      friends: {
+        title: "Friends",
+        description: "Manage friends, requests, messages, and match challenges.",
+      },
+      home: {
+        title: "Home",
+        description: "Choose AI training, human matches, messages, or the live leaderboard.",
+      },
+      human: {
+        title: "vs Human",
+        description: "Join matchmaking, create rooms, and challenge other Gomoku players.",
+      },
+      leaderboard: {
+        title: "Leaderboard",
+        description: "View Gomoku Heroes rankings, rating movement, and top players.",
+      },
+      login: {
+        title: "Log In",
+        description: "Sign in to Gomoku Heroes to play matches and access your profile.",
+      },
+      messages: {
+        title: "Messages",
+        description: "Chat with friends and coordinate rematches in Gomoku Heroes.",
+      },
+      privacy: {
+        title: "Privacy Policy",
+        description: "Read how Gomoku Heroes handles account, session, social, and match data.",
+      },
+      profile: {
+        title: "Profile",
+        description: "View your Gomoku Heroes profile, match history, stats, and achievements.",
+      },
+      publicProfile: {
+        title: "@{username}'s Profile",
+        description: "View @{username}'s Gomoku rating, match history, and achievements.",
+      },
+      resetPassword: {
+        title: "Choose New Password",
+        description: "Finish resetting your Gomoku Heroes password with a secure link.",
+      },
+      signup: {
+        title: "Sign Up",
+        description: "Create a Gomoku Heroes account and start playing online.",
+      },
+      status: {
+        title: "System Status",
+        description: "Check Gomoku Heroes service health, backups, and recovery readiness.",
+      },
+      terms: {
+        title: "Terms of Service",
+        description: "Read the Gomoku Heroes terms for account access, fair play, and enforcement.",
+      },
+      test: {
+        title: "UI Test",
+        description: "A local development route for checking Gomoku Heroes interface pieces.",
+      },
+    },
   },
   brand: {
-    name: "五目並べヒーロー",
-    logoAlt: "Transcendence logo",
+    name: "Gomoku Heroes",
+    subtitle: "Competitive Gomoku",
+    logoAlt: "Gomoku Heroes logo",
   },
   nav: {
+    primaryLabel: "Primary navigation",
     home: "Home",
     vsAi: "vs AI",
     vsHuman: "vs Human",
@@ -21,6 +100,11 @@ export const messages = {
       ja: "日本語",
       zh: "中文",
     },
+    groups: {
+      play: "Play",
+      social: "Social",
+    },
+    session: "Ranked Session",
     userMenu: {
       trigger: "Profile",
       avatarAlt: "User avatar",
@@ -35,7 +119,7 @@ export const messages = {
   footer: {
     terms: "Terms of Service",
     privacy: "Privacy Policy",
-    copyright: "© {year} 五目並べヒーロー",
+    copyright: "© {year} Gomoku Heroes",
   },
   home: {
     eyebrow: "42 Transcendence",

--- a/app/i18n/messages/ja.ts
+++ b/app/i18n/messages/ja.ts
@@ -3,11 +3,94 @@ import { messages as enMessages } from "./en";
 export const messages = {
   ...enMessages,
   metadata: {
-    title: "Transcendence",
-    description: "42 Transcendence 用のローカルフルスタック Next.js アプリです。",
+    appName: "五目並べヒーローズ",
+    title: "五目並べヒーローズ",
+    titleTemplate: "{pageTitle} | {appName}",
+    description: "AI 練習、フレンドとの対局、ランキング管理を楽しめる五目並べヒーローズです。",
+    pages: {
+      account: {
+        title: "アカウント設定",
+        description: "五目並べヒーローズのプロフィール、セキュリティ、連携を管理します。",
+      },
+      ai: {
+        title: "AI 戦",
+        description: "強さを調整できる AI と五目並べを練習し、対局を振り返ります。",
+      },
+      editProfile: {
+        title: "プロフィール編集",
+        description: "表示名、アバター、アカウント情報を更新します。",
+      },
+      forgotPassword: {
+        title: "パスワード再設定",
+        description: "五目並べヒーローズの安全なパスワード再設定リンクをリクエストします。",
+      },
+      friends: {
+        title: "フレンド",
+        description: "フレンド、申請、メッセージ、対局チャレンジを管理します。",
+      },
+      home: {
+        title: "ホーム",
+        description: "AI 練習、対人戦、メッセージ、ライブランキングへ移動できます。",
+      },
+      human: {
+        title: "対人戦",
+        description: "マッチメイキング、ルーム作成、他プレイヤーへの挑戦を行います。",
+      },
+      leaderboard: {
+        title: "ランキング",
+        description: "五目並べヒーローズの順位、レーティング変動、上位プレイヤーを確認します。",
+      },
+      login: {
+        title: "ログイン",
+        description: "五目並べヒーローズにログインして、対局とプロフィール機能を利用します。",
+      },
+      messages: {
+        title: "メッセージ",
+        description: "フレンドとチャットし、再戦や対局の予定を調整します。",
+      },
+      privacy: {
+        title: "プライバシーポリシー",
+        description: "アカウント、セッション、ソーシャル、対局データの扱いを確認します。",
+      },
+      profile: {
+        title: "プロフィール",
+        description: "自分のプロフィール、対局履歴、統計、実績を確認します。",
+      },
+      publicProfile: {
+        title: "@{username} のプロフィール",
+        description: "@{username} のレーティング、対局履歴、実績を確認します。",
+      },
+      resetPassword: {
+        title: "新しいパスワードを設定",
+        description: "安全なリンクから五目並べヒーローズのパスワード再設定を完了します。",
+      },
+      signup: {
+        title: "登録",
+        description: "五目並べヒーローズのアカウントを作成してオンライン対局を始めます。",
+      },
+      status: {
+        title: "システム状態",
+        description: "サービスのヘルス、バックアップ、復旧準備状況を確認します。",
+      },
+      terms: {
+        title: "利用規約",
+        description: "アカウント利用、フェアプレイ、運用ルールを確認します。",
+      },
+      test: {
+        title: "UI テスト",
+        description: "ローカル開発用にインターフェース部品を確認するルートです。",
+      },
+    },
+  },
+  brand: {
+    ...enMessages.brand,
+    name: "五目並べヒーローズ",
+    subtitle: "競技五目並べ",
+    logoAlt: "五目並べヒーローズのロゴ",
   },
   nav: {
     ...enMessages.nav,
+    primaryLabel: "メインナビゲーション",
     home: "ホーム",
     vsAi: "AI 戦",
     vsHuman: "対人戦",
@@ -16,6 +99,11 @@ export const messages = {
     login: "ログイン",
     signup: "登録",
     languageLabel: "言語",
+    groups: {
+      play: "対局",
+      social: "交流",
+    },
+    session: "ランク戦セッション",
     userMenu: {
       ...enMessages.nav.userMenu,
       trigger: "プロフィール",
@@ -31,6 +119,7 @@ export const messages = {
     ...enMessages.footer,
     terms: "利用規約",
     privacy: "プライバシーポリシー",
+    copyright: "© {year} 五目並べヒーローズ",
   },
   home: {
     eyebrow: "42 Transcendence",

--- a/app/i18n/messages/zh.ts
+++ b/app/i18n/messages/zh.ts
@@ -3,11 +3,94 @@ import { messages as enMessages } from "./en";
 export const messages = {
   ...enMessages,
   metadata: {
-    title: "Transcendence",
-    description: "42 Transcendence 的本地全栈 Next.js 应用。",
+    appName: "五子棋英雄",
+    title: "五子棋英雄",
+    titleTemplate: "{pageTitle} | {appName}",
+    description: "在五子棋英雄中练习 AI、挑战好友，并追踪你的五子棋天梯。",
+    pages: {
+      account: {
+        title: "账户设置",
+        description: "管理五子棋英雄账户、资料、安全设置和登录连接。",
+      },
+      ai: {
+        title: "对战 AI",
+        description: "与可调难度的 AI 练习五子棋，并回顾训练对局。",
+      },
+      editProfile: {
+        title: "编辑资料",
+        description: "更新你的显示名称、头像和账户信息。",
+      },
+      forgotPassword: {
+        title: "重置密码",
+        description: "为五子棋英雄账户请求安全的密码重置链接。",
+      },
+      friends: {
+        title: "好友",
+        description: "管理好友、请求、消息和对局挑战。",
+      },
+      home: {
+        title: "首页",
+        description: "进入 AI 训练、真人对战、消息或实时排行榜。",
+      },
+      human: {
+        title: "真人对战",
+        description: "加入匹配、创建房间，并挑战其他五子棋玩家。",
+      },
+      leaderboard: {
+        title: "排行榜",
+        description: "查看五子棋英雄排名、等级分变化和顶尖玩家。",
+      },
+      login: {
+        title: "登录",
+        description: "登录五子棋英雄以进行对局并访问个人资料。",
+      },
+      messages: {
+        title: "消息",
+        description: "与好友聊天，并安排重赛和房间邀请。",
+      },
+      privacy: {
+        title: "隐私政策",
+        description: "了解五子棋英雄如何处理账户、会话、社交和对局数据。",
+      },
+      profile: {
+        title: "个人资料",
+        description: "查看你的个人资料、对局历史、统计和成就。",
+      },
+      publicProfile: {
+        title: "@{username} 的资料",
+        description: "查看 @{username} 的五子棋等级分、对局历史和成就。",
+      },
+      resetPassword: {
+        title: "设置新密码",
+        description: "通过安全链接完成五子棋英雄密码重置。",
+      },
+      signup: {
+        title: "注册",
+        description: "创建五子棋英雄账户并开始在线对局。",
+      },
+      status: {
+        title: "系统状态",
+        description: "检查服务健康、备份计划和恢复准备情况。",
+      },
+      terms: {
+        title: "服务条款",
+        description: "阅读账户访问、公平对局和规则执行相关条款。",
+      },
+      test: {
+        title: "UI 测试",
+        description: "用于本地开发时检查界面组件的路由。",
+      },
+    },
+  },
+  brand: {
+    ...enMessages.brand,
+    name: "五子棋英雄",
+    subtitle: "竞技五子棋",
+    logoAlt: "五子棋英雄标志",
   },
   nav: {
     ...enMessages.nav,
+    primaryLabel: "主导航",
     home: "首页",
     vsAi: "对战 AI",
     vsHuman: "真人对战",
@@ -16,6 +99,11 @@ export const messages = {
     login: "登录",
     signup: "注册",
     languageLabel: "语言",
+    groups: {
+      play: "对局",
+      social: "社交",
+    },
+    session: "排位会话",
     userMenu: {
       ...enMessages.nav.userMenu,
       trigger: "个人资料",
@@ -31,6 +119,7 @@ export const messages = {
     ...enMessages.footer,
     terms: "服务条款",
     privacy: "隐私政策",
+    copyright: "© {year} 五子棋英雄",
   },
   home: {
     eyebrow: "42 Transcendence",

--- a/app/lib/auth-email.test.ts
+++ b/app/lib/auth-email.test.ts
@@ -103,7 +103,7 @@ describe("sendPasswordResetEmail", () => {
   test("sends reset emails through Resend SMTP mode", async () => {
     process.env["AUTH_EMAIL_MODE"] = "resend-smtp";
     process.env["RESEND_API_KEY"] = "re_test_key";
-    process.env["RESEND_FROM_EMAIL"] = "42 Transcendence Gomoku <passwords@example.com>";
+    process.env["RESEND_FROM_EMAIL"] = "Gomoku Heroes <passwords@example.com>";
     process.env["RESEND_REPLY_TO_EMAIL"] = "support@example.com";
 
     const originalConsoleInfo = console.info;
@@ -131,10 +131,10 @@ describe("sendPasswordResetEmail", () => {
 
     const message = sendMail.mock.calls[0]?.[0];
 
-    expect(message?.from).toBe("42 Transcendence Gomoku <passwords@example.com>");
+    expect(message?.from).toBe("Gomoku Heroes <passwords@example.com>");
     expect(message?.to).toBe("player@example.com");
     expect(message?.replyTo).toBe("support@example.com");
-    expect(message?.subject).toBe("Reset your 42 Transcendence Gomoku password");
+    expect(message?.subject).toBe("Reset your Gomoku Heroes password");
     expect(message?.text).toContain("https://app.test/en/reset-password?token=abc123");
     expect(message?.text).toContain("This link expires in 1 hour.");
     expect(message?.html).toContain("Reset your password");
@@ -147,7 +147,7 @@ describe("sendPasswordResetEmail", () => {
 
   test("requires Resend credentials before sending through SMTP", async () => {
     process.env["AUTH_EMAIL_MODE"] = "resend-smtp";
-    process.env["RESEND_FROM_EMAIL"] = "42 Transcendence Gomoku <passwords@example.com>";
+    process.env["RESEND_FROM_EMAIL"] = "Gomoku Heroes <passwords@example.com>";
 
     let error: unknown;
 
@@ -196,7 +196,7 @@ describe("sendEmailVerificationEmail", () => {
   test("sends verification emails through the shared auth email transport", async () => {
     process.env["AUTH_EMAIL_MODE"] = "resend-smtp";
     process.env["RESEND_API_KEY"] = "re_verify_key";
-    process.env["RESEND_FROM_EMAIL"] = "42 Transcendence Gomoku <passwords@example.com>";
+    process.env["RESEND_FROM_EMAIL"] = "Gomoku Heroes <passwords@example.com>";
 
     const originalConsoleInfo = console.info;
     const consoleInfo = mock((_message: string, _details: unknown) => undefined);
@@ -222,9 +222,9 @@ describe("sendEmailVerificationEmail", () => {
       port: 465,
       secure: true,
     });
-    expect(message?.from).toBe("42 Transcendence Gomoku <passwords@example.com>");
+    expect(message?.from).toBe("Gomoku Heroes <passwords@example.com>");
     expect(message?.to).toBe("player@example.com");
-    expect(message?.subject).toBe("Verify your 42 Transcendence Gomoku email");
+    expect(message?.subject).toBe("Verify your Gomoku Heroes email");
     expect(message?.text).toContain("https://app.test/api/auth/verify-email?token=verify123");
     expect(message?.html).toContain("Verify your email address");
     expect(consoleInfo).toHaveBeenCalledWith("[auth-email] Resend SMTP accepted auth email", {

--- a/app/lib/auth-email.ts
+++ b/app/lib/auth-email.ts
@@ -205,7 +205,7 @@ export async function sendPasswordResetEmail({
       "<p>If you did not request this, you can ignore this email.</p>",
     ].join("\n"),
     to: email,
-    subject: "Reset your 42 Transcendence Gomoku password",
+    subject: "Reset your Gomoku Heroes password",
     text: [
       "A password reset was requested for your account.",
       "",
@@ -226,15 +226,15 @@ export async function sendEmailVerificationEmail({
 
   await sendAuthEmail({
     html: [
-      "<p>Welcome to 42 Transcendence Gomoku.</p>",
+      "<p>Welcome to Gomoku Heroes.</p>",
       `<p><a href="${escapedVerificationUrl}">Verify your email address</a></p>`,
       "<p>This link expires in 1 hour.</p>",
       "<p>If you did not create this account, you can ignore this email.</p>",
     ].join("\n"),
     to: email,
-    subject: "Verify your 42 Transcendence Gomoku email",
+    subject: "Verify your Gomoku Heroes email",
     text: [
-      "Welcome to 42 Transcendence Gomoku.",
+      "Welcome to Gomoku Heroes.",
       "",
       `Verify your email address here: ${verificationUrl}`,
       "",

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -173,7 +173,7 @@ function getBetterAuthBaseUrl() {
 }
 
 export const auth = betterAuth({
-  appName: "42 Transcendence Gomoku",
+  appName: "Gomoku Heroes",
   baseURL: getBetterAuthBaseUrl(),
   secret: process.env["BETTER_AUTH_SECRET"],
   trustedOrigins,

--- a/app/lib/page-metadata.test.ts
+++ b/app/lib/page-metadata.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { messages as enMessages } from "@/i18n/messages/en";
+import { messages as jaMessages } from "@/i18n/messages/ja";
+import { messages as zhMessages } from "@/i18n/messages/zh";
+
+const messagesByLocale = {
+  en: enMessages,
+  ja: jaMessages,
+  zh: zhMessages,
+};
+
+type Locale = keyof typeof messagesByLocale;
+type MessageValue = string | { [key: string]: MessageValue };
+
+await mock.module("server-only", () => ({}));
+
+await mock.module("next-intl/server", () => ({
+  getTranslations: async ({ locale, namespace }: { locale: Locale; namespace: string }) => {
+    const namespaceMessages = getMessageValue(messagesByLocale[locale], namespace);
+
+    return (key: string, values?: Record<string, string>) => {
+      const value = getMessageValue(namespaceMessages, key);
+
+      if (typeof value !== "string") {
+        throw new Error(`Expected string message for ${namespace}.${key}`);
+      }
+
+      return interpolate(value, values);
+    };
+  },
+}));
+
+const { buildPageMetadata, createPageMetadata, getRootMetadataBase } =
+  await import("./page-metadata");
+
+function getMessageValue(source: MessageValue, key: string): MessageValue {
+  return key.split(".").reduce<MessageValue>((current, segment) => {
+    if (typeof current !== "object" || current === null || !(segment in current)) {
+      throw new Error(`Missing message key: ${key}`);
+    }
+
+    return current[segment] as MessageValue;
+  }, source);
+}
+
+function interpolate(message: string, values: Record<string, string> = {}) {
+  return message.replace(/\{(\w+)\}/g, (placeholder, key: string) => values[key] ?? placeholder);
+}
+
+describe("buildPageMetadata", () => {
+  test("builds localized public metadata with canonical and language alternates", async () => {
+    const metadata = await buildPageMetadata({
+      locale: "zh",
+      page: "terms",
+      path: "/terms",
+    });
+
+    expect(metadata.title).toBe("服务条款 | 五子棋英雄");
+    expect(metadata.description).toBe("阅读账户访问、公平对局和规则执行相关条款。");
+    expect(metadata.alternates).toEqual({
+      canonical: "/zh/terms",
+      languages: {
+        en: "/en/terms",
+        ja: "/ja/terms",
+        zh: "/zh/terms",
+      },
+    });
+    expect(metadata.openGraph).toMatchObject({
+      alternateLocale: ["en_US", "ja_JP"],
+      description: "阅读账户访问、公平对局和规则执行相关条款。",
+      locale: "zh_CN",
+      siteName: "五子棋英雄",
+      title: "服务条款 | 五子棋英雄",
+      type: "website",
+      url: "/zh/terms",
+    });
+    expect(metadata.twitter).toMatchObject({
+      card: "summary",
+      description: "阅读账户访问、公平对局和规则执行相关条款。",
+      title: "服务条款 | 五子棋英雄",
+    });
+    expect(metadata.robots).toBeUndefined();
+  });
+
+  test("marks private utility routes noindex", async () => {
+    const metadata = await buildPageMetadata({
+      locale: "en",
+      page: "account",
+      path: "/account",
+    });
+
+    expect(metadata.title).toBe("Account Settings | Gomoku Heroes");
+    expect(metadata.robots).toEqual({ follow: false, index: false });
+  });
+
+  test("falls back to the default locale for unsupported locale params", async () => {
+    const metadata = await buildPageMetadata({
+      locale: "fr",
+      page: "human",
+      path: "/human",
+    });
+
+    expect(metadata.title).toBe("vs Human | Gomoku Heroes");
+    expect(metadata.alternates).toMatchObject({
+      canonical: "/en/human",
+    });
+    expect(metadata.openGraph).toMatchObject({
+      locale: "en_US",
+      siteName: "Gomoku Heroes",
+    });
+  });
+
+  test("formats dynamic public profile titles and encoded paths", async () => {
+    const metadata = await buildPageMetadata({
+      locale: "en",
+      page: "publicProfile",
+      path: "/profile/Ada%20Lovelace",
+      values: {
+        username: "Ada Lovelace",
+      },
+    });
+
+    expect(metadata.title).toBe("@Ada Lovelace's Profile | Gomoku Heroes");
+    expect(metadata.description).toBe(
+      "View @Ada Lovelace's Gomoku rating, match history, and achievements.",
+    );
+    expect(metadata.alternates).toMatchObject({
+      canonical: "/en/profile/Ada%20Lovelace",
+      languages: {
+        en: "/en/profile/Ada%20Lovelace",
+        ja: "/ja/profile/Ada%20Lovelace",
+        zh: "/zh/profile/Ada%20Lovelace",
+      },
+    });
+  });
+});
+
+describe("createPageMetadata", () => {
+  test("uses the static route path table for page canonical URLs", async () => {
+    const generateMetadata = createPageMetadata("leaderboard");
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "ja" }),
+    });
+
+    expect(metadata.title).toBe("ランキング | 五目並べヒーローズ");
+    expect(metadata.alternates).toMatchObject({
+      canonical: "/ja/leaderboard",
+    });
+  });
+
+  test("supports explicit route path overrides for alternate page entrypoints", async () => {
+    const generateMetadata = createPageMetadata("home", "/home");
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en" }),
+    });
+
+    expect(metadata.title).toBe("Home | Gomoku Heroes");
+    expect(metadata.alternates).toMatchObject({
+      canonical: "/en/home",
+    });
+  });
+});
+
+describe("getRootMetadataBase", () => {
+  const originalNextPublicAppUrl = process.env["NEXT_PUBLIC_APP_URL"];
+  const originalBetterAuthUrl = process.env["BETTER_AUTH_URL"];
+
+  afterEach(() => {
+    if (originalNextPublicAppUrl === undefined) {
+      delete process.env["NEXT_PUBLIC_APP_URL"];
+    } else {
+      process.env["NEXT_PUBLIC_APP_URL"] = originalNextPublicAppUrl;
+    }
+
+    if (originalBetterAuthUrl === undefined) {
+      delete process.env["BETTER_AUTH_URL"];
+    } else {
+      process.env["BETTER_AUTH_URL"] = originalBetterAuthUrl;
+    }
+  });
+
+  test("prefers NEXT_PUBLIC_APP_URL for absolute metadata composition", () => {
+    process.env["NEXT_PUBLIC_APP_URL"] = "https://gomoku.example";
+    process.env["BETTER_AUTH_URL"] = "https://auth.example";
+
+    expect(getRootMetadataBase().toString()).toBe("https://gomoku.example/");
+  });
+
+  test("falls back to localhost when configured metadata base is invalid", () => {
+    process.env["NEXT_PUBLIC_APP_URL"] = "not a url";
+    delete process.env["BETTER_AUTH_URL"];
+
+    expect(getRootMetadataBase().toString()).toBe("http://localhost:3000/");
+  });
+});

--- a/app/lib/page-metadata.ts
+++ b/app/lib/page-metadata.ts
@@ -1,0 +1,151 @@
+import "server-only";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+
+import { defaultLocale, locales, type Locale } from "@/i18n/config";
+import type { Messages } from "@/i18n/messages";
+
+type MetadataMessages = Messages["metadata"];
+export type MetadataPageKey = keyof MetadataMessages["pages"];
+type StaticMetadataPageKey = Exclude<MetadataPageKey, "publicProfile">;
+
+export type PageMetadataProps = {
+  params: Promise<{
+    locale: string;
+  }>;
+};
+
+const staticPagePaths = {
+  account: "/account",
+  ai: "/ai",
+  editProfile: "/profile/edit",
+  forgotPassword: "/forgot-password",
+  friends: "/friends",
+  home: "/",
+  human: "/human",
+  leaderboard: "/leaderboard",
+  login: "/login",
+  messages: "/messages",
+  privacy: "/privacy",
+  profile: "/profile",
+  resetPassword: "/reset-password",
+  signup: "/signup",
+  status: "/status",
+  terms: "/terms",
+  test: "/test",
+} as const satisfies Record<StaticMetadataPageKey, `/${string}`>;
+
+const noIndexPages = new Set<MetadataPageKey>([
+  "account",
+  "editProfile",
+  "forgotPassword",
+  "friends",
+  "messages",
+  "profile",
+  "resetPassword",
+  "status",
+  "test",
+]);
+
+const openGraphLocales = {
+  en: "en_US",
+  ja: "ja_JP",
+  zh: "zh_CN",
+} as const satisfies Record<Locale, string>;
+
+type BuildMetadataOptions = {
+  locale: string;
+  page: MetadataPageKey;
+  path: `/${string}`;
+  values?: Record<string, string>;
+  noIndex?: boolean;
+};
+
+export function createPageMetadata(
+  page: StaticMetadataPageKey,
+  path: `/${string}` = staticPagePaths[page],
+) {
+  return async function generateMetadata({ params }: PageMetadataProps): Promise<Metadata> {
+    const { locale } = await params;
+
+    return buildPageMetadata({
+      locale,
+      page,
+      path,
+    });
+  };
+}
+
+export async function buildPageMetadata({
+  locale,
+  page,
+  path,
+  values,
+  noIndex = noIndexPages.has(page),
+}: BuildMetadataOptions): Promise<Metadata> {
+  const resolvedLocale = resolveLocale(locale);
+  const t = await getTranslations({ locale: resolvedLocale, namespace: "metadata" });
+  const appName = t("appName");
+  const pageTitle = t(`pages.${page}.title`, values);
+  const description = t(`pages.${page}.description`, values);
+  const title = t("titleTemplate", {
+    appName,
+    pageTitle,
+  });
+  const alternates = getAlternates(path, resolvedLocale);
+
+  return {
+    alternates,
+    description,
+    openGraph: {
+      alternateLocale: locales
+        .filter((candidate) => candidate !== resolvedLocale)
+        .map((candidate) => openGraphLocales[candidate]),
+      description,
+      locale: openGraphLocales[resolvedLocale],
+      siteName: appName,
+      title,
+      type: "website",
+      url: alternates.canonical,
+    },
+    robots: noIndex ? { follow: false, index: false } : undefined,
+    title,
+    twitter: {
+      card: "summary",
+      description,
+      title,
+    },
+  };
+}
+
+export function getRootMetadataBase(): URL {
+  const configuredUrl =
+    process.env["NEXT_PUBLIC_APP_URL"] ?? process.env["BETTER_AUTH_URL"] ?? "http://localhost:3000";
+
+  try {
+    return new URL(configuredUrl);
+  } catch {
+    return new URL("http://localhost:3000");
+  }
+}
+
+export function getLocaleOpenGraphLocale(locale: string): string {
+  return openGraphLocales[resolveLocale(locale)];
+}
+
+function getAlternates(path: `/${string}`, locale: Locale) {
+  return {
+    canonical: getLocalizedPath(locale, path),
+    languages: Object.fromEntries(
+      locales.map((candidate) => [candidate, getLocalizedPath(candidate, path)]),
+    ),
+  };
+}
+
+function getLocalizedPath(locale: Locale, path: `/${string}`) {
+  return `/${locale}${path === "/" ? "" : path}`;
+}
+
+function resolveLocale(locale: string): Locale {
+  return locales.includes(locale as Locale) ? (locale as Locale) : defaultLocale;
+}

--- a/tests/e2e/smoke.e2e.ts
+++ b/tests/e2e/smoke.e2e.ts
@@ -20,7 +20,7 @@ test.setTimeout(90_000);
 test("home page renders the redesigned command center", async ({ page }) => {
   await gotoAppRoute(page, "/");
 
-  await expect(page).toHaveTitle(/Transcendence/);
+  await expect(page).toHaveTitle(/Home \| Gomoku Heroes/);
   await expect(page).toHaveURL(/\/en$/);
   await expect(page.getByRole("heading", { level: 1, name: "Master the board." })).toBeVisible();
   await expect(page.getByText("Ranked Snapshot", { exact: true })).toBeVisible();


### PR DESCRIPTION
## Summary

- Add a shared localized metadata helper for page titles, descriptions, Open Graph, Twitter cards, canonical links, alternate language links, and noindex handling.
- Wire every locale page route to its own localized metadata key, including dynamic public profile titles.
- Localize the sidebar brand/session/group labels and update the app name in Better Auth/email copy to Gomoku Heroes.

## Why

All routes inherited the same title, so browser tabs and share metadata did not reflect the current page or selected language. The new helper keeps the metadata policy in one place while page modules declare the page they represent.

## Validation

- `bun run typecheck`
- `bun run lint:js`
- `bun test app/lib/auth-email.test.ts`
- Browser smoke with the repo server helper for `/en`, `/ja`, `/zh`, `/en/login`, and `/en/terms` titles/sidebar brand text

Note: local `gh` is not installed in this environment, so the PR was opened through the GitHub app after pushing the branch with git.