### PR TITLE
[codex] Improve CI build caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,14 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Generate Prisma client
+        run: bun run prisma:generate
+
       - name: Check formatting
         run: bun run format:check
 
       - name: Lint code
         run: bun run lint
-
-      - name: Generate Prisma client
-        run: bun run prisma:generate
 
       - name: Apply database migrations
         run: bun run prisma:migrate:deploy
@@ -88,11 +88,20 @@ jobs:
           REDIS_SMOKE_URL: redis://:ci-redis-password@127.0.0.1:6379/0
         run: bun run test:redis:smoke
 
+      - name: Cache Next.js build output
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: >-
+            ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-${{ hashFiles('package.json', 'next.config.ts', 'tsconfig.json', 'postcss.config.mjs', 'components.json', 'app/**', 'public/**', 'shared/**', 'realtime/**', 'prisma/**', 'proxy.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-
+
       - name: Build app
         env:
           BETTER_AUTH_SECRET: ci_better_auth_secret_change_me_32_chars
           BETTER_AUTH_URL: http://localhost:3000
-        run: bun run build
+        run: bun run build:next
 
       - name: Install Playwright browsers
         run: bun run pw:install --with-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: bun run test:redis:smoke
 
       - name: Cache Next.js build output
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.next/cache
           key: >-

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev --hostname 0.0.0.0 --port 3000",
     "dev:realtime": "bun realtime/server.ts",
     "build": "bun run prisma:generate && next build",
+    "build:next": "next build",
     "typecheck": "next typegen && tsc --noEmit",
     "start": "next start --hostname 0.0.0.0 --port 3000",
     "start:realtime": "bun realtime/server.ts",


### PR DESCRIPTION
## Summary

- Generate the Prisma client before formatting and linting in CI so type-aware oxlint can resolve generated Prisma types.
- Add a Next.js `.next/cache` restore/save step before the app build.
- Add `build:next` and use it in CI to avoid running `prisma generate` twice.

## Validation

- `bun run format:check`
- `bun run prisma:generate && bun run lint:js`
- `CI=true bun run lint:js`
- `BETTER_AUTH_SECRET=ci_better_auth_secret_change_me_32_chars BETTER_AUTH_URL=http://localhost:3000 bun run build:next`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'workflow yaml parsed'"`

## Timing Notes

The first PR CI run is expected to populate the Next.js cache. Later runs should show whether restore/save overhead produces a net win for the app build step.