### PR TITLE
[codex] Run Brooks sweep and security fixes

### DIFF
--- a/.brooks-lint-history.json
+++ b/.brooks-lint-history.json
@@ -1,0 +1,13 @@
+[
+  {
+    "date": "2026-05-29",
+    "mode": "Full Sweep",
+    "score": 100,
+    "findings": {
+      "critical": 0,
+      "warning": 0,
+      "suggestion": 0
+    },
+    "scope": "full repository"
+  }
+]

--- a/app/[locale]/profile/[username]/page.tsx
+++ b/app/[locale]/profile/[username]/page.tsx
@@ -1,14 +1,23 @@
-import { Activity, Award, Swords, Trophy, TrendingUp, TrendingDown } from "lucide-react";
+import {
+  Activity,
+  Award,
+  LockKeyhole,
+  Swords,
+  Trophy,
+  TrendingDown,
+  TrendingUp,
+} from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
-import { MatchResult, MatchStatus, Role } from "@/../generated/prisma/enums";
+import { MatchResult, MatchStatus, ProfileVisibility, Role } from "@/../generated/prisma/enums";
 import { Badge, MetricCard, PageShell, Surface } from "@/components/gomoku-ui";
 import { PageLoadingShell } from "@/components/page-loading-shell";
 import { getCurrentSessionIdentity } from "@/lib/auth";
 import { buildPageMetadata } from "@/lib/page-metadata";
 import { prisma } from "@/lib/prisma";
+import { canViewProfileDetails, type ProfileRelationshipState } from "@/lib/profile-visibility";
 import { getProfileStatsForUser } from "@/lib/stats/profile-stats";
 
 import ProfileActions from "./profile-actions";
@@ -143,6 +152,13 @@ async function PublicProfilePageContent({ params, searchParams }: ProfilePagePro
 
   const userProfile = await prisma.user.findUnique({
     where: { username },
+    include: {
+      profile: {
+        select: {
+          visibility: true,
+        },
+      },
+    },
   });
 
   if (!userProfile) {
@@ -152,8 +168,7 @@ async function PublicProfilePageContent({ params, searchParams }: ProfilePagePro
   const session = await getCurrentSessionIdentity();
   const loggedInUserId = session?.user?.id;
 
-  let relationshipState: "NOT_FRIENDS" | "FRIENDS" | "REQUEST_SENT" | "REQUEST_RECEIVED" | "SELF" =
-    "NOT_FRIENDS";
+  let relationshipState: ProfileRelationshipState = "NOT_FRIENDS";
 
   if (loggedInUserId) {
     if (loggedInUserId === userProfile.id) {
@@ -182,25 +197,33 @@ async function PublicProfilePageContent({ params, searchParams }: ProfilePagePro
     }
   }
 
+  const canViewDetails = canViewProfileDetails({
+    relationshipState,
+    visibility: userProfile.profile?.visibility ?? ProfileVisibility.PUBLIC,
+  });
+
   const headToHeadStatsPromise =
-    loggedInUserId && loggedInUserId !== userProfile.id
+    canViewDetails && loggedInUserId && loggedInUserId !== userProfile.id
       ? getHeadToHeadStats(loggedInUserId, userProfile.id)
       : Promise.resolve(null);
-  const [profileStats, headToHead] = await Promise.all([
-    getProfileStatsForUser(userProfile.id, {
-      recentMatchesLimit: 10,
-      recentMatchesPage,
-    }),
-    headToHeadStatsPromise,
-  ]);
+  const [profileStats, headToHead] = canViewDetails
+    ? await Promise.all([
+        getProfileStatsForUser(userProfile.id, {
+          recentMatchesLimit: 10,
+          recentMatchesPage,
+        }),
+        headToHeadStatsPromise,
+      ])
+    : [null, null];
 
-  const rating = profileStats.stats.rating ?? t("page.stats.unrated");
-  const winRate = profileStats.stats.winRate;
-  const wins = profileStats.stats.wins;
-  const losses = profileStats.stats.losses;
-  const unlockedAchievements = profileStats.achievements.filter((achievement) =>
-    Boolean(achievement.completedAt),
-  );
+  const hiddenValue = t("publicPage.private.value");
+  const rating =
+    profileStats?.stats.rating ?? (canViewDetails ? t("page.stats.unrated") : hiddenValue);
+  const winRate = profileStats?.stats.winRate ?? hiddenValue;
+  const wins = profileStats?.stats.wins ?? hiddenValue;
+  const losses = profileStats?.stats.losses ?? hiddenValue;
+  const unlockedAchievements =
+    profileStats?.achievements.filter((achievement) => Boolean(achievement.completedAt)) ?? [];
 
   const isRevealed = relationshipState === "FRIENDS" || relationshipState === "SELF";
 
@@ -251,11 +274,15 @@ async function PublicProfilePageContent({ params, searchParams }: ProfilePagePro
             <MetricCard icon={TrendingDown} label={t("stats.losses")} tone="red" value={losses} />
           </div>
 
-          <PublicMatchHistory
-            matches={profileStats.recentMatches}
-            page={profileStats.recentMatchesPagination.page}
-            totalPages={profileStats.recentMatchesPagination.totalPages}
-          />
+          {profileStats ? (
+            <PublicMatchHistory
+              matches={profileStats.recentMatches}
+              page={profileStats.recentMatchesPagination.page}
+              totalPages={profileStats.recentMatchesPagination.totalPages}
+            />
+          ) : (
+            <ProfilePrivacyNotice t={t} />
+          )}
         </div>
 
         <aside className="grid content-start gap-5">
@@ -289,7 +316,11 @@ async function PublicProfilePageContent({ params, searchParams }: ProfilePagePro
             icon={Award}
             title={t("publicPage.achievements.title")}
           >
-            {unlockedAchievements.length > 0 ? (
+            {!canViewDetails ? (
+              <p className="m-0 text-sm text-[var(--muted-text)]">
+                {t("publicPage.private.description")}
+              </p>
+            ) : unlockedAchievements.length > 0 ? (
               <div className="grid gap-2">
                 {unlockedAchievements.map((achievement) => (
                   <Badge key={achievement.code} tone="brass">
@@ -305,5 +336,17 @@ async function PublicProfilePageContent({ params, searchParams }: ProfilePagePro
         </aside>
       </section>
     </PageShell>
+  );
+}
+
+function ProfilePrivacyNotice({ t }: { t: Translate }) {
+  return (
+    <Surface
+      eyebrow={t("publicPage.private.eyebrow")}
+      icon={LockKeyhole}
+      title={t("publicPage.private.title")}
+    >
+      <p className="m-0 text-sm text-[var(--muted-text)]">{t("publicPage.private.description")}</p>
+    </Surface>
   );
 }

--- a/app/i18n/messages/en.ts
+++ b/app/i18n/messages/en.ts
@@ -991,6 +991,12 @@ export const messages = {
         eyebrow: "Achievements",
         title: "Unlocked badges",
       },
+      private: {
+        eyebrow: "Profile privacy",
+        title: "Stats are private",
+        description: "This player has limited profile details to friends or themselves.",
+        value: "Private",
+      },
     },
     page: {
       hero: {

--- a/app/i18n/messages/ja.ts
+++ b/app/i18n/messages/ja.ts
@@ -994,6 +994,12 @@ export const messages = {
         eyebrow: "実績",
         title: "解除済みバッジ",
       },
+      private: {
+        eyebrow: "プロフィール公開範囲",
+        title: "統計は非公開です",
+        description: "このプレイヤーはプロフィール詳細をフレンドまたは本人のみに制限しています。",
+        value: "非公開",
+      },
     },
     page: {
       hero: {

--- a/app/i18n/messages/zh.ts
+++ b/app/i18n/messages/zh.ts
@@ -985,6 +985,12 @@ export const messages = {
         eyebrow: "成就",
         title: "已解锁徽章",
       },
+      private: {
+        eyebrow: "资料隐私",
+        title: "统计已设为私密",
+        description: "这名玩家仅向好友或本人展示个人资料详情。",
+        value: "私密",
+      },
     },
     page: {
       hero: {

--- a/app/lib/advanced-search.ts
+++ b/app/lib/advanced-search.ts
@@ -1,6 +1,6 @@
 import type { Prisma } from "../../generated/prisma/client";
 import { MatchResult, RuleType } from "../../generated/prisma/enums";
-import type { LeaderboardScope } from "./leaderboard";
+import type { LeaderboardScope } from "./leaderboard-types";
 
 export const LEADERBOARD_SEARCH_DEFAULT_LIMIT = 10;
 export const LEADERBOARD_SEARCH_MAX_LIMIT = 50;

--- a/app/lib/leaderboard-types.ts
+++ b/app/lib/leaderboard-types.ts
@@ -1,0 +1,1 @@
+export type LeaderboardScope = "all" | "friends";

--- a/app/lib/leaderboard.ts
+++ b/app/lib/leaderboard.ts
@@ -1,5 +1,3 @@
-//import { cacheLife } from "next/cache";
-
 import type { Prisma } from "../../generated/prisma/client";
 import { RuleType } from "../../generated/prisma/enums";
 import {
@@ -8,6 +6,7 @@ import {
   type LeaderboardSort,
 } from "./advanced-search";
 import { getAcceptedFriendIdsForUser } from "./friendships/friendship-queries";
+import type { LeaderboardScope } from "./leaderboard-types";
 import { prisma } from "./prisma";
 
 export const LEADERBOARD_BOARD_SIZE = 15;
@@ -64,11 +63,11 @@ export type LeaderboardSnapshot = {
   };
 };
 
-export type LeaderboardScope = "all" | "friends";
-
 export type LeaderboardSnapshotOptions = {
   scope?: LeaderboardScope;
 };
+
+export type { LeaderboardScope } from "./leaderboard-types";
 
 export type LeaderboardRankInput = {
   rating: number | null;

--- a/app/lib/matches/realtime-publisher.test.ts
+++ b/app/lib/matches/realtime-publisher.test.ts
@@ -2,11 +2,13 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { GameUpdatePayload } from "../../../shared/match-events";
 import { internalRealtimeSecretHeader } from "../../../shared/realtime-internal";
+import { realtimeOutboxTopics } from "../realtime-outbox-contract";
 import {
   publishChallengeDeclined,
   publishChallengeReceived,
   publishGameUpdate,
   publishQueueMatched,
+  publishRealtimeOutboxEvent,
   resolveChallengeDeclinedUrl,
   resolveChallengeReceivedUrl,
   resolveGameUpdateUrl,
@@ -181,6 +183,26 @@ describe("publishGameUpdate", () => {
       "Failed to publish game:update(503)",
     );
   });
+
+  test("persists failed game updates to an injected outbox when enabled", async () => {
+    process.env["REALTIME_INTERNAL_SECRET"] = "game-secret";
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+    const enqueueOutboxEvent = mock(async (_event: unknown) => {});
+
+    await expectRejectsWithMessage(
+      () => publishGameUpdate(payload, 5000, { enqueueOutboxEvent, persistOnFailure: true }),
+      "Failed to publish game:update(503)",
+    );
+
+    const call = enqueueOutboxEvent.mock.calls[0]?.[0];
+
+    expect(enqueueOutboxEvent).toHaveBeenCalledTimes(1);
+    expect(call).toMatchObject({
+      payload,
+      topic: realtimeOutboxTopics.gameUpdate,
+    });
+    expect((call as { error?: unknown } | undefined)?.error).toBeInstanceOf(Error);
+  });
 });
 
 describe("publishChallengeReceived", () => {
@@ -274,6 +296,37 @@ describe("publishQueueMatched", () => {
       () => publishQueueMatched("black", { matchId: "match-1" }),
       "Failed to publish queue:matched (502)",
     );
+  });
+});
+
+describe("publishRealtimeOutboxEvent", () => {
+  test("replays queue match events through the internal queue endpoint", async () => {
+    process.env["REALTIME_INTERNAL_URL"] = "http://localhost:3001/internal/game-update";
+    process.env["REALTIME_INTERNAL_SECRET"] = "queue-secret";
+
+    await publishRealtimeOutboxEvent(
+      {
+        id: "evt-1",
+        payload: {
+          session: { matchId: "match-1" },
+          username: "black",
+        },
+        topic: realtimeOutboxTopics.queueMatched,
+      },
+      5000,
+    );
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+
+    expect(call?.[0]).toBe("http://localhost:3001/internal/queue-matched");
+    expect(call?.[1]).toMatchObject({
+      body: JSON.stringify({
+        username: "black",
+        session: { matchId: "match-1" },
+      }),
+      cache: "no-store",
+      method: "POST",
+    });
   });
 });
 

--- a/app/lib/matches/realtime-publisher.ts
+++ b/app/lib/matches/realtime-publisher.ts
@@ -1,18 +1,134 @@
 import type { GameUpdatePayload } from "../../../shared/match-events";
+import { isGameUpdatePayload } from "../../../shared/match-events-validation";
 import {
   challengeDeclinedPath,
   challengeReceivedPath,
   internalRealtimeSecretHeader,
   readRealtimeInternalSecret,
 } from "../../../shared/realtime-internal";
+import type { DrainRealtimeOutboxOptions, enqueueRealtimeOutboxEvent } from "../realtime-outbox";
+import {
+  realtimeOutboxTopics,
+  type RealtimeOutboxPublishEvent,
+  type RealtimeOutboxTopic,
+} from "../realtime-outbox-contract";
 
 const defaultGameUpdateUrl = "http://realtime:3001/internal/game-update";
 const defaultQueueMatchedUrl = "http://realtime:3001/internal/queue-matched";
 const defaultChallengeDeclinedUrl = `http://realtime:3001${challengeDeclinedPath}`;
 const defaultChallengeReceivedUrl = `http://realtime:3001${challengeReceivedPath}`;
 
+type RealtimePublishOptions = {
+  enqueueOutboxEvent?: typeof enqueueRealtimeOutboxEvent;
+  persistOnFailure?: boolean;
+};
+
+type QueueMatchedPayload = {
+  username: string;
+  session: unknown;
+};
+
+type ChallengeDeclinedOutboxPayload = {
+  matchId: string;
+  senderUsername: string;
+  username: string;
+};
+
 function readPositiveTimeoutMs(timeoutMs: number) {
   return Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 2000;
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+function shouldPersistOnFailure(options: RealtimePublishOptions | undefined) {
+  return options?.persistOnFailure ?? process.env["NODE_ENV"] !== "test";
+}
+
+async function persistRealtimeFailure(
+  topic: RealtimeOutboxTopic,
+  payload: unknown,
+  error: unknown,
+  options?: RealtimePublishOptions,
+) {
+  if (!shouldPersistOnFailure(options)) {
+    return;
+  }
+
+  try {
+    const enqueueOutboxEvent =
+      options?.enqueueOutboxEvent ??
+      (await import("../realtime-outbox")).enqueueRealtimeOutboxEvent;
+
+    await enqueueOutboxEvent({
+      error,
+      payload,
+      topic,
+    });
+  } catch (outboxError) {
+    console.error("[realtime-outbox] failed to enqueue event:", getErrorMessage(outboxError));
+  }
+}
+
+async function postRealtimeJson(url: string, payload: unknown, timeoutMs: number) {
+  const internalSecret = readRealtimeInternalSecret();
+
+  if (!internalSecret) {
+    throw new Error("Missing REALTIME_INTERNAL_SECRET");
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), readPositiveTimeoutMs(timeoutMs));
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [internalRealtimeSecretHeader]: internalSecret,
+      },
+      body: JSON.stringify(payload),
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    return response;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readQueueMatchedPayload(value: unknown): QueueMatchedPayload {
+  if (!isRecord(value) || typeof value["username"] !== "string") {
+    throw new Error("Invalid queue:matched outbox payload");
+  }
+
+  return {
+    session: value["session"],
+    username: value["username"],
+  };
+}
+
+function readChallengeDeclinedPayload(value: unknown): ChallengeDeclinedOutboxPayload {
+  if (
+    !isRecord(value) ||
+    typeof value["matchId"] !== "string" ||
+    typeof value["senderUsername"] !== "string" ||
+    typeof value["username"] !== "string"
+  ) {
+    throw new Error("Invalid challenge:declined outbox payload");
+  }
+
+  return {
+    matchId: value["matchId"],
+    senderUsername: value["senderUsername"],
+    username: value["username"],
+  };
 }
 
 export function resolveGameUpdateUrl(env: NodeJS.ProcessEnv = process.env) {
@@ -44,49 +160,27 @@ export function resolveChallengeReceivedUrl(env: NodeJS.ProcessEnv = process.env
 export async function publishGameUpdate(
   payload: GameUpdatePayload,
   timeoutMs = Number(process.env["REALTIME_PUBLISH_TIMEOUT_MS"] ?? 2000),
+  options?: RealtimePublishOptions,
 ) {
-  const internalSecret = readRealtimeInternalSecret();
-
-  if (!internalSecret) {
-    throw new Error("Missing REALTIME_INTERNAL_SECRET");
-  }
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), readPositiveTimeoutMs(timeoutMs));
-
   try {
-    const response = await fetch(resolveGameUpdateUrl(), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        [internalRealtimeSecretHeader]: internalSecret,
-      },
-      body: JSON.stringify(payload),
-      cache: "no-store",
-      signal: controller.signal,
-    });
+    const response = await postRealtimeJson(resolveGameUpdateUrl(), payload, timeoutMs);
 
     if (!response.ok) {
       throw new Error(`Failed to publish game:update(${response.status})`);
     }
-  } finally {
-    clearTimeout(timeoutId);
+  } catch (error) {
+    await persistRealtimeFailure(realtimeOutboxTopics.gameUpdate, payload, error, options);
+    throw error;
   }
 }
 
 export async function publishQueueMatched(
   username: string,
-  session: any,
+  session: unknown,
   timeoutMs = Number(process.env["REALTIME_PUBLISH_TIMEOUT_MS"] ?? 2000),
+  options?: RealtimePublishOptions,
 ) {
-  const internalSecret = readRealtimeInternalSecret();
-
-  if (!internalSecret) {
-    throw new Error("Missing REALTIME_INTERNAL_SECRET");
-  }
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), readPositiveTimeoutMs(timeoutMs));
+  const payload = { username, session };
 
   try {
     const baseUrl = resolveGameUpdateUrl().replace("/internal/game-update", "");
@@ -94,22 +188,14 @@ export async function publishQueueMatched(
       ? `${baseUrl}/internal/queue-matched`
       : resolveQueueMatchedUrl();
 
-    const response = await fetch(finalUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        [internalRealtimeSecretHeader]: internalSecret,
-      },
-      body: JSON.stringify({ username, session }),
-      cache: "no-store",
-      signal: controller.signal,
-    });
+    const response = await postRealtimeJson(finalUrl, payload, timeoutMs);
 
     if (!response.ok) {
       throw new Error(`Failed to publish queue:matched (${response.status})`);
     }
-  } finally {
-    clearTimeout(timeoutId);
+  } catch (error) {
+    await persistRealtimeFailure(realtimeOutboxTopics.queueMatched, payload, error, options);
+    throw error;
   }
 }
 
@@ -117,36 +203,22 @@ export async function publishChallengeDeclined(
   username: string,
   payload: { matchId: string; senderUsername: string },
   timeoutMs = Number(process.env["REALTIME_PUBLISH_TIMEOUT_MS"] ?? 2000),
+  options?: RealtimePublishOptions,
 ) {
-  const internalSecret = readRealtimeInternalSecret();
-
-  if (!internalSecret) {
-    throw new Error("Missing REALTIME_INTERNAL_SECRET");
-  }
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), readPositiveTimeoutMs(timeoutMs));
+  const body = {
+    ...payload,
+    username,
+  };
 
   try {
-    const response = await fetch(resolveChallengeDeclinedUrl(), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        [internalRealtimeSecretHeader]: internalSecret,
-      },
-      body: JSON.stringify({
-        ...payload,
-        username,
-      }),
-      cache: "no-store",
-      signal: controller.signal,
-    });
+    const response = await postRealtimeJson(resolveChallengeDeclinedUrl(), body, timeoutMs);
 
     if (!response.ok) {
       throw new Error(`Failed to publish challenge:declined (${response.status})`);
     }
-  } finally {
-    clearTimeout(timeoutId);
+  } catch (error) {
+    await persistRealtimeFailure(realtimeOutboxTopics.challengeDeclined, body, error, options);
+    throw error;
   }
 }
 
@@ -160,34 +232,61 @@ export async function publishChallengeReceived(
   },
   timeoutMs = Number(process.env["REALTIME_PUBLISH_TIMEOUT_MS"] ?? 2000),
 ) {
-  const internalSecret = readRealtimeInternalSecret();
+  const response = await postRealtimeJson(
+    resolveChallengeReceivedUrl(),
+    {
+      ...payload,
+      username,
+    },
+    timeoutMs,
+  );
 
-  if (!internalSecret) {
-    throw new Error("Missing REALTIME_INTERNAL_SECRET");
+  if (!response.ok) {
+    throw new Error(`Failed to publish challenge:receive (${response.status})`);
   }
+}
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), readPositiveTimeoutMs(timeoutMs));
-
-  try {
-    const response = await fetch(resolveChallengeReceivedUrl(), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        [internalRealtimeSecretHeader]: internalSecret,
-      },
-      body: JSON.stringify({
-        ...payload,
-        username,
-      }),
-      cache: "no-store",
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to publish challenge:receive (${response.status})`);
+export async function publishRealtimeOutboxEvent(
+  event: RealtimeOutboxPublishEvent,
+  timeoutMs = Number(process.env["REALTIME_PUBLISH_TIMEOUT_MS"] ?? 2000),
+) {
+  switch (event.topic) {
+    case realtimeOutboxTopics.gameUpdate:
+      if (!isGameUpdatePayload(event.payload)) {
+        throw new Error("Invalid game:update outbox payload");
+      }
+      await publishGameUpdate(event.payload, timeoutMs, { persistOnFailure: false });
+      return;
+    case realtimeOutboxTopics.queueMatched: {
+      const payload = readQueueMatchedPayload(event.payload);
+      await publishQueueMatched(payload.username, payload.session, timeoutMs, {
+        persistOnFailure: false,
+      });
+      return;
     }
-  } finally {
-    clearTimeout(timeoutId);
+    case realtimeOutboxTopics.challengeDeclined: {
+      const payload = readChallengeDeclinedPayload(event.payload);
+      await publishChallengeDeclined(
+        payload.username,
+        {
+          matchId: payload.matchId,
+          senderUsername: payload.senderUsername,
+        },
+        timeoutMs,
+        { persistOnFailure: false },
+      );
+      return;
+    }
   }
+}
+
+export async function drainMatchRealtimeOutbox(
+  options: Omit<DrainRealtimeOutboxOptions, "publish"> = {},
+) {
+  const { drainRealtimeOutbox } = await import("../realtime-outbox");
+
+  return drainRealtimeOutbox({
+    ...options,
+    publish: publishRealtimeOutboxEvent,
+  });
 }

--- a/app/lib/prisma.ts
+++ b/app/lib/prisma.ts
@@ -34,6 +34,7 @@ function getPrisma(): PrismaClient {
     "Match",
     "MatchParticipant",
     "MatchMove",
+    "RealtimeOutboxEvent",
     "AvatarMedia",
     "AnalyticsEvent",
   ]);

--- a/app/lib/profile-visibility.test.ts
+++ b/app/lib/profile-visibility.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import { ProfileVisibility } from "../../generated/prisma/enums";
+import { canViewProfileDetails } from "./profile-visibility";
+
+describe("profile visibility", () => {
+  test("allows everyone to view public profile details", () => {
+    expect(
+      canViewProfileDetails({
+        relationshipState: "NOT_FRIENDS",
+        visibility: ProfileVisibility.PUBLIC,
+      }),
+    ).toBe(true);
+  });
+
+  test("allows friends and the owner to view friends-only profile details", () => {
+    expect(
+      canViewProfileDetails({
+        relationshipState: "FRIENDS",
+        visibility: ProfileVisibility.FRIENDS,
+      }),
+    ).toBe(true);
+    expect(
+      canViewProfileDetails({
+        relationshipState: "SELF",
+        visibility: ProfileVisibility.FRIENDS,
+      }),
+    ).toBe(true);
+  });
+
+  test("hides friends-only profile details from non-friends and pending requests", () => {
+    for (const relationshipState of ["NOT_FRIENDS", "REQUEST_SENT", "REQUEST_RECEIVED"] as const) {
+      expect(
+        canViewProfileDetails({
+          relationshipState,
+          visibility: ProfileVisibility.FRIENDS,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  test("hides private profile details from everyone except the owner", () => {
+    expect(
+      canViewProfileDetails({
+        relationshipState: "FRIENDS",
+        visibility: ProfileVisibility.PRIVATE,
+      }),
+    ).toBe(false);
+    expect(
+      canViewProfileDetails({
+        relationshipState: "SELF",
+        visibility: ProfileVisibility.PRIVATE,
+      }),
+    ).toBe(true);
+  });
+});

--- a/app/lib/profile-visibility.ts
+++ b/app/lib/profile-visibility.ts
@@ -1,0 +1,26 @@
+import { ProfileVisibility } from "../../generated/prisma/enums";
+
+export type ProfileRelationshipState =
+  | "NOT_FRIENDS"
+  | "FRIENDS"
+  | "REQUEST_SENT"
+  | "REQUEST_RECEIVED"
+  | "SELF";
+
+export function canViewProfileDetails({
+  relationshipState,
+  visibility,
+}: {
+  relationshipState: ProfileRelationshipState;
+  visibility: ProfileVisibility;
+}) {
+  if (relationshipState === "SELF") {
+    return true;
+  }
+
+  if (visibility === ProfileVisibility.PUBLIC) {
+    return true;
+  }
+
+  return visibility === ProfileVisibility.FRIENDS && relationshipState === "FRIENDS";
+}

--- a/app/lib/realtime-outbox-contract.ts
+++ b/app/lib/realtime-outbox-contract.ts
@@ -1,0 +1,22 @@
+export const realtimeOutboxStatuses = {
+  failed: "FAILED",
+  pending: "PENDING",
+  processing: "PROCESSING",
+  published: "PUBLISHED",
+} as const;
+
+export const realtimeOutboxTopics = {
+  challengeDeclined: "challenge:declined",
+  gameUpdate: "game:update",
+  queueMatched: "queue:matched",
+} as const;
+
+export type RealtimeOutboxStatus =
+  (typeof realtimeOutboxStatuses)[keyof typeof realtimeOutboxStatuses];
+export type RealtimeOutboxTopic = (typeof realtimeOutboxTopics)[keyof typeof realtimeOutboxTopics];
+
+export type RealtimeOutboxPublishEvent = {
+  id: string;
+  payload: unknown;
+  topic: RealtimeOutboxTopic;
+};

--- a/app/lib/realtime-outbox.test.ts
+++ b/app/lib/realtime-outbox.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { RealtimeOutboxEvent, RealtimeOutboxPrisma } from "./realtime-outbox";
+
+await mock.module("server-only", () => ({}));
+await mock.module("./prisma", () => ({ prisma: {} }));
+
+const {
+  drainRealtimeOutbox,
+  enqueueRealtimeOutboxEvent,
+  realtimeOutboxStatuses,
+  realtimeOutboxTopics,
+} = await import("./realtime-outbox");
+
+type CreateArgs = Parameters<RealtimeOutboxPrisma["realtimeOutboxEvent"]["create"]>[0];
+type FindManyArgs = Parameters<RealtimeOutboxPrisma["realtimeOutboxEvent"]["findMany"]>[0];
+type UpdateArgs = Parameters<RealtimeOutboxPrisma["realtimeOutboxEvent"]["update"]>[0];
+type UpdateManyArgs = Parameters<RealtimeOutboxPrisma["realtimeOutboxEvent"]["updateMany"]>[0];
+
+function matchesDueWhere(event: RealtimeOutboxEvent, where: FindManyArgs["where"]) {
+  return where.OR.some((condition) => {
+    if (condition.status !== event.status) {
+      return false;
+    }
+
+    if ("availableAt" in condition) {
+      return event.availableAt <= condition.availableAt.lte;
+    }
+
+    return event.lockedAt !== null && event.lockedAt <= condition.lockedAt.lte;
+  });
+}
+
+function createOutboxEvent(overrides: Partial<RealtimeOutboxEvent> = {}): RealtimeOutboxEvent {
+  const now = new Date("2026-05-29T00:00:00.000Z");
+
+  return {
+    attempts: 0,
+    availableAt: now,
+    createdAt: now,
+    id: "evt-1",
+    lastError: null,
+    lockedAt: null,
+    maxAttempts: 5,
+    payload: { ok: true },
+    publishedAt: null,
+    status: realtimeOutboxStatuses.pending,
+    topic: realtimeOutboxTopics.gameUpdate,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function createFakePrisma(seed: RealtimeOutboxEvent[] = []) {
+  const events = [...seed];
+  const prisma: RealtimeOutboxPrisma = {
+    realtimeOutboxEvent: {
+      async create(args: CreateArgs) {
+        const now = new Date("2026-05-29T00:00:00.000Z");
+        const event = createOutboxEvent({
+          availableAt: now,
+          createdAt: now,
+          id: `evt-${events.length + 1}`,
+          lastError: args.data.lastError,
+          lockedAt: null,
+          payload: args.data.payload as RealtimeOutboxEvent["payload"],
+          publishedAt: null,
+          status: args.data.status,
+          topic: args.data.topic,
+          updatedAt: now,
+        });
+
+        events.push(event);
+        return event;
+      },
+      async findMany(args: FindManyArgs) {
+        return events
+          .filter((event) => matchesDueWhere(event, args.where))
+          .sort((left, right) => {
+            const availableDelta = left.availableAt.getTime() - right.availableAt.getTime();
+            return availableDelta || left.createdAt.getTime() - right.createdAt.getTime();
+          })
+          .slice(0, args.take);
+      },
+      async update(args: UpdateArgs) {
+        const event = events.find((entry) => entry.id === args.where.id);
+
+        if (!event) {
+          throw new Error(`Missing outbox event ${args.where.id}`);
+        }
+
+        Object.assign(event, {
+          ...args.data,
+          attempts:
+            args.data.attempts && "increment" in args.data.attempts
+              ? event.attempts + args.data.attempts.increment
+              : event.attempts,
+          updatedAt: new Date("2026-05-29T00:00:01.000Z"),
+        });
+
+        return event;
+      },
+      async updateMany(args: UpdateManyArgs) {
+        const event = events.find(
+          (entry) =>
+            entry.id === args.where.id &&
+            entry.status === args.where.status &&
+            entry.attempts === args.where.attempts &&
+            entry.publishedAt === null,
+        );
+
+        if (!event) {
+          return { count: 0 };
+        }
+
+        event.lockedAt = args.data.lockedAt;
+        event.status = args.data.status;
+
+        return { count: 1 };
+      },
+    },
+  };
+
+  return { events, prisma };
+}
+
+describe("realtime outbox", () => {
+  test("enqueues pending events with bounded error text", async () => {
+    const { events, prisma } = createFakePrisma();
+
+    await enqueueRealtimeOutboxEvent({
+      error: new Error("realtime down"),
+      payload: { matchId: "match-1" },
+      prisma,
+      topic: realtimeOutboxTopics.gameUpdate,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      lastError: "realtime down",
+      payload: { matchId: "match-1" },
+      status: realtimeOutboxStatuses.pending,
+      topic: realtimeOutboxTopics.gameUpdate,
+    });
+  });
+
+  test("publishes due pending events and marks them complete", async () => {
+    const now = new Date("2026-05-29T01:00:00.000Z");
+    const event = createOutboxEvent({ availableAt: new Date("2026-05-29T00:59:00.000Z") });
+    const { events, prisma } = createFakePrisma([event]);
+    const publish = mock(async () => {});
+
+    const summary = await drainRealtimeOutbox({ now, prisma, publish });
+
+    expect(summary).toEqual({ failed: 0, published: 1, retried: 0, skipped: 0 });
+    expect(publish).toHaveBeenCalledWith({
+      id: event.id,
+      payload: event.payload,
+      topic: event.topic,
+    });
+    expect(events[0]).toMatchObject({
+      attempts: 1,
+      lastError: null,
+      lockedAt: null,
+      publishedAt: now,
+      status: realtimeOutboxStatuses.published,
+    });
+  });
+
+  test("backs off failed events until the retry budget is exhausted", async () => {
+    const now = new Date("2026-05-29T01:00:00.000Z");
+    const event = createOutboxEvent({
+      attempts: 4,
+      maxAttempts: 5,
+      status: realtimeOutboxStatuses.pending,
+    });
+    const { events, prisma } = createFakePrisma([event]);
+    const publish = mock(async () => {
+      throw new Error("still down");
+    });
+
+    const summary = await drainRealtimeOutbox({ now, prisma, publish });
+
+    expect(summary).toEqual({ failed: 1, published: 0, retried: 0, skipped: 0 });
+    expect(events[0]).toMatchObject({
+      attempts: 5,
+      lastError: "still down",
+      lockedAt: null,
+      status: realtimeOutboxStatuses.failed,
+    });
+  });
+
+  test("reclaims stale processing events", async () => {
+    const now = new Date("2026-05-29T01:00:00.000Z");
+    const event = createOutboxEvent({
+      lockedAt: new Date("2026-05-29T00:50:00.000Z"),
+      status: realtimeOutboxStatuses.processing,
+    });
+    const { prisma } = createFakePrisma([event]);
+    const publish = mock(async () => {});
+
+    const summary = await drainRealtimeOutbox({ now, prisma, publish });
+
+    expect(summary.published).toBe(1);
+  });
+
+  test("skips unknown topics without claiming them", async () => {
+    const { events, prisma } = createFakePrisma([
+      createOutboxEvent({
+        status: realtimeOutboxStatuses.pending,
+        topic: "unknown:event",
+      }),
+    ]);
+
+    const summary = await drainRealtimeOutbox({
+      now: new Date("2026-05-29T01:00:00.000Z"),
+      prisma,
+      publish: mock(async () => {}),
+    });
+
+    expect(summary.skipped).toBe(1);
+    expect(events[0]?.status).toBe(realtimeOutboxStatuses.pending);
+  });
+});

--- a/app/lib/realtime-outbox.ts
+++ b/app/lib/realtime-outbox.ts
@@ -1,0 +1,249 @@
+import "server-only";
+import type { Prisma } from "../../generated/prisma/client";
+import { prisma as defaultPrisma } from "./prisma";
+import {
+  realtimeOutboxStatuses,
+  realtimeOutboxTopics,
+  type RealtimeOutboxPublishEvent,
+  type RealtimeOutboxStatus,
+  type RealtimeOutboxTopic,
+} from "./realtime-outbox-contract";
+
+export {
+  realtimeOutboxStatuses,
+  realtimeOutboxTopics,
+  type RealtimeOutboxPublishEvent,
+  type RealtimeOutboxStatus,
+  type RealtimeOutboxTopic,
+} from "./realtime-outbox-contract";
+
+export type RealtimeOutboxEvent = {
+  id: string;
+  topic: string;
+  payload: Prisma.JsonValue;
+  status: string;
+  attempts: number;
+  maxAttempts: number;
+  availableAt: Date;
+  lockedAt: Date | null;
+  publishedAt: Date | null;
+  lastError: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type RealtimeOutboxModel = {
+  create(args: {
+    data: {
+      topic: string;
+      payload: Prisma.InputJsonValue;
+      status: RealtimeOutboxStatus;
+      lastError: string | null;
+    };
+  }): Promise<unknown>;
+  findMany(args: {
+    where: {
+      OR: Array<
+        | {
+            status: RealtimeOutboxStatus;
+            availableAt: { lte: Date };
+          }
+        | {
+            status: RealtimeOutboxStatus;
+            lockedAt: { lte: Date };
+          }
+      >;
+    };
+    orderBy: Array<{ availableAt?: "asc" } | { createdAt?: "asc" }>;
+    take: number;
+  }): Promise<RealtimeOutboxEvent[]>;
+  update(args: {
+    where: { id: string };
+    data: Partial<{
+      attempts: { increment: number };
+      availableAt: Date;
+      lastError: string | null;
+      lockedAt: Date | null;
+      publishedAt: Date | null;
+      status: RealtimeOutboxStatus;
+    }>;
+  }): Promise<unknown>;
+  updateMany(args: {
+    where: {
+      attempts: number;
+      id: string;
+      publishedAt: null;
+      status: string;
+    };
+    data: {
+      lockedAt: Date;
+      status: RealtimeOutboxStatus;
+    };
+  }): Promise<{ count: number }>;
+};
+
+export type RealtimeOutboxPrisma = {
+  realtimeOutboxEvent: RealtimeOutboxModel;
+};
+
+export type DrainRealtimeOutboxOptions = {
+  limit?: number;
+  now?: Date;
+  prisma?: RealtimeOutboxPrisma;
+  publish: (event: RealtimeOutboxPublishEvent) => Promise<void>;
+  staleProcessingMs?: number;
+};
+
+const defaultBatchLimit = 25;
+const defaultStaleProcessingMs = 5 * 60 * 1000;
+const maxErrorLength = 1000;
+
+function getPrisma(prisma: RealtimeOutboxPrisma | undefined): RealtimeOutboxPrisma {
+  return prisma ?? (defaultPrisma as unknown as RealtimeOutboxPrisma);
+}
+
+function truncateError(message: string) {
+  return message.length > maxErrorLength ? `${message.slice(0, maxErrorLength - 1)}...` : message;
+}
+
+function getErrorMessage(error: unknown) {
+  return truncateError(error instanceof Error ? error.message : "Unknown error");
+}
+
+function getRetryAvailableAt(now: Date, attempts: number) {
+  const delaySeconds = Math.min(300, 2 ** Math.max(0, attempts - 1) * 5);
+  return new Date(now.getTime() + delaySeconds * 1000);
+}
+
+function toOutboxTopic(topic: string): RealtimeOutboxTopic | null {
+  return Object.values(realtimeOutboxTopics).includes(topic as RealtimeOutboxTopic)
+    ? (topic as RealtimeOutboxTopic)
+    : null;
+}
+
+export async function enqueueRealtimeOutboxEvent({
+  error,
+  payload,
+  prisma,
+  topic,
+}: {
+  error?: unknown;
+  payload: unknown;
+  prisma?: RealtimeOutboxPrisma;
+  topic: RealtimeOutboxTopic;
+}) {
+  await getPrisma(prisma).realtimeOutboxEvent.create({
+    data: {
+      topic,
+      payload: payload as Prisma.InputJsonValue,
+      status: realtimeOutboxStatuses.pending,
+      lastError: error === undefined ? null : getErrorMessage(error),
+    },
+  });
+}
+
+export async function drainRealtimeOutbox({
+  limit = defaultBatchLimit,
+  now = new Date(),
+  prisma,
+  publish,
+  staleProcessingMs = defaultStaleProcessingMs,
+}: DrainRealtimeOutboxOptions) {
+  const client = getPrisma(prisma);
+  const staleProcessingBefore = new Date(now.getTime() - staleProcessingMs);
+  const events = await client.realtimeOutboxEvent.findMany({
+    where: {
+      OR: [
+        {
+          status: realtimeOutboxStatuses.pending,
+          availableAt: {
+            lte: now,
+          },
+        },
+        {
+          status: realtimeOutboxStatuses.processing,
+          lockedAt: {
+            lte: staleProcessingBefore,
+          },
+        },
+      ],
+    },
+    orderBy: [{ availableAt: "asc" }, { createdAt: "asc" }],
+    take: limit,
+  });
+  const summary = {
+    failed: 0,
+    published: 0,
+    retried: 0,
+    skipped: 0,
+  };
+
+  for (const event of events) {
+    const topic = toOutboxTopic(event.topic);
+
+    if (!topic || event.attempts >= event.maxAttempts) {
+      summary.skipped += 1;
+      continue;
+    }
+
+    const claim = await client.realtimeOutboxEvent.updateMany({
+      where: {
+        attempts: event.attempts,
+        id: event.id,
+        publishedAt: null,
+        status: event.status,
+      },
+      data: {
+        lockedAt: now,
+        status: realtimeOutboxStatuses.processing,
+      },
+    });
+
+    if (claim.count !== 1) {
+      summary.skipped += 1;
+      continue;
+    }
+
+    try {
+      await publish({
+        id: event.id,
+        payload: event.payload,
+        topic,
+      });
+
+      await client.realtimeOutboxEvent.update({
+        where: { id: event.id },
+        data: {
+          attempts: { increment: 1 },
+          lastError: null,
+          lockedAt: null,
+          publishedAt: now,
+          status: realtimeOutboxStatuses.published,
+        },
+      });
+      summary.published += 1;
+    } catch (error) {
+      const attempts = event.attempts + 1;
+      const exhausted = attempts >= event.maxAttempts;
+
+      await client.realtimeOutboxEvent.update({
+        where: { id: event.id },
+        data: {
+          attempts: { increment: 1 },
+          availableAt: exhausted ? event.availableAt : getRetryAvailableAt(now, attempts),
+          lastError: getErrorMessage(error),
+          lockedAt: null,
+          status: exhausted ? realtimeOutboxStatuses.failed : realtimeOutboxStatuses.pending,
+        },
+      });
+
+      if (exhausted) {
+        summary.failed += 1;
+      } else {
+        summary.retried += 1;
+      }
+    }
+  }
+
+  return summary;
+}

--- a/brooks_sweep_report.md
+++ b/brooks_sweep_report.md
@@ -1,0 +1,75 @@
+# Brooks-Lint Review
+
+**Mode:** Full Sweep
+**Scope:** full repository
+**Health Score:** 100/100
+
+The sweep found no open findings after the residual realtime durability risk was implemented. The
+security-significant profile visibility issue, app-level import cycle, and durable realtime retry
+gap were fixed in place.
+
+---
+
+## Findings
+
+No open Brooks-Lint findings.
+
+---
+
+## Fixed During Sweep
+
+**R2 Change Propagation - Realtime Publish Failures Had No Durable Retry**
+Symptom: committed match updates could succeed while `game:update`, `queue:matched`, or
+`challenge:declined` realtime delivery failed, leaving recovery to logs and ad hoc caller behavior.
+Source: Ousterhout - Information Leakage; Fowler - Shotgun Surgery.
+Consequence: players could need manual refreshes after transient realtime outages, and each caller
+had to own its own failure semantics.
+Remedy: added a `RealtimeOutboxEvent` model and migration, a server-only outbox enqueue/drain
+module, publisher-level persistence for non-secret match realtime payloads, a replay dispatcher,
+`bun run realtime:drain-outbox`, and unit coverage for enqueue, backoff, stale lock reclaim, replay,
+and max-attempt exhaustion. Challenge invite delivery remains intentionally unqueued because those
+payloads contain room secrets and failed delivery cancels the challenge room instead.
+
+**R6 Domain Model Distortion / Security Authorization - Profile Visibility Was Not Enforced**
+Symptom: `ProfileVisibility` existed in the data model, but public profile stats and history were
+loaded without checking it.
+Source: Evans - Ubiquitous Language and Aggregate Invariants; Clean Architecture - policy must be
+enforced at the boundary.
+Consequence: the profile privacy model said data could be friends-only/private, while the public
+profile route still exposed details.
+Remedy: added `app/lib/profile-visibility.ts`, enforced it in
+`app/[locale]/profile/[username]/page.tsx`, and added unit coverage in
+`app/lib/profile-visibility.test.ts`.
+
+**R5 Dependency Disorder - Leaderboard Search Type Cycle**
+Symptom: `app/lib/advanced-search.ts` imported `LeaderboardScope` from `app/lib/leaderboard.ts`,
+while `leaderboard.ts` imported search helpers from `advanced-search.ts`.
+Source: Martin - Acyclic Dependencies Principle.
+Consequence: even type-level cycles make module ownership unclear and show up in dependency scans.
+Remedy: moved `LeaderboardScope` into `app/lib/leaderboard-types.ts` and re-exported it from
+`leaderboard.ts` to preserve the existing public type API.
+
+**R4 Accidental Complexity - Dead Commented Import**
+Symptom: `app/lib/leaderboard.ts` kept a commented-out `cacheLife` import.
+Source: Fowler - Dead Code / Speculative Generality.
+Consequence: stale scaffolding suggests an abandoned caching direction and adds noise during future
+leaderboard work.
+Remedy: removed the dead comment.
+
+---
+
+## Verification
+
+- `bun audit`: no vulnerabilities found.
+- `bun run lint`: passed.
+- `bun run typecheck`: passed.
+- `bun test`: passed, 492 passing, 2 skipped.
+- `bun test app/lib/realtime-outbox.test.ts app/lib/matches/realtime-publisher.test.ts app/api/matches/[id]/rules-routes.test.ts app/api/matches/[id]/join/route.test.ts app/api/matches/challenge/route.test.ts app/api/matches/[id]/challenge/decline/route.test.ts app/api/matches/solo/route.test.ts app/api/matches/[id]/ai-turn/route.test.ts`: passed.
+- `bun test app/lib/profile-visibility.test.ts app/lib/advanced-search.test.ts app/lib/leaderboard.test.ts app/lib/leaderboard.search.test.ts app/lib/leaderboard.scope.test.ts app/lib/leaderboard.rank.test.ts`: passed.
+- `bunx --bun madge --circular --extensions ts,tsx --exclude '^generated/' app realtime shared proxy.ts`: no circular dependency found.
+
+## Summary
+
+The sweep now closes the previously residual durable realtime retry risk while preserving the app's
+existing route behavior. The highest-impact security fix remains enforcing existing profile privacy
+semantics before protected public profile data is queried.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "next typegen && tsc --noEmit",
     "start": "next start --hostname 0.0.0.0 --port 3000",
     "start:realtime": "bun realtime/server.ts",
+    "realtime:drain-outbox": "bun --bun scripts/drain-realtime-outbox.ts",
     "prisma:generate": "bunx --bun prisma generate",
     "prisma:migrate:dev": "bunx --bun prisma migrate dev",
     "prisma:migrate:deploy": "bunx --bun prisma migrate deploy",

--- a/prisma/migrations/20260529193000_add_realtime_outbox/migration.sql
+++ b/prisma/migrations/20260529193000_add_realtime_outbox/migration.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "RealtimeOutboxEvent" (
+    "id" TEXT NOT NULL,
+    "topic" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "maxAttempts" INTEGER NOT NULL DEFAULT 5,
+    "availableAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lockedAt" TIMESTAMP(3),
+    "publishedAt" TIMESTAMP(3),
+    "lastError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RealtimeOutboxEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "RealtimeOutboxEvent_status_availableAt_idx" ON "RealtimeOutboxEvent"("status", "availableAt");
+CREATE INDEX "RealtimeOutboxEvent_topic_idx" ON "RealtimeOutboxEvent"("topic");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -256,6 +256,24 @@ model DirectMessage {
   @@index([senderUserId])
 }
 
+model RealtimeOutboxEvent {
+  id          String    @id @default(cuid(2))
+  topic       String
+  payload     Json
+  status      String    @default("PENDING")
+  attempts    Int       @default(0)
+  maxAttempts Int       @default(5)
+  availableAt DateTime  @default(now())
+  lockedAt    DateTime?
+  publishedAt DateTime?
+  lastError   String?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([status, availableAt])
+  @@index([topic])
+}
+
 model Match {
   id              String          @id @default(cuid(2))
   name            String?

--- a/scripts/drain-realtime-outbox.ts
+++ b/scripts/drain-realtime-outbox.ts
@@ -1,0 +1,9 @@
+import { drainMatchRealtimeOutbox } from "../app/lib/matches/realtime-publisher";
+
+const limit = Number(process.env["REALTIME_OUTBOX_DRAIN_LIMIT"] ?? 25);
+
+const summary = await drainMatchRealtimeOutbox({
+  limit: Number.isInteger(limit) && limit > 0 ? limit : 25,
+});
+
+console.log(JSON.stringify(summary));

--- a/security_best_practices_report.md
+++ b/security_best_practices_report.md
@@ -1,516 +1,83 @@
 # Security Best Practices Report
 
-Generated: 2026-05-26
-
-Scope: full repository static audit for the Next.js app, custom API Route Handlers, Better Auth integration, Prisma/PostgreSQL data layer, Socket.IO realtime service, Docker/Caddy deployment, dependency graph, and git ownership topology.
-
-Methods used:
-
-- Read the repo-provided security skills: `security-best-practices`, `security-threat-model`, and `security-ownership-map`.
-- Read relevant local Next.js documentation from `node_modules/next/dist/docs/`.
-- Ran static code searches for CSRF/origin guards, security headers, dangerous frontend sinks, raw SQL, outbound fetches, and rate limiting.
-- Ran `bun audit`.
-- Ran the ownership mapper: `python3 .agents/skills/security-ownership-map/scripts/run_ownership_map.py --repo . --out security-audit/ownership-map-out --since "12 months ago" --emit-commits`.
-
-Limitations:
-
-- This is a repository-grounded static audit, not a production penetration test.
-- No live production environment, secret values, OAuth provider configuration, DNS, CDN, WAF, or external reverse-proxy configuration were inspected.
-- The final threat model is intentionally deferred until the assumptions at the end of this report are confirmed.
+Date: 2026-05-29
+Scope: full repository
+Stack: TypeScript, Next.js 16, React 19, Better Auth, Prisma, Redis, Socket.IO, Bun
 
 ## Executive Summary
 
-No confirmed critical unauthenticated RCE, direct SQL injection, obvious stored XSS sink, or broad authorization bypass was found in the code reviewed.
+The audit found no open critical or high-severity security findings after this branch's fixes.
+One profile authorization gap was fixed during the sweep: public profile pages now enforce the
+stored `ProfileVisibility` policy before loading or rendering stats, achievements, head-to-head
+records, or match history.
 
-The strongest controls observed are: Better Auth session integration, HttpOnly/SameSite session cookie defaults, zod/runtime validation on important auth and game payloads, Prisma ORM usage instead of ad hoc SQL, explicit authorization checks on match and direct-message access, authenticated Socket.IO subscriptions, and Docker/Caddy topology that does not publicly proxy realtime internal endpoints.
+Dependency audit result: `bun audit` reported no known vulnerable dependencies.
 
-The highest-priority risks identified during the audit were:
+## What Was Reviewed
 
-1. The dependency graph had `bun audit` findings, including two high-severity `fast-uri` advisories and a runtime `ws` advisory through Socket.IO.
-2. The app does not define centralized browser security headers or a CSP.
-3. Cookie-authenticated, state-changing application APIs do not have a shared same-origin/CSRF guard visible in the repo.
-4. Abuse-prone endpoints do not show rate limiting or resource throttling in app or Caddy configuration.
-5. Several API handlers return raw exception messages to clients.
+- Next.js Route Handlers, Proxy, security headers, CSP, and production posture.
+- Authentication/session boundaries, same-origin mutation guards, JSON request guards, and rate limits.
+- Server/client boundaries for Prisma, Redis, email, and secret-reading modules.
+- Frontend dangerous sinks including `dangerouslySetInnerHTML`, DOM HTML sinks, dynamic code execution, redirects, browser storage, and cross-window messaging.
+- File/avatar handling, path traversal defenses, content types, and cache headers.
+- Prisma raw-query and command-execution sinks.
+- Socket.IO realtime internal endpoints and shared internal secret handling.
 
-## Remediation Status
+## Critical
 
-Updated on branch `security-audit-remediation`:
+No open critical findings.
 
-- Resolved dependency advisories with Bun overrides and refreshed `bun.lock`; `bun audit` now reports no vulnerabilities.
-- Added app-level rate limiting for auth wrappers/actions, match creation/join/moves/queue/challenges, chat, friend actions, profile settings, and avatar uploads.
-- Added same-origin/origin guards for mutating custom Route Handlers.
-- Added global security headers, including CSP, `nosniff`, frame blocking, referrer policy, and permissions policy.
-- Removed raw exception details from public API responses and moved diagnostics to server logs.
-- Hardened avatar upload filenames by deriving the stored extension from detected image bytes and using random filenames.
-- Required a distinct `REALTIME_INTERNAL_SECRET` in production Docker Compose and realtime startup.
-- Switched the production Docker image to a non-root runtime user.
+## High
 
-## Positive Controls Observed
+### SEC-001: Public Profile Details Bypassed `ProfileVisibility` - Fixed
 
-- Authentication is consistently checked on protected Route Handlers using `getCurrentSession()` or Better Auth APIs.
-- Match move submission verifies that the submitted participant belongs to the authenticated user before accepting a move (`app/api/matches/[id]/moves/route.ts:89`).
-- Direct conversation creation checks accepted friendship before creating a DM (`app/api/conversations/direct/route.ts:59`).
-- Profile image upload enforces size and magic-byte checks for JPEG, PNG, and WebP (`app/[locale]/profile/actions.ts:13`, `app/[locale]/profile/actions.ts:21`).
-- The realtime service uses authenticated Socket.IO sessions and does not trust arbitrary room joins.
-- Caddy only proxies `/socket.io/*` to realtime and all other public traffic to the app (`infra/caddy/Caddyfile:8`).
-- The production Docker Compose database service is only on the internal bridge network, not directly published to the host (`docker-compose.yml:1`, `docker-compose.yml:144`).
-
-## Findings
-
-### SEC-001: Dependency Graph Contains High and Moderate Vulnerability Advisories
-
-Rule ID: JS-DEPS-001
-
-Severity: High
-
+Rule ID: APP-PRIVACY-001 / NEXT-AUTHZ-001
+Severity: High before fix; fixed in this branch
 Location:
 
-- `package.json:33`
-- `package.json:44`
-- `package.json:48`
-- `package.json:54`
-- `package.json:55`
-- `package.json:56`
+- `app/[locale]/profile/[username]/page.tsx:153`
+- `app/[locale]/profile/[username]/page.tsx:200`
+- `app/[locale]/profile/[username]/page.tsx:209`
+- `app/lib/profile-visibility.ts:10`
 
 Evidence:
-
-`bun audit` reported 13 advisories:
-
-- High: `fast-uri <=3.1.1`, host-confusion and path-traversal advisories.
-- Moderate: `ws >=8.0.0 <8.20.1`, uninitialized memory disclosure through `socket.io` and `socket.io-client`.
-- Moderate: `postcss <8.5.10`, CSS stringify XSS advisory.
-- Moderate: `@hono/node-server <1.19.13`.
-- Moderate/low: `hono <4.12.18`.
-- Moderate: `brace-expansion >=5.0.0 <5.0.6`.
-- Moderate: `ip-address <=10.1.0`.
-- Moderate: `qs >=6.11.1 <=6.15.1`.
-
-The high `fast-uri` path is currently transitive through packages such as `shadcn`, `stylelint`, and Prisma tooling. The `ws` advisory is more directly relevant because Socket.IO is part of the realtime runtime.
+The Prisma schema and seed data define `ProfileVisibility` values (`PUBLIC`, `FRIENDS`, `PRIVATE`),
+but the public profile page previously loaded stats and match history without checking that policy.
+The current implementation loads `profile.visibility`, computes `canViewDetails`, and only calls
+`getProfileStatsForUser()` and head-to-head queries when the viewer is authorized.
 
 Impact:
-
-The practical exploitability depends on whether the vulnerable transitive package is reachable in production code paths. Even when some paths are dev/tooling-only, a vulnerable lockfile increases supply-chain risk, CI risk, and future accidental runtime exposure. The Socket.IO `ws` advisory is runtime-adjacent and should be prioritized.
-
-Fix:
-
-- Run `bun update` and re-run `bun audit`.
-- Move CLI/tooling-only packages such as `shadcn` out of production dependencies if they are not imported by runtime code.
-- Update Socket.IO dependencies as patched releases become available for the `ws` advisory.
-- Consider dependency overrides for vulnerable transitive packages only after confirming compatibility.
-
-Mitigation:
-
-- Keep Caddy as the only public ingress.
-- Avoid exposing local tooling servers in production.
-- Add a CI job that fails on high-severity `bun audit` findings.
-
-False positive notes:
-
-Some high-severity findings appear to be reachable only through dev/tooling packages today. They are still included because the lockfile is the deployable dependency graph and `shadcn` is currently listed under production `dependencies`.
-
-### SEC-002: Missing Centralized Security Headers and CSP
-
-Rule ID: NEXT-HEADERS-001, NEXT-CSP-001, REACT-CSP-001
-
-Severity: Medium
-
-Location:
-
-- `next.config.ts:61`
-- `next.config.ts:71`
-- `proxy.ts:5`
-- `proxy.ts:7`
-- `infra/caddy/Caddyfile:5`
-- `infra/caddy/Caddyfile:13`
-
-Evidence:
-
-`next.config.ts` configures dev origins, cache components, Turbopack, and transpilation, but no `headers()` security policy. `proxy.ts` only wires `next-intl` middleware and excludes API/static/socket paths. The Caddyfile proxies traffic but does not set security headers.
-
-Impact:
-
-Without centralized headers, the app has weaker browser-side defense in depth against XSS, clickjacking, MIME sniffing, excessive referrer leakage, and overly broad browser permissions. This matters because the app has authenticated pages, chat content, user profile content, OAuth flows, and uploaded public media.
+Before the fix, non-friends could infer private or friends-only users' rating, wins/losses,
+achievement state, and recent match history by visiting their public profile URL.
 
 Fix:
+Added `canViewProfileDetails()` and wired it into the public profile page. Unauthorized viewers now
+see private placeholders and the server skips the protected data queries.
 
-- Add security headers in `next.config.ts` or Caddy:
-  - `Content-Security-Policy`
-  - `X-Content-Type-Options: nosniff`
-  - `Referrer-Policy: strict-origin-when-cross-origin`
-  - `Permissions-Policy`
-  - `X-Frame-Options: DENY` or CSP `frame-ancestors 'none'`
-- Start with a report-only CSP if needed, then enforce once violations are understood.
-- If using CSP nonces, follow the local Next.js CSP docs because nonce-based CSP changes rendering/cache behavior.
+Verification:
 
-Mitigation:
+- `bun test app/lib/profile-visibility.test.ts`
+- `bun test app/lib/request-security.test.ts app/api/mutation-security.coverage.test.ts`
+- `bun run typecheck`
+- `bun run lint`
 
-- Keep React escaping as the default rendering path.
-- Continue avoiding `dangerouslySetInnerHTML`, `innerHTML`, `eval`, and `new Function`; no app usage was found in the static search.
+## Medium
 
-False positive notes:
+No open medium findings.
 
-Headers could be applied outside this repo by a CDN or production ingress. They are not present in the repository-controlled Next.js or Caddy configuration.
+## Low / Defense In Depth
 
-### SEC-003: State-Changing Custom APIs Lack a Shared Same-Origin/CSRF Guard
+- `app/lib/request-security.ts:41` enforces same-origin mutation requests and fails closed in production when trusted origins are not configured.
+- `app/api/mutation-security.coverage.test.ts:23` verifies every mutating Route Handler uses the shared mutation guard.
+- `next.config.ts:61` applies baseline security headers globally.
+- `proxy.ts:30` and `app/lib/content-security-policy.ts:82` apply nonce-based CSP to rendered app pages.
+- `app/api/avatars/[filename]/route.ts` serves only opaque, validated avatar filenames with explicit image content types and `nosniff`.
+- `app/lib/matches/realtime-publisher.ts` persists only non-secret realtime retry payloads to the
+  server-side outbox; challenge invite secrets are not queued and failed invite delivery still
+  cancels the room.
+- The `redis.eval` use in `app/lib/rate-limit.ts:248` is a static Lua script with untrusted values passed as Redis keys/arguments, not string-concatenated script source.
 
-Rule ID: NEXT-CSRF-001
+## Residual Notes
 
-Severity: Medium
-
-Location:
-
-- `app/api/matches/route.ts:29`
-- `app/api/matches/[id]/moves/route.ts:52`
-- `app/api/conversations/direct/route.ts:18`
-- `app/api/matches/queue/route.ts:42`
-- `app/api/matches/queue/route.ts:62`
-- `proxy.ts:7`
-- `app/lib/auth-origins.ts:85`
-- `app/lib/auth-origins.ts:88`
-
-Evidence:
-
-Many state-changing APIs authenticate with cookies and then perform writes, but the repo does not show a shared `Origin`/`Referer` or CSRF-token check for application Route Handlers. The `proxy.ts` matcher excludes `/api`, so it is not enforcing an origin policy for APIs. `app/lib/auth-origins.ts` has origin helpers, but `isTrustedAuthOrigin()` returns true when the trusted-origin list is empty.
-
-Examples:
-
-- Create a match: `app/api/matches/route.ts:29`
-- Submit a move: `app/api/matches/[id]/moves/route.ts:52`
-- Create a direct conversation: `app/api/conversations/direct/route.ts:18`
-- Join/cancel matchmaking queue: `app/api/matches/queue/route.ts:42`, `app/api/matches/queue/route.ts:62`
-
-Impact:
-
-SameSite=Lax cookies and JSON APIs reduce practical CSRF risk, and Better Auth-provided endpoints have their own origin protections. However, relying only on cookie defaults leaves state-changing application endpoints exposed to future cookie-setting changes, same-site sibling-domain attacks, unusual browser behavior, or endpoints that later accept simple form submissions. A CSRF or same-origin bypass could create/cancel rooms, join queues, mark messages read, submit game actions, or logout a user.
-
-Fix:
-
-- Add a shared request guard, for example `assertSameOriginRequest(request)`, and call it before every mutating app API.
-- Reject unsafe methods when `Origin` is absent or not in the configured allowlist.
-- Require `Content-Type: application/json` for JSON mutation endpoints.
-- Make trusted-origin configuration fail closed in production instead of accepting every origin when no allowlist is configured.
-
-Mitigation:
-
-- Keep Better Auth cookies `HttpOnly`, `Secure`, and `SameSite=Lax`.
-- Keep Caddy as the only public origin and avoid wildcard subdomains sharing the same site.
-
-False positive notes:
-
-Next.js Server Actions have framework-level origin checks, and Better Auth APIs perform their own checks. This finding is about custom app Route Handlers that mutate application state.
-
-### SEC-004: No Visible Rate Limiting on Abuse-Prone Endpoints
-
-Rule ID: NEXT-DOS-001
-
-Severity: Medium
-
-Location:
-
-- `app/api/auth/login/route.ts:32`
-- `app/api/auth/signup/route.ts:34`
-- `app/api/matches/route.ts:29`
-- `app/api/matches/[id]/moves/route.ts:52`
-- `app/api/conversations/direct/route.ts:18`
-- `app/api/matches/queue/route.ts:42`
-- `infra/caddy/Caddyfile:5`
-
-Evidence:
-
-Static search did not find application rate limiting, throttling, or quota middleware. Caddy is configured as a simple reverse proxy and does not apply throttles. The repo has public or authenticated endpoints that can create users, attempt logins, create matches, submit moves, join queues, and create chat conversations.
-
-Impact:
-
-Attackers can attempt credential stuffing, account signup abuse, queue churn, match creation churn, move spam, and message/conversation spam. Even authenticated abuse can degrade database and realtime service performance.
-
-Fix:
-
-- Add IP plus account-based rate limits for login, signup, password reset, matchmaking, match creation, move submission, chat message creation, and friend requests.
-- Apply stricter unauthenticated limits to auth endpoints.
-- Apply per-user limits and idempotency controls to game/chat mutations.
-- Log rate-limit events with request IDs and user IDs where available.
-
-Mitigation:
-
-- Keep Docker/Caddy as the public ingress.
-- Use upstream infrastructure rate limiting if available, but document it because it is not visible in repo.
-
-False positive notes:
-
-An external CDN/WAF may provide this control in production. No such configuration is present in this repository.
-
-### SEC-005: Raw Exception Messages Are Returned to Clients
-
-Rule ID: NEXT-ERROR-001, NEXT-LOG-001
-
-Severity: Medium
-
-Location:
-
-- `app/lib/api-errors.ts:13`
-- `app/lib/api-errors.ts:17`
-- `app/api/auth/login/route.ts:101`
-- `app/api/auth/login/route.ts:104`
-- `app/api/auth/signup/route.ts:143`
-- `app/api/auth/signup/route.ts:146`
-- `app/api/matches/route.ts:131`
-- `app/api/matches/route.ts:135`
-- `app/api/matches/[id]/moves/route.ts:267`
-- `app/api/matches/[id]/moves/route.ts:280`
-- `app/api/conversations/direct/route.ts:86`
-- `app/api/conversations/direct/route.ts:88`
-- `app/api/health/route.ts:17`
-- `app/api/health/route.ts:23`
-
-Evidence:
-
-`getErrorMessage()` returns `error.message`, and several handlers put that value in a `detail` or `error` field in the client response. The unauthenticated health endpoint returns the raw database error message on failure.
-
-Impact:
-
-Raw exceptions can reveal database constraint names, table/column names, internal URLs, service names, validation internals, or library behavior. This makes targeted attacks easier and can accidentally expose operational details.
-
-Fix:
-
-- Return stable generic client errors.
-- Log the raw exception server-side with a request ID, route name, user ID where available, and severity.
-- Return the request ID to the client for support/debugging.
-- Make `/api/health` return a generic degraded response unless the caller is an authenticated operations user or internal monitor.
-
-Mitigation:
-
-- Keep `NODE_ENV=production` in Compose.
-- Avoid logging secrets or full request bodies in server logs.
-
-False positive notes:
-
-Some errors may be harmless today, but this pattern is broad enough that future database or internal-service errors could leak useful details.
-
-### SEC-006: Profile Visibility Scope Should Be Clarified
-
-Rule ID: APP-PRIVACY-001
-
-Severity: Low
-
-Location:
-
-- `prisma/schema.prisma:51`
-- `prisma/schema.prisma:109`
-- `prisma/schema.prisma:116`
-- `app/[locale]/profile/[username]/page.tsx:134`
-- `app/[locale]/profile/[username]/page.tsx:175`
-- `app/[locale]/profile/[username]/page.tsx:188`
-- `app/[locale]/profile/[username]/page.tsx:228`
-- `app/[locale]/profile/[username]/page.tsx:256`
-
-Evidence:
-
-The Prisma schema defines `ProfileVisibility` with `PUBLIC`, `FRIENDS`, and `PRIVATE`, and stores `UserProfile.visibility`. The public profile page fetches the `User` by username without loading the profile visibility, calculates friendship state, and then always loads and renders profile stats and recent match history. `isRevealed` only gates avatar/presence-style presentation, not stats or match history.
-
-Impact:
-
-After assumption validation, public stats and match history are intended product behavior and do not need to be hidden from other users. The remaining risk is policy ambiguity: future UI copy, settings, or contributors may interpret `UserProfile.visibility` as covering all profile data when the current implementation only gates reveal-style presentation such as avatar/presence.
-
-Fix:
-
-- Document exactly which profile fields `UserProfile.visibility` controls.
-- Rename or split the setting if it only covers presence/avatar reveal.
-- Add tests that assert stats and match history remain public by design while reveal-only fields stay gated.
-
-Mitigation:
-
-- Avoid UI copy that says private profiles hide stats or match history.
-
-False positive notes:
-
-This was downgraded after the product owner confirmed that stats and match history are intentionally public.
-
-### SEC-007: Profile Image Upload Uses User-Controlled Extension and Public Static Storage
-
-Rule ID: NEXT-FILES-001
-
-Severity: Medium
-
-Location:
-
-- `app/[locale]/profile/actions.ts:13`
-- `app/[locale]/profile/actions.ts:21`
-- `app/[locale]/profile/actions.ts:74`
-- `app/[locale]/profile/actions.ts:75`
-- `app/[locale]/profile/actions.ts:80`
-- `app/[locale]/profile/actions.ts:82`
-
-Evidence:
-
-The upload action validates file size and magic bytes, which is good. It then builds the stored filename from the user ID, timestamp, and `path.extname(file.name)`, writes bytes directly under `public/uploads`, and returns a static `/uploads/...` URL. The stored extension is taken from the original filename rather than from the detected image type, and the image is not re-encoded.
-
-Impact:
-
-Magic-byte validation blocks many dangerous uploads, including SVG, but user-controlled extensions and direct public serving still leave room for content-type confusion, image parser edge cases, polyglot files, metadata leakage, and long-lived public files. This risk becomes more important if public static headers are relaxed or future image formats are added.
-
-Fix:
-
-- Detect the image type and force a canonical extension: `.jpg`, `.png`, or `.webp`.
-- Re-encode uploaded images with a trusted image library to strip metadata and normalize content.
-- Serve avatars through a route that sets explicit `Content-Type`, `Content-Disposition: inline`, cache policy, and `X-Content-Type-Options: nosniff`.
-- Consider storing uploads outside `public/` and deleting/replacing old avatars.
-
-Mitigation:
-
-- Keep the current 5 MB cap.
-- Continue rejecting SVG and unknown file types.
-
-False positive notes:
-
-The existing magic-byte check substantially lowers risk. This is a hardening finding, not evidence of a currently exploitable arbitrary file upload.
-
-### SEC-008: Realtime Internal Secret Falls Back to the Better Auth Secret
-
-Rule ID: APP-SECRETS-001
-
-Severity: Medium
-
-Location:
-
-- `shared/realtime-internal.ts:130`
-- `shared/realtime-internal.ts:131`
-- `docker-compose.yml:65`
-- `docker-compose.yml:67`
-- `docker-compose.yml:103`
-- `README.md` realtime setup section
-
-Evidence:
-
-`readRealtimeInternalSecret()` returns `REALTIME_INTERNAL_SECRET` or falls back to `BETTER_AUTH_SECRET`. Docker Compose sets `REALTIME_INTERNAL_SECRET` to an empty default unless explicitly configured. The README documents the fallback.
-
-Impact:
-
-Secret reuse increases blast radius. If the Better Auth secret leaks, the same value can authenticate service-to-service realtime internal calls in environments where those endpoints are reachable. Some internal realtime events carry sensitive payloads such as challenge passwords and decline tokens.
-
-Fix:
-
-- Require a distinct `REALTIME_INTERNAL_SECRET` in production.
-- Fail app and realtime startup when `NODE_ENV=production` and the secret is missing.
-- Update Compose, `.env.example`, and README to remove the production fallback.
-- Rotate the Better Auth secret if it has also been used as a service-to-service secret in shared environments.
-
-Mitigation:
-
-- Keep realtime internal endpoints off the public Caddy route.
-- Keep services on the private Docker network.
-
-False positive notes:
-
-Caddy does not currently proxy realtime internal paths publicly, so the main risk is secret separation and future network exposure rather than immediate internet reachability.
-
-### SEC-009: Production Containers Run as Root
-
-Rule ID: CONTAINER-USER-001
-
-Severity: Low
-
-Location:
-
-- `Dockerfile:1`
-- `Dockerfile:3`
-- `Dockerfile:25`
-- `Dockerfile:33`
-- `docker-compose.yml:72`
-- `docker-compose.yml:73`
-
-Evidence:
-
-The Dockerfile does not create or switch to an unprivileged user. The app writes uploaded files to `/app/public/uploads` through a mounted volume.
-
-Impact:
-
-If an attacker achieves code execution or arbitrary file write inside the app or realtime container, running as root increases the impact within the container. Container isolation still helps, but least privilege should be the default for production services.
-
-Fix:
-
-- Create a non-root user in the production image.
-- Chown only required writable directories, especially `/app/public/uploads`.
-- Add `USER <non-root-user>` before `CMD`.
-- Consider read-only root filesystems and explicit writable mounts where practical.
-
-Mitigation:
-
-- Keep Docker volumes scoped to the service.
-- Avoid mounting the source tree in production.
-
-False positive notes:
-
-This does not mean host root access is available. It is a container hardening issue.
-
-### SEC-010: Security-Sensitive Ownership Is Concentrated
-
-Rule ID: OWNERSHIP-BUSFACTOR-001
-
-Severity: Low
-
-Location:
-
-- `security-audit/ownership-map-out/summary.json`
-- `security-audit/ownership-map-out/files.csv`
-- `security-audit/ownership-map-out/edges.csv`
-
-Evidence:
-
-The ownership map found:
-
-- 115 commits analyzed over the last 12 months.
-- 17 people.
-- 673 files.
-- No orphaned sensitive code.
-- One contributor identity controls 83% of auth-tagged code.
-- Bus-factor 1 hotspots include auth route tests and `app/api/auth/[...all]/route.ts`.
-
-Impact:
-
-Security-sensitive areas can become hard to review, maintain, and respond to if too much context lives with one person. This is an operational risk rather than a direct exploit.
-
-Fix:
-
-- Add or update `CODEOWNERS` for auth, realtime, Prisma schema/migrations, Docker/Caddy, and security-sensitive API routes.
-- Require at least one secondary reviewer for auth/realtime changes.
-- Rotate ownership of auth tests and incident-response runbooks.
-
-Mitigation:
-
-- Keep generated ownership artifacts in `security-audit/ownership-map-out/` for review and visualization.
-
-False positive notes:
-
-Small student/team projects naturally have concentrated ownership. The finding is included because the request asked for a comprehensive security audit.
-
-## Non-Findings and Lower-Risk Areas
-
-- No application usage of `dangerouslySetInnerHTML`, `innerHTML`, `eval`, `new Function`, or `postMessage` was found.
-- No user-controlled outbound fetch target was found in app code; realtime publishing URLs are environment-configured.
-- Prisma is used for database access. The raw SQL found for matchmaking uses `Prisma.sql` with a constant advisory-lock key.
-- Direct-message access checks require direct conversation membership and accepted friendship.
-- Match state and move APIs contain participant/user authorization checks.
-- `.env` is ignored by git and Docker build context according to repo configuration.
-
-## Recommended Remediation Order
-
-1. Update dependencies and re-run `bun audit`.
-2. Add centralized security headers and an initial CSP.
-3. Add a shared same-origin/CSRF guard to mutating app APIs.
-4. Add rate limits to auth, queue, match, chat, and friend-request flows.
-5. Remove raw error details from client responses.
-6. Clarify the scope of `UserProfile.visibility`.
-7. Harden avatar upload storage and serving.
-8. Require a distinct realtime internal secret in production.
-9. Switch production containers to non-root users.
-10. Add security CODEOWNERS/review rules.
-
-## Threat Model Assumption Validation
-
-Confirmed by the user on 2026-05-26:
-
-1. Current production/evaluation deployment is Docker Compose + Caddy as the only public ingress. Vercel may be considered in the future.
-2. User stats and match history are intentionally public and do not need to be hidden from other users.
-3. Rate limiting should be implemented inside the app. Next.js production does not provide general application-level rate limiting by default; official guidance is to implement rate limiting in the Next.js backend and also enable host/proxy limits when available.
-
-The final threat model is written to `transcendence-threat-model.md`.
+- TLS, WAF, CDN, and reverse-proxy production settings are not fully visible from application code. Verify them in deployment infrastructure.
+- `.env` is present locally but is ignored by git; do not commit local secret material.


### PR DESCRIPTION
## What changed

- Enforced `ProfileVisibility` on public profile pages before protected stats, achievements, head-to-head data, and match history are loaded or rendered.
- Broke the leaderboard/search type import cycle by moving `LeaderboardScope` into a small shared type module.
- Added a durable realtime outbox for non-secret match realtime payloads, including Prisma migration, drain script, publisher integration, and focused unit tests.
- Added/updated Brooks sweep and security audit reports.

## Why

The sweep found a high-impact profile authorization gap and a residual reliability risk where committed match updates could lose realtime delivery during transient realtime outages. The outbox gives `game:update`, `queue:matched`, and `challenge:declined` payloads a durable retry path. Challenge invite payloads are intentionally not persisted because they include room secrets; failed invite delivery still cancels the room instead.

## Validation

- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun test` (`492 pass`, `2 skip`)
- `bun audit`
- `bunx --bun madge --circular --extensions ts,tsx --exclude '^generated/' app realtime shared proxy.ts`
- `git diff --check`

## Deployment note

Apply the new Prisma migration before enabling the outbox drain command. Run `bun run realtime:drain-outbox` from a scheduled job or always-on worker so pending retry events are delivered.