### PR TITLE
[codex] Add realtime outbox worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Then run the Next app and realtime service from separate host shells:
 ```bash
 bun run dev
 bun run dev:realtime
+bun run realtime:drain-outbox:loop
 ```
 
 This host-shell path still serves plain HTTP on `http://localhost:3000`. Set
@@ -64,6 +65,12 @@ service. Friendship refreshes are derived from that URL unless you set
 `REALTIME_FRIENDSHIP_INTERNAL_URL` explicitly. Internal friendship publishes use
 `REALTIME_INTERNAL_SECRET` as the shared service-to-service header secret. In
 production this must be distinct from `BETTER_AUTH_SECRET`.
+
+The realtime outbox drain loop is the host-shell worker for retrying durable
+match realtime events after transient publish failures. Tune it with
+`REALTIME_OUTBOX_DRAIN_INTERVAL_SECONDS` and `REALTIME_OUTBOX_DRAIN_LIMIT`; set
+`REALTIME_OUTBOX_DRAIN_DISABLED=true` to keep the worker container alive without
+processing events.
 
 Redis is optional for single-process host development. When `REDIS_URL` is set,
 the app uses it for shared app rate limits and Better Auth secondary storage,
@@ -134,7 +141,7 @@ data you need to keep.
 docker compose up --build
 ```
 
-This runs the Next app, Bun realtime service, Caddy HTTPS reverse proxy, PostgreSQL, and the PostgreSQL backup sidecar in a production-style local container mode. Open the app at `https://localhost:8443`.
+This runs the Next app, Bun realtime service, realtime outbox worker, Caddy HTTPS reverse proxy, PostgreSQL, and the PostgreSQL backup sidecar in a production-style local container mode. Open the app at `https://localhost:8443`.
 
 ### Run the full stack in Docker dev mode
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,6 +43,15 @@ services:
     healthcheck:
       start_period: 5s
 
+  realtime-outbox:
+    build:
+      target: dev
+    environment:
+      NODE_ENV: development
+    volumes:
+      - .:/app
+      - app_node_modules:/app/node_modules
+
 volumes:
   app_generated:
   app_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,29 @@ services:
       retries: 10
       start_period: 5s
 
+  realtime-outbox:
+    build:
+      context: .
+    command: ["bun", "run", "realtime:drain-outbox:loop"]
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: postgresql://${POSTGRES_USER:-transcendence}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@database:5432/${POSTGRES_DB:-transcendence}?schema=public
+      REALTIME_INTERNAL_SECRET: ${REALTIME_INTERNAL_SECRET:?REALTIME_INTERNAL_SECRET is required}
+      REALTIME_INTERNAL_URL: http://realtime:3001/internal/game-update
+      REALTIME_OUTBOX_DRAIN_DISABLED: ${REALTIME_OUTBOX_DRAIN_DISABLED:-false}
+      REALTIME_OUTBOX_DRAIN_INTERVAL_SECONDS: ${REALTIME_OUTBOX_DRAIN_INTERVAL_SECONDS:-5}
+      REALTIME_OUTBOX_DRAIN_LIMIT: ${REALTIME_OUTBOX_DRAIN_LIMIT:-25}
+    depends_on:
+      app:
+        condition: service_healthy
+      database:
+        condition: service_healthy
+      realtime:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - transcendence
+
   caddy:
     image: caddy:2.11.2-alpine
     environment:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3000",
     "start:realtime": "bun realtime/server.ts",
     "realtime:drain-outbox": "bun --bun scripts/drain-realtime-outbox.ts",
+    "realtime:drain-outbox:loop": "sh scripts/realtime-outbox-drain-loop.sh",
     "prisma:generate": "bunx --bun prisma generate",
     "prisma:migrate:dev": "bunx --bun prisma migrate dev",
     "prisma:migrate:deploy": "bunx --bun prisma migrate deploy",

--- a/scripts/realtime-outbox-drain-loop.sh
+++ b/scripts/realtime-outbox-drain-loop.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+if [ "${REALTIME_OUTBOX_DRAIN_DISABLED:-false}" = "true" ]; then
+  echo "Realtime outbox drain disabled."
+  exec tail -f /dev/null
+fi
+
+interval_seconds="${REALTIME_OUTBOX_DRAIN_INTERVAL_SECONDS:-5}"
+
+if ! [ "$interval_seconds" -gt 0 ] 2>/dev/null; then
+  echo "Invalid REALTIME_OUTBOX_DRAIN_INTERVAL_SECONDS: $interval_seconds" >&2
+  interval_seconds=5
+fi
+
+while true; do
+  if ! bun run realtime:drain-outbox; then
+    echo "Realtime outbox drain failed; retrying after ${interval_seconds}s." >&2
+  fi
+
+  sleep "$interval_seconds"
+done


### PR DESCRIPTION
## What changed

- Added a `realtime-outbox` Docker Compose sidecar that continuously runs the realtime outbox drain loop.
- Added `scripts/realtime-outbox-drain-loop.sh` and `bun run realtime:drain-outbox:loop` for both container and host-shell operation.
- Added dev Compose mounts for the worker and documented host-shell/Docker usage.

## Why

The previous outbox PR added durable retry storage and a one-shot drain command. This PR wires that drain command into an actual long-running worker so pending realtime events are retried automatically after transient realtime publish failures.

## Validation

- `sh -n scripts/realtime-outbox-drain-loop.sh`
- `docker compose -f docker-compose.yml -f docker-compose.dev.yml config`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `git diff --check`

## Audit follow-up

A Brooks sweep and security audit will be posted as a PR comment after creation.