### PR TITLE
[codex] Show OAuth callback error feedback

### DIFF
--- a/app/[locale]/account/page.tsx
+++ b/app/[locale]/account/page.tsx
@@ -18,6 +18,7 @@ import {
   getCurrentSession,
   serializeUserForResponse,
 } from "@/lib/auth";
+import { getOAuthCallbackErrorKey, type OAuthCallbackErrorKey } from "@/lib/oauth-callback-errors";
 import { oauthProviderIds, type OAuthProviderId } from "@/lib/oauth-providers";
 import { createPageMetadata } from "@/lib/page-metadata";
 
@@ -80,19 +81,29 @@ type AccountPageProps = {
   params: Promise<{
     locale: string;
   }>;
+  searchParams?: Promise<{
+    error?: string | string[];
+  }>;
 };
 
 export const generateMetadata = createPageMetadata("account");
 
-export default function AccountPage({ params }: AccountPageProps) {
+export default function AccountPage({ params, searchParams }: AccountPageProps) {
   return (
     <Suspense fallback={<PageLoadingShell />}>
-      <AccountPageContent params={params} />
+      <AccountPageContent params={params} searchParams={searchParams} />
     </Suspense>
   );
 }
 
-async function AccountPageContent({ params }: AccountPageProps) {
+function getConnectionOAuthErrorMessage(
+  t: Awaited<ReturnType<typeof getTranslations>>,
+  errorKey: OAuthCallbackErrorKey,
+) {
+  return t(`settings.sections.connections.callbackErrors.${errorKey}`);
+}
+
+async function AccountPageContent({ params, searchParams }: AccountPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 
@@ -119,6 +130,10 @@ async function AccountPageContent({ params }: AccountPageProps) {
   if (!session && !loadError) {
     redirect({ href: "/login", locale });
   }
+
+  const query = (await searchParams) ?? {};
+  const oauthErrorKey = getOAuthCallbackErrorKey(query.error);
+  const oauthErrorMessage = oauthErrorKey ? getConnectionOAuthErrorMessage(t, oauthErrorKey) : null;
 
   return (
     <PageShell>
@@ -211,7 +226,11 @@ async function AccountPageContent({ params }: AccountPageProps) {
                 icon={KeyRound}
                 title={t("settings.sections.connections.title")}
               >
-                <OAuthAccountConnections locale={locale} providers={session.oauthProviders} />
+                <OAuthAccountConnections
+                  initialMessage={oauthErrorMessage}
+                  locale={locale}
+                  providers={session.oauthProviders}
+                />
               </Surface>
             </section>
 

--- a/app/[locale]/account/page.tsx
+++ b/app/[locale]/account/page.tsx
@@ -18,7 +18,7 @@ import {
   getCurrentSession,
   serializeUserForResponse,
 } from "@/lib/auth";
-import { getOAuthCallbackErrorKey, type OAuthCallbackErrorKey } from "@/lib/oauth-callback-errors";
+import { getOAuthCallbackErrorMessage } from "@/lib/oauth-callback-messages";
 import { oauthProviderIds, type OAuthProviderId } from "@/lib/oauth-providers";
 import { createPageMetadata } from "@/lib/page-metadata";
 
@@ -96,19 +96,20 @@ export default function AccountPage({ params, searchParams }: AccountPageProps) 
   );
 }
 
-function getConnectionOAuthErrorMessage(
-  t: Awaited<ReturnType<typeof getTranslations>>,
-  errorKey: OAuthCallbackErrorKey,
-) {
-  return t(`settings.sections.connections.callbackErrors.${errorKey}`);
-}
-
 async function AccountPageContent({ params, searchParams }: AccountPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const t = await getTranslations({ locale, namespace: "account" });
-  const format = await getFormatter({ locale });
+  const [t, format, oauthErrorMessage] = await Promise.all([
+    getTranslations({ locale, namespace: "account" }),
+    getFormatter({ locale }),
+    getOAuthCallbackErrorMessage({
+      keyPrefix: "settings.sections.connections.callbackErrors",
+      locale,
+      namespace: "account",
+      searchParams,
+    }),
+  ]);
   const settingsNavItems = [
     { id: "profile", label: t("settings.sidebar.profile") },
     { id: "security", label: t("settings.sidebar.security") },
@@ -130,10 +131,6 @@ async function AccountPageContent({ params, searchParams }: AccountPageProps) {
   if (!session && !loadError) {
     redirect({ href: "/login", locale });
   }
-
-  const query = (await searchParams) ?? {};
-  const oauthErrorKey = getOAuthCallbackErrorKey(query.error);
-  const oauthErrorMessage = oauthErrorKey ? getConnectionOAuthErrorMessage(t, oauthErrorKey) : null;
 
   return (
     <PageShell>

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -7,7 +7,7 @@ import { LoginForm } from "@/components/login-form";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
 import { getConfiguredOAuthProviders, getCurrentSessionIdentity } from "@/lib/auth";
-import { getOAuthCallbackErrorKey, type OAuthCallbackErrorKey } from "@/lib/oauth-callback-errors";
+import { getOAuthCallbackErrorMessage } from "@/lib/oauth-callback-messages";
 import { createPageMetadata } from "@/lib/page-metadata";
 
 type LoginPageProps = {
@@ -29,13 +29,6 @@ export default function LoginPage({ params, searchParams }: LoginPageProps) {
   );
 }
 
-function getOAuthErrorMessage(
-  t: Awaited<ReturnType<typeof getTranslations>>,
-  errorKey: OAuthCallbackErrorKey,
-) {
-  return t(`callbackErrors.${errorKey}`);
-}
-
 async function LoginPageContent({ params, searchParams }: LoginPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
@@ -46,13 +39,12 @@ async function LoginPageContent({ params, searchParams }: LoginPageProps) {
     redirect({ href: "/account", locale });
   }
 
-  const shared = await getTranslations({ locale, namespace: "auth.shared" });
-  const login = await getTranslations({ locale, namespace: "auth.login" });
-  const oauth = await getTranslations({ locale, namespace: "auth.oauth" });
+  const [shared, login, oauthErrorMessage] = await Promise.all([
+    getTranslations({ locale, namespace: "auth.shared" }),
+    getTranslations({ locale, namespace: "auth.login" }),
+    getOAuthCallbackErrorMessage({ locale, namespace: "auth.oauth", searchParams }),
+  ]);
   const oauthProviders = getConfiguredOAuthProviders();
-  const query = (await searchParams) ?? {};
-  const oauthErrorKey = getOAuthCallbackErrorKey(query.error);
-  const oauthErrorMessage = oauthErrorKey ? getOAuthErrorMessage(oauth, oauthErrorKey) : null;
 
   return (
     <PageShell wide={false}>

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -7,25 +7,36 @@ import { LoginForm } from "@/components/login-form";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { redirect } from "@/i18n/navigation";
 import { getConfiguredOAuthProviders, getCurrentSessionIdentity } from "@/lib/auth";
+import { getOAuthCallbackErrorKey, type OAuthCallbackErrorKey } from "@/lib/oauth-callback-errors";
 import { createPageMetadata } from "@/lib/page-metadata";
 
 type LoginPageProps = {
   params: Promise<{
     locale: string;
   }>;
+  searchParams?: Promise<{
+    error?: string | string[];
+  }>;
 };
 
 export const generateMetadata = createPageMetadata("login");
 
-export default function LoginPage({ params }: LoginPageProps) {
+export default function LoginPage({ params, searchParams }: LoginPageProps) {
   return (
     <Suspense fallback={<PageLoadingShell wide={false} />}>
-      <LoginPageContent params={params} />
+      <LoginPageContent params={params} searchParams={searchParams} />
     </Suspense>
   );
 }
 
-async function LoginPageContent({ params }: LoginPageProps) {
+function getOAuthErrorMessage(
+  t: Awaited<ReturnType<typeof getTranslations>>,
+  errorKey: OAuthCallbackErrorKey,
+) {
+  return t(`callbackErrors.${errorKey}`);
+}
+
+async function LoginPageContent({ params, searchParams }: LoginPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 
@@ -37,7 +48,11 @@ async function LoginPageContent({ params }: LoginPageProps) {
 
   const shared = await getTranslations({ locale, namespace: "auth.shared" });
   const login = await getTranslations({ locale, namespace: "auth.login" });
+  const oauth = await getTranslations({ locale, namespace: "auth.oauth" });
   const oauthProviders = getConfiguredOAuthProviders();
+  const query = (await searchParams) ?? {};
+  const oauthErrorKey = getOAuthCallbackErrorKey(query.error);
+  const oauthErrorMessage = oauthErrorKey ? getOAuthErrorMessage(oauth, oauthErrorKey) : null;
 
   return (
     <PageShell wide={false}>
@@ -88,7 +103,7 @@ async function LoginPageContent({ params }: LoginPageProps) {
             <p className="eyebrow">{shared("eyebrow")}</p>
             <h2 className="font-serif text-4xl leading-none font-black">{login("title")}</h2>
             <p className="mt-4 mb-7 leading-7 text-[var(--muted-text)]">{login("lede")}</p>
-            <LoginForm oauthProviders={oauthProviders} />
+            <LoginForm oauthErrorMessage={oauthErrorMessage} oauthProviders={oauthProviders} />
           </section>
         </div>
       </section>

--- a/app/[locale]/profile/edit/page.tsx
+++ b/app/[locale]/profile/edit/page.tsx
@@ -16,7 +16,7 @@ import {
   getCurrentSession,
   hasCredentialPassword,
 } from "@/lib/auth";
-import { getOAuthCallbackErrorKey, type OAuthCallbackErrorKey } from "@/lib/oauth-callback-errors";
+import { getOAuthCallbackErrorMessage } from "@/lib/oauth-callback-messages";
 import { oauthProviderIds, type OAuthProviderId } from "@/lib/oauth-providers";
 import { createPageMetadata } from "@/lib/page-metadata";
 
@@ -66,13 +66,6 @@ export default function EditProfilePage({ params, searchParams }: EditProfilePag
   );
 }
 
-function getConnectionOAuthErrorMessage(
-  t: Awaited<ReturnType<typeof getTranslations>>,
-  errorKey: OAuthCallbackErrorKey,
-) {
-  return t(`settings.sections.connections.callbackErrors.${errorKey}`);
-}
-
 async function EditProfilePageContent({ params, searchParams }: EditProfilePageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
@@ -84,17 +77,18 @@ async function EditProfilePageContent({ params, searchParams }: EditProfilePageP
     return null;
   }
 
-  const [accountT, oauthProviders, t, hasPassword] = await Promise.all([
+  const [accountT, oauthProviders, t, hasPassword, oauthErrorMessage] = await Promise.all([
     getTranslations({ locale, namespace: "account" }),
     loadOAuthProviders(),
     getTranslations({ locale, namespace: "profile.edit" }),
     hasCredentialPassword(sessionData.user.id),
+    getOAuthCallbackErrorMessage({
+      keyPrefix: "settings.sections.connections.callbackErrors",
+      locale,
+      namespace: "account",
+      searchParams,
+    }),
   ]);
-  const query = (await searchParams) ?? {};
-  const oauthErrorKey = getOAuthCallbackErrorKey(query.error);
-  const oauthErrorMessage = oauthErrorKey
-    ? getConnectionOAuthErrorMessage(accountT, oauthErrorKey)
-    : null;
 
   return (
     <PageShell>

--- a/app/[locale]/profile/edit/page.tsx
+++ b/app/[locale]/profile/edit/page.tsx
@@ -16,6 +16,7 @@ import {
   getCurrentSession,
   hasCredentialPassword,
 } from "@/lib/auth";
+import { getOAuthCallbackErrorKey, type OAuthCallbackErrorKey } from "@/lib/oauth-callback-errors";
 import { oauthProviderIds, type OAuthProviderId } from "@/lib/oauth-providers";
 import { createPageMetadata } from "@/lib/page-metadata";
 
@@ -25,6 +26,9 @@ import EditProfileForm from "./edit-form";
 type EditProfilePageProps = {
   params: Promise<{
     locale: string;
+  }>;
+  searchParams?: Promise<{
+    error?: string | string[];
   }>;
 };
 
@@ -54,15 +58,22 @@ async function loadOAuthProviders(): Promise<OAuthProviderConnection[]> {
   });
 }
 
-export default function EditProfilePage({ params }: EditProfilePageProps) {
+export default function EditProfilePage({ params, searchParams }: EditProfilePageProps) {
   return (
     <Suspense fallback={<PageLoadingShell />}>
-      <EditProfilePageContent params={params} />
+      <EditProfilePageContent params={params} searchParams={searchParams} />
     </Suspense>
   );
 }
 
-async function EditProfilePageContent({ params }: EditProfilePageProps) {
+function getConnectionOAuthErrorMessage(
+  t: Awaited<ReturnType<typeof getTranslations>>,
+  errorKey: OAuthCallbackErrorKey,
+) {
+  return t(`settings.sections.connections.callbackErrors.${errorKey}`);
+}
+
+async function EditProfilePageContent({ params, searchParams }: EditProfilePageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 
@@ -79,6 +90,11 @@ async function EditProfilePageContent({ params }: EditProfilePageProps) {
     getTranslations({ locale, namespace: "profile.edit" }),
     hasCredentialPassword(sessionData.user.id),
   ]);
+  const query = (await searchParams) ?? {};
+  const oauthErrorKey = getOAuthCallbackErrorKey(query.error);
+  const oauthErrorMessage = oauthErrorKey
+    ? getConnectionOAuthErrorMessage(accountT, oauthErrorKey)
+    : null;
 
   return (
     <PageShell>
@@ -131,6 +147,7 @@ async function EditProfilePageContent({ params }: EditProfilePageProps) {
           >
             <OAuthAccountConnections
               callbackPath="/profile/edit"
+              initialMessage={oauthErrorMessage}
               locale={locale}
               providers={oauthProviders}
             />

--- a/app/[locale]/signup/page.tsx
+++ b/app/[locale]/signup/page.tsx
@@ -7,25 +7,36 @@ import { PageLoadingShell } from "@/components/page-loading-shell";
 import { SignupForm } from "@/components/signup-form";
 import { redirect } from "@/i18n/navigation";
 import { getConfiguredOAuthProviders, getCurrentSessionIdentity } from "@/lib/auth";
+import { getOAuthCallbackErrorKey, type OAuthCallbackErrorKey } from "@/lib/oauth-callback-errors";
 import { createPageMetadata } from "@/lib/page-metadata";
 
 type SignupPageProps = {
   params: Promise<{
     locale: string;
   }>;
+  searchParams?: Promise<{
+    error?: string | string[];
+  }>;
 };
 
 export const generateMetadata = createPageMetadata("signup");
 
-export default function SignupPage({ params }: SignupPageProps) {
+export default function SignupPage({ params, searchParams }: SignupPageProps) {
   return (
     <Suspense fallback={<PageLoadingShell wide={false} />}>
-      <SignupPageContent params={params} />
+      <SignupPageContent params={params} searchParams={searchParams} />
     </Suspense>
   );
 }
 
-async function SignupPageContent({ params }: SignupPageProps) {
+function getOAuthErrorMessage(
+  t: Awaited<ReturnType<typeof getTranslations>>,
+  errorKey: OAuthCallbackErrorKey,
+) {
+  return t(`callbackErrors.${errorKey}`);
+}
+
+async function SignupPageContent({ params, searchParams }: SignupPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 
@@ -37,7 +48,11 @@ async function SignupPageContent({ params }: SignupPageProps) {
 
   const shared = await getTranslations({ locale, namespace: "auth.shared" });
   const signup = await getTranslations({ locale, namespace: "auth.signup" });
+  const oauth = await getTranslations({ locale, namespace: "auth.oauth" });
   const oauthProviders = getConfiguredOAuthProviders();
+  const query = (await searchParams) ?? {};
+  const oauthErrorKey = getOAuthCallbackErrorKey(query.error);
+  const oauthErrorMessage = oauthErrorKey ? getOAuthErrorMessage(oauth, oauthErrorKey) : null;
 
   return (
     <PageShell wide={false}>
@@ -47,7 +62,7 @@ async function SignupPageContent({ params }: SignupPageProps) {
             <p className="eyebrow">{shared("eyebrow")}</p>
             <h1 className="font-serif text-4xl leading-none font-black">{signup("title")}</h1>
             <p className="mt-4 mb-7 leading-7 text-[var(--muted-text)]">{signup("lede")}</p>
-            <SignupForm oauthProviders={oauthProviders} />
+            <SignupForm oauthErrorMessage={oauthErrorMessage} oauthProviders={oauthProviders} />
           </section>
         </div>
 

--- a/app/[locale]/signup/page.tsx
+++ b/app/[locale]/signup/page.tsx
@@ -7,7 +7,7 @@ import { PageLoadingShell } from "@/components/page-loading-shell";
 import { SignupForm } from "@/components/signup-form";
 import { redirect } from "@/i18n/navigation";
 import { getConfiguredOAuthProviders, getCurrentSessionIdentity } from "@/lib/auth";
-import { getOAuthCallbackErrorKey, type OAuthCallbackErrorKey } from "@/lib/oauth-callback-errors";
+import { getOAuthCallbackErrorMessage } from "@/lib/oauth-callback-messages";
 import { createPageMetadata } from "@/lib/page-metadata";
 
 type SignupPageProps = {
@@ -29,13 +29,6 @@ export default function SignupPage({ params, searchParams }: SignupPageProps) {
   );
 }
 
-function getOAuthErrorMessage(
-  t: Awaited<ReturnType<typeof getTranslations>>,
-  errorKey: OAuthCallbackErrorKey,
-) {
-  return t(`callbackErrors.${errorKey}`);
-}
-
 async function SignupPageContent({ params, searchParams }: SignupPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
@@ -46,13 +39,12 @@ async function SignupPageContent({ params, searchParams }: SignupPageProps) {
     redirect({ href: "/account", locale });
   }
 
-  const shared = await getTranslations({ locale, namespace: "auth.shared" });
-  const signup = await getTranslations({ locale, namespace: "auth.signup" });
-  const oauth = await getTranslations({ locale, namespace: "auth.oauth" });
+  const [shared, signup, oauthErrorMessage] = await Promise.all([
+    getTranslations({ locale, namespace: "auth.shared" }),
+    getTranslations({ locale, namespace: "auth.signup" }),
+    getOAuthCallbackErrorMessage({ locale, namespace: "auth.oauth", searchParams }),
+  ]);
   const oauthProviders = getConfiguredOAuthProviders();
-  const query = (await searchParams) ?? {};
-  const oauthErrorKey = getOAuthCallbackErrorKey(query.error);
-  const oauthErrorMessage = oauthErrorKey ? getOAuthErrorMessage(oauth, oauthErrorKey) : null;
 
   return (
     <PageShell wide={false}>

--- a/app/components/login-form.tsx
+++ b/app/components/login-form.tsx
@@ -13,7 +13,12 @@ import { authValidationLimits } from "@/lib/validation/auth-profile-limits";
 import { initialLoginActionState } from "../auth-action-state";
 import { loginAction } from "../auth-actions";
 
-export function LoginForm({ oauthProviders }: { oauthProviders: OAuthProviderId[] }) {
+type LoginFormProps = {
+  oauthErrorMessage?: string | null;
+  oauthProviders: OAuthProviderId[];
+};
+
+export function LoginForm({ oauthErrorMessage = null, oauthProviders }: LoginFormProps) {
   const locale = useLocale();
   const shared = useTranslations("auth.shared");
   const login = useTranslations("auth.login");
@@ -98,6 +103,7 @@ export function LoginForm({ oauthProviders }: { oauthProviders: OAuthProviderId[
       <OAuthProviderButtons
         callbackPath={`/${locale}/account`}
         errorPath={`/${locale}/login`}
+        initialErrorMessage={oauthErrorMessage}
         providers={oauthProviders}
       />
 

--- a/app/components/oauth-account-connections.tsx
+++ b/app/components/oauth-account-connections.tsx
@@ -3,8 +3,9 @@
 import { Loader2, Unlink } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { OAuthFeedbackAlert } from "@/components/oauth-feedback-alert";
 import { OAuthSocialButton } from "@/components/oauth-social-button";
 import { authClient } from "@/lib/auth-client";
 import { oauthProviderLabels, type OAuthProviderId } from "@/lib/oauth-providers";
@@ -19,19 +20,25 @@ export type OAuthProviderConnection = {
 
 type OAuthAccountConnectionsProps = {
   callbackPath?: string;
+  initialMessage?: string | null;
   locale: string;
   providers: OAuthProviderConnection[];
 };
 
 export function OAuthAccountConnections({
   callbackPath = "/account",
+  initialMessage = null,
   locale,
   providers,
 }: OAuthAccountConnectionsProps) {
   const router = useRouter();
   const t = useTranslations("account.settings.sections.connections");
   const [pendingProvider, setPendingProvider] = useState<OAuthProviderId | null>(null);
-  const [message, setMessage] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(initialMessage);
+
+  useEffect(() => {
+    setMessage(initialMessage);
+  }, [initialMessage]);
 
   async function connectProvider(provider: OAuthProviderConnection) {
     setPendingProvider(provider.id);
@@ -135,11 +142,7 @@ export function OAuthAccountConnections({
         })}
       </div>
 
-      {message ? (
-        <p className="error-text" role="alert" aria-live="polite">
-          {message}
-        </p>
-      ) : null}
+      {message ? <OAuthFeedbackAlert>{message}</OAuthFeedbackAlert> : null}
     </div>
   );
 }

--- a/app/components/oauth-feedback-alert.tsx
+++ b/app/components/oauth-feedback-alert.tsx
@@ -1,0 +1,15 @@
+import { CircleAlert } from "lucide-react";
+import type { ReactNode } from "react";
+
+type OAuthFeedbackAlertProps = {
+  children: ReactNode;
+};
+
+export function OAuthFeedbackAlert({ children }: OAuthFeedbackAlertProps) {
+  return (
+    <p className="oauth-feedback-alert" role="alert" aria-live="polite">
+      <CircleAlert aria-hidden="true" className="size-4 shrink-0" />
+      <span>{children}</span>
+    </p>
+  );
+}

--- a/app/components/oauth-provider-buttons.tsx
+++ b/app/components/oauth-provider-buttons.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { OAuthFeedbackAlert } from "@/components/oauth-feedback-alert";
 import { OAuthSocialButton } from "@/components/oauth-social-button";
 import { authClient } from "@/lib/auth-client";
 import { oauthProviderLabels, type OAuthProviderId } from "@/lib/oauth-providers";
@@ -10,17 +11,23 @@ import { oauthProviderLabels, type OAuthProviderId } from "@/lib/oauth-providers
 type OAuthProviderButtonsProps = {
   callbackPath: string;
   errorPath: string;
+  initialErrorMessage?: string | null;
   providers: OAuthProviderId[];
 };
 
 export function OAuthProviderButtons({
   callbackPath,
   errorPath,
+  initialErrorMessage = null,
   providers,
 }: OAuthProviderButtonsProps) {
   const t = useTranslations("auth.oauth");
   const [pendingProvider, setPendingProvider] = useState<OAuthProviderId | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(initialErrorMessage);
+
+  useEffect(() => {
+    setErrorMessage(initialErrorMessage);
+  }, [initialErrorMessage]);
 
   if (!providers.length) {
     return null;
@@ -61,11 +68,7 @@ export function OAuthProviderButtons({
         );
       })}
 
-      {errorMessage ? (
-        <p className="error-text" role="alert" aria-live="polite">
-          {errorMessage}
-        </p>
-      ) : null}
+      {errorMessage ? <OAuthFeedbackAlert>{errorMessage}</OAuthFeedbackAlert> : null}
     </div>
   );
 }

--- a/app/components/signup-form.tsx
+++ b/app/components/signup-form.tsx
@@ -13,7 +13,12 @@ import { authValidationLimits } from "@/lib/validation/auth-profile-limits";
 import { initialSignupActionState } from "../auth-action-state";
 import { signupAction } from "../auth-actions";
 
-export function SignupForm({ oauthProviders }: { oauthProviders: OAuthProviderId[] }) {
+type SignupFormProps = {
+  oauthErrorMessage?: string | null;
+  oauthProviders: OAuthProviderId[];
+};
+
+export function SignupForm({ oauthErrorMessage = null, oauthProviders }: SignupFormProps) {
   const locale = useLocale();
   const shared = useTranslations("auth.shared");
   const signup = useTranslations("auth.signup");
@@ -141,6 +146,7 @@ export function SignupForm({ oauthProviders }: { oauthProviders: OAuthProviderId
       <OAuthProviderButtons
         callbackPath={`/${locale}/account`}
         errorPath={`/${locale}/signup`}
+        initialErrorMessage={oauthErrorMessage}
         providers={oauthProviders}
       />
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -563,6 +563,21 @@ a.command-panel {
   color: var(--danger);
 }
 
+.oauth-feedback-alert {
+  display: flex;
+  gap: 0.55rem;
+  align-items: flex-start;
+  padding: 0.85rem 0.95rem;
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 800;
+  line-height: 1.45;
+  color: var(--danger);
+  background: rgb(216 60 52 / 14%);
+  border: 1px solid rgb(216 60 52 / 36%);
+  border-radius: 0.5rem;
+}
+
 .oauth-social-button {
   display: inline-flex;
   align-items: center;

--- a/app/i18n/messages/en.ts
+++ b/app/i18n/messages/en.ts
@@ -221,6 +221,16 @@ export const messages = {
     oauth: {
       continueWithProvider: "Sign in with {provider}",
       startError: "Unable to start {provider} sign-in right now.",
+      callbackErrors: {
+        accountAlreadyLinked: "That OAuth account is already connected to another player.",
+        accountNotLinked:
+          "OAuth sign-in was blocked because this email belongs to an existing account. Sign in with email and password first, then connect the matching provider.",
+        emailMismatch:
+          "OAuth sign-in was blocked because the provider email does not match this account.",
+        generic: "OAuth sign-in could not be completed. Try again or choose another account.",
+        unableToLink:
+          "OAuth sign-in could not be linked to this account. Try again or choose another provider account.",
+      },
     },
     login: {
       title: "Welcome back.",
@@ -390,6 +400,17 @@ export const messages = {
           connectError: "Unable to connect {provider} right now.",
           disconnectError: "Unable to disconnect {provider} right now.",
           lastAccount: "Add another sign-in method before disconnecting this one.",
+          callbackErrors: {
+            accountAlreadyLinked: "That OAuth account is already connected to another player.",
+            accountNotLinked:
+              "OAuth connection was blocked because this provider account cannot be linked automatically.",
+            emailMismatch:
+              "OAuth connection blocked: the provider email does not match this account.",
+            generic:
+              "OAuth connection could not be completed. Try again or choose another provider account.",
+            unableToLink:
+              "OAuth connection could not be linked to this account. Try again or choose another provider account.",
+          },
         },
         language: {
           eyebrow: "Language",

--- a/app/i18n/messages/ja.ts
+++ b/app/i18n/messages/ja.ts
@@ -219,6 +219,17 @@ export const messages = {
     oauth: {
       continueWithProvider: "{provider} でログイン",
       startError: "{provider} ログインを開始できません。",
+      callbackErrors: {
+        accountAlreadyLinked: "その OAuth アカウントは別のプレイヤーに連携済みです。",
+        accountNotLinked:
+          "このメールは既存アカウントに属しているため OAuth ログインを停止しました。先にメールとパスワードでログインし、同じメールのプロバイダーを連携してください。",
+        emailMismatch:
+          "プロバイダーのメールがこのアカウントと一致しないため OAuth ログインを停止しました。",
+        generic:
+          "OAuth ログインを完了できませんでした。もう一度試すか、別のアカウントを選んでください。",
+        unableToLink:
+          "OAuth ログインをこのアカウントに連携できませんでした。もう一度試すか、別のプロバイダーアカウントを選んでください。",
+      },
     },
     login: {
       title: "おかえりなさい。",
@@ -391,6 +402,17 @@ export const messages = {
           connectError: "{provider} を連携できません。",
           disconnectError: "{provider} の連携を解除できません。",
           lastAccount: "解除する前に別のログイン方法を追加してください。",
+          callbackErrors: {
+            accountAlreadyLinked: "その OAuth アカウントは別のプレイヤーに連携済みです。",
+            accountNotLinked:
+              "このプロバイダーアカウントは自動連携できないため OAuth 連携を停止しました。",
+            emailMismatch:
+              "OAuth 連携を停止しました。プロバイダーのメールがこのアカウントと一致しません。",
+            generic:
+              "OAuth 連携を完了できませんでした。もう一度試すか、別のプロバイダーアカウントを選んでください。",
+            unableToLink:
+              "OAuth 連携をこのアカウントに保存できませんでした。もう一度試すか、別のプロバイダーアカウントを選んでください。",
+          },
         },
         language: {
           eyebrow: "言語",

--- a/app/i18n/messages/zh.ts
+++ b/app/i18n/messages/zh.ts
@@ -219,6 +219,14 @@ export const messages = {
     oauth: {
       continueWithProvider: "使用 {provider} 登录",
       startError: "现在无法开始 {provider} 登录。",
+      callbackErrors: {
+        accountAlreadyLinked: "该 OAuth 账户已连接到另一位玩家。",
+        accountNotLinked:
+          "由于该邮箱属于现有账户，OAuth 登录已被阻止。请先使用邮箱和密码登录，然后连接邮箱一致的提供商。",
+        emailMismatch: "由于提供商邮箱与此账户不一致，OAuth 登录已被阻止。",
+        generic: "无法完成 OAuth 登录。请重试或选择另一个账户。",
+        unableToLink: "无法将 OAuth 登录连接到此账户。请重试或选择另一个提供商账户。",
+      },
     },
     login: {
       title: "欢迎回来。",
@@ -387,6 +395,13 @@ export const messages = {
           connectError: "现在无法连接 {provider}。",
           disconnectError: "现在无法断开 {provider}。",
           lastAccount: "断开前请先添加另一种登录方式。",
+          callbackErrors: {
+            accountAlreadyLinked: "该 OAuth 账户已连接到另一位玩家。",
+            accountNotLinked: "由于无法自动连接此提供商账户，OAuth 连接已被阻止。",
+            emailMismatch: "OAuth 连接已被阻止：提供商邮箱与此账户不一致。",
+            generic: "无法完成 OAuth 连接。请重试或选择另一个提供商账户。",
+            unableToLink: "无法将 OAuth 连接保存到此账户。请重试或选择另一个提供商账户。",
+          },
         },
         language: {
           eyebrow: "语言",

--- a/app/lib/oauth-callback-errors.test.ts
+++ b/app/lib/oauth-callback-errors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { getOAuthCallbackErrorKey } from "./oauth-callback-errors";
+
+describe("getOAuthCallbackErrorKey", () => {
+  test("ignores missing or empty callback error values", () => {
+    expect(getOAuthCallbackErrorKey(undefined)).toBeNull();
+    expect(getOAuthCallbackErrorKey("")).toBeNull();
+    expect(getOAuthCallbackErrorKey("   ")).toBeNull();
+  });
+
+  test("maps Better Auth OAuth linking failures to UI message keys", () => {
+    expect(getOAuthCallbackErrorKey("email_doesn't_match")).toBe("emailMismatch");
+    expect(getOAuthCallbackErrorKey("account_not_linked")).toBe("accountNotLinked");
+    expect(getOAuthCallbackErrorKey("account_already_linked_to_different_user")).toBe(
+      "accountAlreadyLinked",
+    );
+    expect(getOAuthCallbackErrorKey("unable_to_link_account")).toBe("unableToLink");
+  });
+
+  test("uses the first query value and falls back to a generic OAuth message", () => {
+    expect(getOAuthCallbackErrorKey(["LINKING_DIFFERENT_EMAILS_NOT_ALLOWED"])).toBe(
+      "emailMismatch",
+    );
+    expect(getOAuthCallbackErrorKey(["no_code", "email_doesn't_match"])).toBe("generic");
+  });
+});

--- a/app/lib/oauth-callback-errors.ts
+++ b/app/lib/oauth-callback-errors.ts
@@ -1,0 +1,33 @@
+export type OAuthCallbackErrorKey =
+  | "accountAlreadyLinked"
+  | "accountNotLinked"
+  | "emailMismatch"
+  | "generic"
+  | "unableToLink";
+
+type SearchParamValue = string | string[] | undefined;
+
+const oauthCallbackErrorKeys: Record<string, OAuthCallbackErrorKey> = {
+  account_already_linked_to_different_user: "accountAlreadyLinked",
+  account_not_linked: "accountNotLinked",
+  "email_doesn't_match": "emailMismatch",
+  email_doesnt_match: "emailMismatch",
+  linking_different_emails_not_allowed: "emailMismatch",
+  linking_failed: "unableToLink",
+  linking_not_allowed: "unableToLink",
+  unable_to_link_account: "unableToLink",
+};
+
+function getFirstSearchParam(value: SearchParamValue): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function getOAuthCallbackErrorKey(value: SearchParamValue): OAuthCallbackErrorKey | null {
+  const error = getFirstSearchParam(value)?.trim().toLowerCase();
+
+  if (!error) {
+    return null;
+  }
+
+  return oauthCallbackErrorKeys[error] ?? "generic";
+}

--- a/app/lib/oauth-callback-messages.ts
+++ b/app/lib/oauth-callback-messages.ts
@@ -1,0 +1,36 @@
+import "server-only";
+import { getTranslations } from "next-intl/server";
+
+import { getOAuthCallbackErrorKey } from "./oauth-callback-errors";
+
+type OAuthCallbackSearchParams = Promise<
+  | {
+      error?: string | string[];
+    }
+  | undefined
+>;
+
+type OAuthCallbackErrorMessageOptions = {
+  keyPrefix?: string;
+  locale: string;
+  namespace: "account" | "auth.oauth";
+  searchParams?: OAuthCallbackSearchParams;
+};
+
+export async function getOAuthCallbackErrorMessage({
+  keyPrefix = "callbackErrors",
+  locale,
+  namespace,
+  searchParams,
+}: OAuthCallbackErrorMessageOptions): Promise<string | null> {
+  const query = (await searchParams) ?? {};
+  const errorKey = getOAuthCallbackErrorKey(query.error);
+
+  if (!errorKey) {
+    return null;
+  }
+
+  const t = await getTranslations({ locale, namespace });
+
+  return t(`${keyPrefix}.${errorKey}`);
+}

--- a/tests/e2e/oauth-social-login.e2e.ts
+++ b/tests/e2e/oauth-social-login.e2e.ts
@@ -13,12 +13,19 @@ test("configured OAuth providers render branded buttons on auth pages", async ({
     await gotoAppRoute(page, route);
 
     for (const provider of ["Google", "GitHub"]) {
-      const button = page.getByRole("button", { name: `Sign in with ${provider}` });
+      const button = page
+        .getByRole("button", { name: `Sign in with ${provider}` })
+        .filter({ visible: true });
 
       await expect(button).toBeVisible();
       await expect(button).toBeEnabled();
       await expectCenteredButtonContent(button);
     }
+
+    await gotoAppRoute(page, `${route}?error=account_not_linked`);
+    await expect(
+      page.getByRole("alert").filter({ hasText: "OAuth sign-in was blocked", visible: true }),
+    ).toBeVisible();
   }
 });
 
@@ -30,12 +37,21 @@ test("account connections show connect, connected, and disconnect OAuth states",
   try {
     await gotoAppRoute(page, "/account");
 
-    const githubConnect = page.getByRole("button", { name: "Connect GitHub" });
-    const googleConnect = page.getByRole("button", { name: "Connect Google" });
+    const githubConnect = page
+      .getByRole("button", { name: "Connect GitHub" })
+      .filter({ visible: true });
+    const googleConnect = page
+      .getByRole("button", { name: "Connect Google" })
+      .filter({ visible: true });
 
     await expect(githubConnect).toBeEnabled();
     await expect(googleConnect).toBeEnabled();
     await expect(page.getByRole("button", { name: "Disconnect" })).toHaveCount(0);
+
+    await gotoAppRoute(page, "/account?error=email_doesn%27t_match");
+    await expect(
+      page.getByRole("alert").filter({ hasText: "provider email does not match", visible: true }),
+    ).toBeVisible();
 
     await prisma.account.create({
       data: {
@@ -48,14 +64,16 @@ test("account connections show connect, connected, and disconnect OAuth states",
 
     await gotoAppRoute(page, "/account");
 
-    const googleConnected = page.getByRole("button", { name: "Google connected" });
+    const googleConnected = page
+      .getByRole("button", { name: "Google connected" })
+      .filter({ visible: true });
 
     await expect(githubConnect).toBeEnabled();
     await expect(page.getByRole("button", { name: "Connect Google" })).toHaveCount(0);
     await expect(googleConnected).toBeDisabled();
     await expectCenteredButtonContent(googleConnected);
 
-    const disconnect = page.getByRole("button", { name: "Disconnect" });
+    const disconnect = page.getByRole("button", { name: "Disconnect" }).filter({ visible: true });
 
     await expect(disconnect).toHaveCount(1);
     await expect(disconnect).toBeEnabled();

--- a/tests/e2e/oauth-social-login.e2e.ts
+++ b/tests/e2e/oauth-social-login.e2e.ts
@@ -21,7 +21,11 @@ test("configured OAuth providers render branded buttons on auth pages", async ({
       await expect(button).toBeEnabled();
       await expectCenteredButtonContent(button);
     }
+  }
+});
 
+test("auth pages show OAuth callback errors", async ({ page }) => {
+  for (const route of ["/login", "/signup"]) {
     await gotoAppRoute(page, `${route}?error=account_not_linked`);
     await expect(
       page.getByRole("alert").filter({ hasText: "OAuth sign-in was blocked", visible: true }),
@@ -48,11 +52,6 @@ test("account connections show connect, connected, and disconnect OAuth states",
     await expect(googleConnect).toBeEnabled();
     await expect(page.getByRole("button", { name: "Disconnect" })).toHaveCount(0);
 
-    await gotoAppRoute(page, "/account?error=email_doesn%27t_match");
-    await expect(
-      page.getByRole("alert").filter({ hasText: "provider email does not match", visible: true }),
-    ).toBeVisible();
-
     await prisma.account.create({
       data: {
         accountId: `mock-google-${user.token}`,
@@ -78,6 +77,21 @@ test("account connections show connect, connected, and disconnect OAuth states",
     await expect(disconnect).toHaveCount(1);
     await expect(disconnect).toBeEnabled();
     await expectNoDocumentOverflow(page, "/account");
+  } finally {
+    await cleanupTestUsers([user.username]);
+  }
+});
+
+test("account pages show OAuth callback errors", async ({ page }, testInfo) => {
+  const user = await createAndSignInTestUser(page, testInfo);
+
+  try {
+    for (const route of ["/account", "/profile/edit"]) {
+      await gotoAppRoute(page, `${route}?error=email_doesn%27t_match`);
+      await expect(
+        page.getByRole("alert").filter({ hasText: "provider email does not match", visible: true }),
+      ).toBeVisible();
+    }
   } finally {
     await cleanupTestUsers([user.username]);
   }


### PR DESCRIPTION
## Summary
- Reads Better Auth OAuth callback errors from localized route search params.
- Maps known OAuth/linking failures to stable localized UI messages.
- Shows persistent inline feedback near OAuth actions on login, signup, account settings, and profile edit.
- Adds unit and E2E coverage for the callback feedback paths.

## Root Cause
Better Auth redirects back to the configured error callback URL with an `error` query parameter, but the app did not render that callback state anywhere. Users landed back on the auth/account page with no visible explanation.

## Validation
- `bun test app/lib/oauth-callback-errors.test.ts app/auth-actions.test.ts`
- `bun run typecheck`
- `bun run lint:js`
- `bun run lint:css`
- `bunx --bun oxfmt --check ...`
- Browser helper check for `/en/login?error=account_not_linked`

Note: full OAuth E2E could not complete locally because PostgreSQL was not reachable at `127.0.0.1:5432`, and the Next dev overlay emitted CSP console errors in dev mode.