### PR TITLE
[codex] Enable additional oxlint plugins

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,7 +7,21 @@
   "globals": {
     "Bun": "readonly"
   },
-  "plugins": ["unicorn", "typescript", "oxc", "react", "import", "nextjs", "node"],
+  "plugins": [
+    "eslint",
+    "unicorn",
+    "typescript",
+    "oxc",
+    "react",
+    "react-perf",
+    "import",
+    "nextjs",
+    "jsx-a11y",
+    "promise",
+    "node",
+    "jsdoc",
+    "jest"
+  ],
   "ignorePatterns": ["generated/**", ".next/**", "node_modules/**", "next-env.d.ts"],
   "options": {
     "typeAware": true


### PR DESCRIPTION
## Summary

- Expanded `.oxlintrc.json` to include the remaining relevant built-in Oxlint plugins for this Next.js/React/Bun project.
- Enabled Jest-family rules for the existing `bun:test` suite, which uses Jest-compatible test APIs.
- Left Vue and Vitest plugins disabled because this repo does not use those ecosystems.

## Impact

This broadens lint coverage to include accessibility, promise, JSDoc, React performance, and test-rule diagnostics. The first lint run now surfaces existing `jsx-a11y` warnings that can be addressed in follow-up work.

## Validation

- `bun run lint:js` passes with 36 `jsx-a11y` warnings from newly enabled rules.
- `bunx --bun oxfmt --check .oxlintrc.json` passes.